### PR TITLE
(enhancement): Remove unnecessary LF permissions from tests infra

### DIFF
--- a/CONTRIBUTING_COMMON_ERRORS.md
+++ b/CONTRIBUTING_COMMON_ERRORS.md
@@ -111,22 +111,3 @@ brew install unixodbc
 ```
 
 -----
-
-## CloudFormation Deployment
-
-### Error Message
-
-During the deployment of `aws-sdk-pandas-databases`, the creation of the resource `CodeBuildTestRoleLFPermissions` fails with
-
-```
-Resource does not exist or requester is not authorized to access requested permissions. (Service: AWSLakeFormation; Status Code: 400; Error Code: AccessDeniedException; Request ID: 14a26718-ee4e-49f2-a7ca-d308e49485f8; Proxy: null)
-```
-
-### Solution
-
-The IAM role used to deploy the CloudForation stack does not have permissions to assign permissions in AWS Lake Formation. The quickest solution is to find the IAM role and set it as an admin in Lake Formation.
-
-In order to find the role:
-1. Navigate to the CloudFormation console in your account
-1. Select the `aws-sdk-pandas-databases` stack which failed to deploy
-1. Under the "Stack info" tab, find the value for "IAM role". The name of the role should be in the following format: `arn:aws:iam::{ACCOUNT_ID}:role/cdk-{UUID}-cfn-exec-role-{ACCOUNT_ID}-{REGION}`

--- a/test_infra/stacks/databases_stack.py
+++ b/test_infra/stacks/databases_stack.py
@@ -5,7 +5,6 @@ from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_glue_alpha as glue
 from aws_cdk import aws_iam as iam
 from aws_cdk import aws_kms as kms
-from aws_cdk import aws_lakeformation as lf
 from aws_cdk import aws_neptune_alpha as neptune
 from aws_cdk import aws_rds as rds
 from aws_cdk import aws_redshift_alpha as redshift
@@ -217,19 +216,11 @@ class DatabasesStack(Stack):  # type: ignore
                 ),
             },
         )
-        lf.CfnPermissions(
+        ssm.StringParameter(
             self,
-            "CodeBuildTestRoleLFPermissions",
-            data_lake_principal=lf.CfnPermissions.DataLakePrincipalProperty(
-                data_lake_principal_identifier=redshift_role.role_arn
-            ),
-            resource=lf.CfnPermissions.ResourceProperty(
-                table_resource=lf.CfnPermissions.TableResourceProperty(
-                    database_name="aws_sdk_pandas",
-                    table_wildcard={},  # type: ignore
-                )
-            ),
-            permissions=["SELECT", "ALTER", "DESCRIBE", "DROP", "DELETE", "INSERT"],
+            "redshift-role-arn-parameter",
+            parameter_name="/SDKPandas/IAM/RedshiftRoleArn",
+            string_value=redshift_role.role_arn,
         )
         redshift.ClusterSubnetGroup(
             self,


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Enhancement

### Detail
- LakeFormation permissions for the CodeBuild test roles should be handled outside the public repository (i.e. in our internal test infra architecture). With this change, our users won't face the cryptic LF error at deployment anymore.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
