### PR TITLE
feature: Add support for upserting to an empty Glue table

### DIFF
--- a/awswrangler/s3/_merge_upsert_table.py
+++ b/awswrangler/s3/_merge_upsert_table.py
@@ -127,7 +127,7 @@ def merge_upsert_table(
             existing_df = wr.s3.read_parquet_table(database=database, table=table, boto3_session=boto3_session)
 
         except NoFilesFound:
-            # Generate empty frame
+            # Generate empty frame with the schema specified in the Glue catalog
             existing_df = _generate_empty_frame_for_table(database=database, table=table, boto3_session=boto3_session)
 
         # Check if data quality inside dataframes to be merged are sufficient
@@ -141,7 +141,7 @@ def merge_upsert_table(
                 database=database,
                 table=table,
                 boto3_session=boto3_session,
-        )
+            )
     else:
         exception_message = f"database= {database} and table= {table}  does not exist"
         _logger.exception(exception_message)

--- a/tests/test_s3_merge_upsert.py
+++ b/tests/test_s3_merge_upsert.py
@@ -92,3 +92,23 @@ def test_success_case2(glue_database, glue_table, path):
     merged_df = wr.s3.read_parquet_table(database=glue_database, table=glue_table)
     # Row count should still be 2 rows
     assert merged_df.shape == (2, 3)
+
+
+def test_upsert_for_empty_table(glue_database, glue_table, path):
+    wr.catalog.create_parquet_table(
+        database=glue_database,
+        table=glue_table,
+        path=path,
+        columns_types={
+            "id": "bigint",
+            "name": "string",
+        },
+    )
+
+    delta_df = pd.DataFrame({"id": [1, 2], "name": ["foo", "bar"]})
+    primary_key = ["id"]
+
+    merge_upsert_table(delta_df=delta_df, database=glue_database, table=glue_table, primary_key=primary_key)
+
+    merged_df = wr.s3.read_parquet_table(database=glue_database, table=glue_table)
+    assert merged_df.shape == delta_df.shape


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
The `s3.merge_upsert_table` function currently does not work when the destination Glue table is empty. If the Glue table is already created, we should be able to simply insert the data.

### Relates
Closing #1562 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
