### PR TITLE
Fix athena.read_sql_query for empty table and chunk size not returning an empty frame generator

### DIFF
--- a/awswrangler/athena/_read.py
+++ b/awswrangler/athena/_read.py
@@ -12,7 +12,6 @@ import pandas as pd
 
 from awswrangler import _utils, catalog, exceptions, s3
 from awswrangler._config import apply_configs
-from awswrangler._data_types import cast_pandas_with_athena_types
 from awswrangler.athena._utils import (
     _apply_query_metadata,
     _empty_dataframe_response,
@@ -103,12 +102,12 @@ def _fetch_parquet_result(
     if not paths:
         if not temp_table_fqn:
             raise exceptions.EmptyDataFrame("Query would return untyped, empty dataframe.")
-        database, temp_table_name = map(lambda x: x.replace('"', ""), temp_table_fqn.split("."))
-        dtype_dict = catalog.get_table_types(database=database, table=temp_table_name, boto3_session=boto3_session)
-        df = pd.DataFrame(columns=list(dtype_dict.keys()))
-        df = cast_pandas_with_athena_types(df=df, dtype=dtype_dict)
-        df = _apply_query_metadata(df=df, query_metadata=query_metadata)
-        return df
+
+        return _empty_dataframe_response(
+            chunked=bool(chunked),
+            query_metadata=query_metadata,
+        )
+
     ret = s3.read_parquet(
         path=paths,
         use_threads=use_threads,

--- a/tests/test_athena.py
+++ b/tests/test_athena.py
@@ -595,24 +595,13 @@ def test_read_sql_query_wo_results(path, glue_database, glue_table):
     ensure_athena_query_metadata(df=df, ctas_approach=False, encrypted=False)
 
 
-def test_read_sql_query_wo_results_chunked(path, glue_database, glue_table):
+@pytest.mark.parametrize("ctas_approach", [False, True])
+def test_read_sql_query_wo_results_chunked(path, glue_database, glue_table, ctas_approach):
     wr.catalog.create_parquet_table(database=glue_database, table=glue_table, path=path, columns_types={"c0": "int"})
     sql = f"SELECT * FROM {glue_database}.{glue_table}"
 
     counter = 0
-    for df in wr.athena.read_sql_query(sql, database=glue_database, ctas_approach=False, chunksize=100):
-        assert df.empty
-        counter += 1
-
-    assert counter == 1
-
-
-def test_read_sql_query_wo_results_chunked_ctas(path, glue_database, glue_table):
-    wr.catalog.create_parquet_table(database=glue_database, table=glue_table, path=path, columns_types={"c0": "int"})
-    sql = f"SELECT * FROM {glue_database}.{glue_table}"
-
-    counter = 0
-    for df in wr.athena.read_sql_query(sql, database=glue_database, ctas_approach=True, chunksize=100):
+    for df in wr.athena.read_sql_query(sql, database=glue_database, ctas_approach=ctas_approach, chunksize=100):
         assert df.empty
         counter += 1
 

--- a/tests/test_athena.py
+++ b/tests/test_athena.py
@@ -595,6 +595,22 @@ def test_read_sql_query_wo_results(path, glue_database, glue_table):
     ensure_athena_query_metadata(df=df, ctas_approach=False, encrypted=False)
 
 
+def test_read_sql_query_wo_results_chunked(path, glue_database, glue_table):
+    wr.catalog.create_parquet_table(database=glue_database, table=glue_table, path=path, columns_types={"c0": "int"})
+    sql = f"SELECT * FROM {glue_database}.{glue_table}"
+
+    for df in wr.athena.read_sql_query(sql, database=glue_database, ctas_approach=False, chunksize=100):
+        assert df.empty
+
+
+def test_read_sql_query_wo_results_chunked_ctas(path, glue_database, glue_table):
+    wr.catalog.create_parquet_table(database=glue_database, table=glue_table, path=path, columns_types={"c0": "int"})
+    sql = f"SELECT * FROM {glue_database}.{glue_table}"
+
+    for df in wr.athena.read_sql_query(sql, database=glue_database, ctas_approach=True, chunksize=100):
+        assert df.empty
+
+
 @pytest.mark.xfail()
 def test_read_sql_query_wo_results_ctas(path, glue_database, glue_table):
     wr.catalog.create_parquet_table(database=glue_database, table=glue_table, path=path, columns_types={"c0": "int"})

--- a/tests/test_athena.py
+++ b/tests/test_athena.py
@@ -599,16 +599,24 @@ def test_read_sql_query_wo_results_chunked(path, glue_database, glue_table):
     wr.catalog.create_parquet_table(database=glue_database, table=glue_table, path=path, columns_types={"c0": "int"})
     sql = f"SELECT * FROM {glue_database}.{glue_table}"
 
+    counter = 0
     for df in wr.athena.read_sql_query(sql, database=glue_database, ctas_approach=False, chunksize=100):
         assert df.empty
+        counter += 1
+
+    assert counter == 1
 
 
 def test_read_sql_query_wo_results_chunked_ctas(path, glue_database, glue_table):
     wr.catalog.create_parquet_table(database=glue_database, table=glue_table, path=path, columns_types={"c0": "int"})
     sql = f"SELECT * FROM {glue_database}.{glue_table}"
 
+    counter = 0
     for df in wr.athena.read_sql_query(sql, database=glue_database, ctas_approach=True, chunksize=100):
         assert df.empty
+        counter += 1
+
+    assert counter == 1
 
 
 @pytest.mark.xfail()


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
When the query result is empty, `awswrangler.athena.read_sql_query()` returns a list of strings that correspond to the column names instead of an empty DataFrame.

### Relates
- https://github.com/aws/aws-sdk-pandas/issues/1683

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
