### PR TITLE
Use SSL and verify certs only for HTTPS (port 443)

### DIFF
--- a/awswrangler/opensearch/_utils.py
+++ b/awswrangler/opensearch/_utils.py
@@ -33,6 +33,10 @@ def _strip_endpoint(endpoint: str) -> str:
     return uri_schema.sub("", endpoint).strip().strip("/")
 
 
+def _is_https(port: int) -> bool:
+    return port == 443
+
+
 def connect(
     host: str,
     port: Optional[int] = 443,
@@ -95,8 +99,8 @@ def connect(
             host=_strip_endpoint(host),
             port=port,
             http_auth=http_auth,
-            use_ssl=True,
-            verify_certs=True,
+            use_ssl=_is_https(port),
+            verify_certs=_is_https(port),
             connection_class=RequestsHttpConnection,
             timeout=30,
             max_retries=10,


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail

Use SSL and verify certs only for HTTPS (port 443)
for port 443 use options `use_ssl=True, verify_certs=True`
for port 80 use options `use_ssl=False, verify_certs=False`

When working with local opensearch in container

`docker-compose.yml`
```yaml
version: "3.9"

services:
  opensearch:
    container_name: opensearch
    image: opensearchproject/opensearch:1.1.0
    environment:
      - node.name=opensearch
      - cluster.name=opensearch-docker-cluster
      - discovery.type=single-node
      - bootstrap.memory_lock=true
      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
      - "DISABLE_SECURITY_PLUGIN=true"
    ports:
      - "80:9200"
    ulimits:
      memlock:
        soft: -1
        hard: -1
    volumes:
      - data:/usr/share/opensearch/data
    hostname: opensearch
    networks:
      default:
        aliases:
          - opensearch.localhost.localstack.cloud

volumes:
  data:
```

I experienced following error:

```
Traceback (most recent call last):
  File "/project/.venv/lib/python3.10/site-packages/opensearchpy/connection/http_requests.py", line 163, in perform_request
    response = self.session.send(prepared_request, **send_kwargs)
  File "/project/.venv/lib/python3.10/site-packages/requests/sessions.py", line 655, in send
    r = adapter.send(request, **kwargs)
  File "/project/.venv/lib/python3.10/site-packages/requests/adapters.py", line 514, in send
    raise SSLError(e, request=request)
requests.exceptions.SSLError: HTTPSConnectionPool(host='localhost', port=80): Max retries exceeded with url: / (Caused by SSLError(SSLError(1, '[SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:997)')))
```

As you can notice, for localhost:80 SSL was used.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
