### PR TITLE
refactor: Simplify code for merge_upsert_table

### DIFF
--- a/awswrangler/s3/_merge_upsert_table.py
+++ b/awswrangler/s3/_merge_upsert_table.py
@@ -76,11 +76,9 @@ def _generate_empty_frame_for_table(
     table: str,
     boto3_session: Optional[boto3.Session] = None,
 ) -> pandas.DataFrame:
-    df_types = wr.catalog.table(database=database, table=table, boto3_session=boto3_session)
-    type_dict = {row["Column Name"]: row["Type"] for _, row in df_types.iterrows()}
-
-    existing_df = pandas.DataFrame([], columns=type_dict.keys())
-    return _data_types.cast_pandas_with_athena_types(existing_df, type_dict)
+    type_dict = wr.catalog.get_table_types(database=database, table=table, boto3_session=boto3_session)
+    empty_frame = pandas.DataFrame(columns=type_dict.keys())
+    return _data_types.cast_pandas_with_athena_types(empty_frame, type_dict)
 
 
 def merge_upsert_table(


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Detail
- In the previous commit, the schema was unnecessarily fetched as a DataFrame only to be converted back to a dict. It turns out `wr.catalog` has a function to get the table types as a dict automatically.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
