### PR TITLE
upgrade engine versions to match defaults from aws console

### DIFF
--- a/test_infra/stacks/databases_stack.py
+++ b/test_infra/stacks/databases_stack.py
@@ -355,7 +355,7 @@ class DatabasesStack(Stack):  # type: ignore
             self,
             "aws-sdk-pandas-postgresql-params",
             engine=rds.DatabaseClusterEngine.aurora_postgres(
-                version=rds.AuroraPostgresEngineVersion.VER_11_13,
+                version=rds.AuroraPostgresEngineVersion.VER_13_7,
             ),
             parameters={
                 "apg_plan_mgmt.capture_plan_baselines": "off",
@@ -366,7 +366,7 @@ class DatabasesStack(Stack):  # type: ignore
             "aws-sdk-pandas-aurora-cluster-postgresql",
             removal_policy=RemovalPolicy.DESTROY,
             engine=rds.DatabaseClusterEngine.aurora_postgres(
-                version=rds.AuroraPostgresEngineVersion.VER_11_13,
+                version=rds.AuroraPostgresEngineVersion.VER_13_7,
             ),
             cluster_identifier="postgresql-cluster-sdk-pandas",
             instances=1,
@@ -518,7 +518,7 @@ class DatabasesStack(Stack):  # type: ignore
             "aws-sdk-pandas-aurora-cluster-mysql-serverless",
             removal_policy=RemovalPolicy.DESTROY,
             engine=rds.DatabaseClusterEngine.aurora_mysql(
-                version=rds.AuroraMysqlEngineVersion.VER_5_7_12,
+                version=rds.AuroraMysqlEngineVersion.VER_2_10_2,
             ),
             cluster_identifier="mysql-serverless-cluster-sdk-pandas",
             default_database_name=database,
@@ -635,7 +635,7 @@ class DatabasesStack(Stack):  # type: ignore
             "aws-sdk-pandas-oracle-instance",
             removal_policy=RemovalPolicy.DESTROY,
             instance_identifier="oracle-instance-sdk-pandas",
-            engine=rds.DatabaseInstanceEngine.oracle_ee(version=rds.OracleEngineVersion.VER_19_0_0_0_2021_04_R1),
+            engine=rds.DatabaseInstanceEngine.oracle_ee(version=rds.OracleEngineVersion.VER_19),
             instance_type=ec2.InstanceType.of(ec2.InstanceClass.BURSTABLE3, ec2.InstanceSize.SMALL),
             credentials=rds.Credentials.from_password(
                 username=self.db_username,

--- a/test_infra/stacks/opensearch_stack.py
+++ b/test_infra/stacks/opensearch_stack.py
@@ -37,7 +37,7 @@ class OpenSearchStack(Stack):  # type: ignore
         self.bucket = bucket
 
         self._set_opensearch_infra()
-        self._setup_opensearch_1_0()
+        self._setup_opensearch_1()
         self._setup_elasticsearch_7_10_fgac()
 
     def _set_opensearch_infra(self) -> None:
@@ -56,15 +56,15 @@ class OpenSearchStack(Stack):  # type: ignore
         else:
             self.connectivity = {"vpc": self.vpc, "vpc_subnets": [{"subnets": [self.vpc.private_subnets[0]]}]}
 
-    def _setup_opensearch_1_0(self) -> None:
-        domain_name = "sdk-pandas-os-1-0"
+    def _setup_opensearch_1(self) -> None:
+        domain_name = "sdk-pandas-os-1"
         validate_domain_name(domain_name)
         domain_arn = f"arn:aws:es:{self.region}:{self.account}:domain/{domain_name}"
         domain = opensearch.Domain(
             self,
             domain_name,
             domain_name=domain_name,
-            version=opensearch.EngineVersion.OPENSEARCH_1_0,
+            version=opensearch.EngineVersion.OPENSEARCH_1_3,
             capacity=opensearch.CapacityConfig(data_node_instance_type="t3.medium.search", data_nodes=1),
             **self.connectivity,
             access_policies=[


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
- OpenSearch is following semver (contrary to ES) and AWS console does not list < 1.3 any longer, hence why I'm renaming the method to `_setup_opensearch_1`. I'm expecting OpenSearch 2 [to be available eventually](https://opensearch.org/blog/releases/2022/05/opensearch-2-0-is-now-available/) and when that is the case we can add `_setup_opensearch_2`.
- I've updated the Oracle engine version to `rds.OracleEngineVersion.VER_19`. We might prefer keeping a specific version but that is in line with what we do for SQL Server (`rds.SqlServerEngineVersion.VER_15`).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
