### PR TITLE
pin poetry to version 1.1.15 to avoid package resolution issues, do not remove lock file

### DIFF
--- a/.github/workflows/cfn-nag.yml
+++ b/.github/workflows/cfn-nag.yml
@@ -44,9 +44,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install Requirements
         run: |
-          cd test_infra && rm -rf poetry.lock
+          cd test_infra
           python -m pip install --upgrade pip
-          python -m pip install poetry
+          python -m pip install poetry==1.1.15 # 1.2.0 breaking resolution of packages
           poetry config virtualenvs.create false --local
           poetry install -vvv
       - name: CDK Synth


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- other github workflows as well as codebuild buildspecs are currently pinning poetry to version 1.1.15, updating cfn-nag workflow to be consistent
- do not remove poetry.lock

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
