### PR TITLE
Adding support for parameter ClientRequestToken

### DIFF
--- a/awswrangler/athena/_utils.py
+++ b/awswrangler/athena/_utils.py
@@ -62,6 +62,7 @@ def _start_query_execution(
     encryption: Optional[str] = None,
     kms_key: Optional[str] = None,
     boto3_session: Optional[boto3.Session] = None,
+    client_request_token: Optional[str] = None,
 ) -> str:
     args: Dict[str, Any] = {"QueryString": sql}
     session: boto3.Session = _utils.ensure_session(session=boto3_session)
@@ -70,6 +71,11 @@ def _start_query_execution(
     args["ResultConfiguration"] = {
         "OutputLocation": _get_s3_output(s3_output=s3_output, wg_config=wg_config, boto3_session=session)
     }
+
+    if client_request_token:
+        if len(client_request_token) < 32 or len(client_request_token) > 128:
+            raise exceptions.InvalidArgumentCombination("Invalid length for parameter client_request_token, valid min length: 32, valid max length: 128")
+        args["ClientRequestToken"] = client_request_token
 
     # encryption
     if wg_config.enforced is True:

--- a/tutorials/019 - Athena Cache.ipynb
+++ b/tutorials/019 - Athena Cache.ipynb
@@ -8,6 +8,7 @@
     "\n",
     "# 19 - Amazon Athena Cache\n",
     "\n",
+    "### Cache History\n",
     "[Wrangler](https://github.com/awslabs/aws-data-wrangler) has a cache strategy that is disabled by default and can be enabled passing `max_cache_seconds` biggier than 0. This cache strategy for Amazon Athena can help you to **decrease query times and costs**.\n",
     "\n",
     "When calling `read_sql_query`, instead of just running the query, we now can verify if the query has been run before. If so, and this last run was within `max_cache_seconds` (a new parameter to `read_sql_query`), we return the same results as last time if they are still available in S3. We have seen this increase performance more than 100x, but the potential is pretty much infinite.\n",
@@ -19,7 +20,15 @@
     "- For each of those queries, we check if their CompletionDateTime is still within the `max_cache_seconds` window. If so, we check if the query string is the same as now (with some smart heuristics to guarantee coverage over both `ctas_approach`es). If they are the same, we check if the last one's results are still on S3, and then return them instead of re-running the query.\n",
     "- During the whole cache resolution phase, if there is anything wrong, the logic falls back to the usual `read_sql_query` path.\n",
     "\n",
-    "*P.S. The `cache scope is bounded for the current workgroup`, so you will be able to reuse queries results from others colleagues running in the same environment.*"
+    "*P.S. The `cache scope is bounded for the current workgroup`, so you will be able to reuse queries results from others colleagues running in the same environment.*\n",
+    "\n",
+    "### ClientRequestToken\n",
+    "This field is autopopulated if not provided. A unique case-sensitive string used to ensure the request to create the query is idempotent (executes only once). \n",
+    "If another StartQueryExecution request is received, the same response is returned and another query is not created. If a parameter has changed, for example, the QueryString , an error is returned.\n",
+    "\n",
+    "Using this parameter, the same query doesn't run twice. It returns the output from a previous query execution, increasing the query performance and reducing costs\n",
+    "\n",
+    "You can't use Cache History with ClientRequestToken.\n"
    ]
   },
   {
@@ -44,7 +53,7 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdin",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
       " ···········································\n"
@@ -1249,6 +1258,80 @@
    "outputs": [],
    "source": [
     "wr.catalog.delete_database('awswrangler_test')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# ClientRequestToken\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Checking the performance of the query using the parameter client_request_token"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "\n",
+    "wr.athena.read_sql_query(query, database=\"awswrangler_test\", ctas_approach=False, client_request_token='Test client_request_token parameter, caching the query execution')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "\n",
+    "wr.athena.read_sql_query(query, database=\"awswrangler_test\", ctas_approach=False, client_request_token='Test client_request_token parameter, caching the query execution')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Checking the query execution ID with client_request_token parameter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = wr.athena.read_sql_query('select 1', database=\"awswrangler_test\", ctas_approach=False, client_request_token='Showing query execution id when usint client_request_token parameter')\n",
+    "print(f'Query Execution ID: {df.query_metadata[\"QueryExecutionId\"]}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = wr.athena.read_sql_query('select 1', database=\"awswrangler_test\", ctas_approach=False, client_request_token='Showing query execution id when usint client_request_token parameter')\n",
+    "print(f'Query Execution ID: {df.query_metadata[\"QueryExecutionId\"]}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = wr.athena.read_sql_query('select 1', database=\"awswrangler_test\", ctas_approach=False, client_request_token='Showing query execution id when usint client_request_token parameter')\n",
+    "print(f'Query Execution ID: {df.query_metadata[\"QueryExecutionId\"]}')"
    ]
   }
  ],


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Adding support for the feature ClientRequestToken
- We can cache queries using the above approach without the need of reading query history

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
