### PR TITLE
(enhancement): Apply modin repartitioning where required only

### DIFF
--- a/awswrangler/distributed/ray/_register.py
+++ b/awswrangler/distributed/ray/_register.py
@@ -11,8 +11,8 @@ from awswrangler.s3._read_text import _read_text
 from awswrangler.s3._select import _select_object_content, _select_query
 from awswrangler.s3._wait import _wait_object_batch
 from awswrangler.s3._write_dataset import _to_buckets, _to_partitions
-from awswrangler.s3._write_parquet import _to_parquet, to_parquet
-from awswrangler.s3._write_text import _to_text, to_csv, to_json
+from awswrangler.s3._write_parquet import _to_parquet
+from awswrangler.s3._write_text import _to_text
 
 
 def register_ray() -> None:
@@ -28,7 +28,6 @@ def register_ray() -> None:
         engine.register_func(func, ray_remote(func))
 
     if memory_format.get() == MemoryFormatEnum.MODIN:
-        from awswrangler.distributed.ray.modin._core import modin_repartition
         from awswrangler.distributed.ray.modin._data_types import pyarrow_types_from_pandas_distributed
         from awswrangler.distributed.ray.modin._utils import _arrow_refs_to_df
         from awswrangler.distributed.ray.modin.s3._read_parquet import _read_parquet_distributed
@@ -48,9 +47,6 @@ def register_ray() -> None:
             _to_parquet: _to_parquet_distributed,
             _to_partitions: _to_partitions_distributed,
             _to_text: _to_text_distributed,
-            to_csv: modin_repartition(to_csv),
-            to_json: modin_repartition(to_json),
-            to_parquet: modin_repartition(to_parquet),
             table_refs_to_df: _arrow_refs_to_df,
         }.items():
             engine.register_func(o_f, d_f)  # type: ignore

--- a/awswrangler/distributed/ray/modin/s3/_write_dataset.py
+++ b/awswrangler/distributed/ray/modin/s3/_write_dataset.py
@@ -9,6 +9,7 @@ from pandas import DataFrame as PandasDataFrame
 
 from awswrangler._distributed import engine
 from awswrangler.distributed.ray import ray_get, ray_remote
+from awswrangler.distributed.ray.modin import modin_repartition
 from awswrangler.s3._write_concurrent import _WriteProxy
 from awswrangler.s3._write_dataset import _delete_objects, _get_bucketing_series, _to_partitions
 
@@ -22,6 +23,7 @@ def _retrieve_paths(values: Union[str, List[Any]]) -> Iterator[str]:
     yield values
 
 
+@modin_repartition
 def _to_buckets_distributed(  # pylint: disable=unused-argument
     df: pd.DataFrame,
     func: Callable[..., List[str]],
@@ -109,6 +111,7 @@ def _write_partitions_distributed(
     return prefix, df_group.name, paths
 
 
+@modin_repartition
 def _to_partitions_distributed(  # pylint: disable=unused-argument
     df: pd.DataFrame,
     func: Callable[..., List[str]],

--- a/tests/load/test_s3.py
+++ b/tests/load/test_s3.py
@@ -1,6 +1,8 @@
 import modin.pandas as pd
+import numpy as np
 import pytest
 import ray
+from modin.distributed.dataframe.pandas import unwrap_partitions
 
 import awswrangler as wr
 
@@ -192,3 +194,25 @@ def test_wait_object_not_exists(path: str, benchmark_time: int) -> None:
         wr.s3.wait_objects_not_exist(file_paths, parallelism=16)
 
     assert timer.elapsed_time < benchmark_time
+
+
+@pytest.mark.parametrize("size", [(5000, 5000), (1, 5000), (5000, 1), (1, 1)])
+def test_wide_df(size, path) -> None:
+    df = pd.DataFrame(np.random.randint(0, 100, size=size))
+    df.columns = df.columns.map(str)
+
+    num_cols = size[0]
+    df["int"] = np.random.choice(["1", "2", None], num_cols)
+    df["decimal"] = np.random.choice(["1.0", "2.0", None], num_cols)
+    df["date"] = np.random.choice(["2020-01-01", "2020-01-02", None], num_cols)
+    df["par0"] = np.random.choice(["A", "B"], num_cols)
+
+    dtype = {
+        "int": "tinyint",
+        "decimal": "double",
+        "date": "date",
+    }
+
+    result = wr.s3.to_csv(df=df, path=path, dataset=True, dtype=dtype, partition_cols=["par0"])
+    partitions_shape = np.array(unwrap_partitions(df)).shape
+    assert len(result["paths"]) == partitions_shape[0] * len(df["par0"].unique())


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Enhancement

### Detail
Currently modin [repartitioning](https://modin.readthedocs.io/en/stable/flow/modin/distributed/dataframe/pandas.html) is applied as soon as a write method (`to_csv`, `to_parquet`) is called. This is not only a wasteful operation performance-wise but also does not prevent the need to repartition once more if the dataframe is altered within the method (e.g. if a column is cast to a new type).

Instead, repartitioning should be applied when it's currently required, that is before a modin group by only.

### Relates
- https://github.com/modin-project/modin/issues/3435
- https://github.com/modin-project/modin/issues/4165#issuecomment-1039617868

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
