### PR TITLE
Timestream write ray support

### DIFF
--- a/awswrangler/timestream.py
+++ b/awswrangler/timestream.py
@@ -16,15 +16,19 @@ from awswrangler.distributed import ray_get, ray_remote
 _logger: logging.Logger = logging.getLogger(__name__)
 
 
+def _extract_parameter(parameter: Any) -> Any:
+    if pd.isna(parameter):
+        parameter = None
+    elif hasattr(parameter, "to_pydatetime"):
+        parameter = parameter.to_pydatetime()
+    return parameter
+
+
 def _df2list(df: pd.DataFrame) -> List[List[Any]]:
     """Extract Parameters."""
+    df.applymap(_extract_parameter)
     parameters: List[List[Any]] = df.values.tolist()
-    for i, row in enumerate(parameters):
-        for j, value in enumerate(row):
-            if pd.isna(value):
-                parameters[i][j] = None
-            elif hasattr(value, "to_pydatetime"):
-                parameters[i][j] = value.to_pydatetime()
+
     return parameters
 
 

--- a/tests/load/test_timestream_write.py
+++ b/tests/load/test_timestream_write.py
@@ -1,0 +1,30 @@
+import logging
+
+import pytest
+
+import awswrangler as wr
+
+from .._utils import ExecutionTimer
+
+logging.getLogger("awswrangler").setLevel(logging.DEBUG)
+
+
+@pytest.mark.parametrize("benchmark_time", [2000])
+def test_timestream_write(timestream_database_and_table, benchmark_time):
+    # path = "s3://artifacts-s3artifacts6faa504f-265103l9fk5d/artifacts/ray/timestream2.csv"
+    path = "s3://cfait-temp-ray/timestream2.csv"
+    df = wr.s3.read_csv(path, parse_dates=["time"])
+
+    name = timestream_database_and_table
+    with ExecutionTimer("elapsed time of wr.timestream.write() simple") as timer:
+        rejected_records = wr.timestream.write(
+            df=df,
+            database=name,
+            table=name,
+            time_col="time",
+            measure_col="measure",
+            dimensions_cols=["dim0", "dim1"],
+        )
+
+    assert timer.elapsed_time < benchmark_time
+    assert len(rejected_records) == 0


### PR DESCRIPTION
### Feature or Bugfix
- Feature
- Refactoring

### Detail
- Ray support for timestream write
- num_threads argument changed to use_threads to be consistent with the rest of awswrangler + support of os.cpu_count()

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
