### PR TITLE
(fix): Return address config param

### DIFF
--- a/awswrangler/_config.py
+++ b/awswrangler/_config.py
@@ -75,6 +75,7 @@ _CONFIG_ARGS: Dict[str, _ConfigArg] = {
     "memory_format": _ConfigArg(
         dtype=str, nullable=False, loaded=True, default="modin" if importlib.util.find_spec("modin") else "pandas"
     ),
+    "address": _ConfigArg(dtype=str, nullable=True),
     "redis_password": _ConfigArg(dtype=str, nullable=True),
     "ignore_reinit_error": _ConfigArg(dtype=bool, nullable=True),
     "include_dashboard": _ConfigArg(dtype=bool, nullable=True),
@@ -456,6 +457,15 @@ class _Config:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     @memory_format.setter
     def memory_format(self, value: str) -> None:
         self._set_config_value(key="memory_format", value=value)
+
+    @property
+    def address(self) -> Optional[str]:
+        """Property address."""
+        return cast(Optional[str], self["address"])
+
+    @address.setter
+    def address(self, value: Optional[str]) -> None:
+        self._set_config_value(key="address", value=value)
 
     @property
     def ignore_reinit_error(self) -> Optional[bool]:

--- a/awswrangler/distributed/_distributed.py
+++ b/awswrangler/distributed/_distributed.py
@@ -141,6 +141,7 @@ def initialize_ray(
             address = ray_address
 
         if address:
+            _logger.info("Connecting to a Ray cluster at: %s", address)
             ray.init(
                 address=address,
                 include_dashboard=include_dashboard,

--- a/awswrangler/s3/_write_parquet.py
+++ b/awswrangler/s3/_write_parquet.py
@@ -249,6 +249,11 @@ def _to_parquet_distributed(  # pylint: disable=unused-argument
     ds = from_modin(df) if isinstance(df, ModinDataFrame) else from_pandas(df)
     # Repartition into a single block if or writing into a single key or if bucketing is enabled
     if ds.count() > 0 and (path or bucketing):
+        _logger.warning(
+            "Repartitioning frame to single partition as a strict path was defined: %s. "
+            "This operation is inefficient for large datasets.",
+            path,
+        )
         ds = ds.repartition(1)
     # Repartition by max_rows_by_file
     elif max_rows_by_file and (max_rows_by_file > 0):


### PR DESCRIPTION
Ray does not always set `RAY_ADDRESS` environment variable that we use to detect a running cluster and connect to it. Adding `address` parameter back to be able to set conventional `WR_ADDRESS` and connect to a cluster instead of always creating a local cluster.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
