### PR TITLE
[skip-ci] remove semicolon from python code eol in s3 tutorial

### DIFF
--- a/tutorials/003 - Amazon S3.ipynb
+++ b/tutorials/003 - Amazon S3.ipynb
@@ -122,7 +122,7 @@
     "path2 = f\"s3://{bucket}/csv/file2.csv\"\n",
     "\n",
     "wr.s3.to_csv(df1, path1, index=False)\n",
-    "wr.s3.to_csv(df2, path2, index=False);"
+    "wr.s3.to_csv(df2, path2, index=False)"
    ]
   },
   {
@@ -362,7 +362,7 @@
     "path2 = f\"s3://{bucket}/parquet/file2.parquet\"\n",
     "\n",
     "wr.s3.to_parquet(df1, path1)\n",
-    "wr.s3.to_parquet(df2, path2);"
+    "wr.s3.to_parquet(df2, path2)"
    ]
   },
   {
@@ -708,7 +708,7 @@
     "wr.s3.read_fwf(f\"s3://{bucket}/fwf/\", names=[\"id\", \"name\", \"date\"], last_modified_begin=begin_utc, last_modified_end=end_utc)\n",
     "wr.s3.read_json(f\"s3://{bucket}/json/\", last_modified_begin=begin_utc, last_modified_end=end_utc)\n",
     "wr.s3.read_csv(f\"s3://{bucket}/csv/\", last_modified_begin=begin_utc, last_modified_end=end_utc)\n",
-    "wr.s3.read_parquet(f\"s3://{bucket}/parquet/\", last_modified_begin=begin_utc, last_modified_end=end_utc);"
+    "wr.s3.read_parquet(f\"s3://{bucket}/parquet/\", last_modified_begin=begin_utc, last_modified_end=end_utc)"
    ]
   },
   {


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- couple of semicolons that shouldn't be there in S3 tutorial

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
