### PR TITLE
read_csv: read file as binary when encoding_errors is set to ignore

### DIFF
--- a/awswrangler/s3/_fs.py
+++ b/awswrangler/s3/_fs.py
@@ -555,7 +555,7 @@ def open_s3_object(
     newline: Optional[str] = "\n",
     encoding: Optional[str] = "utf-8",
 ) -> Iterator[Union[_S3ObjectBase, io.TextIOWrapper]]:
-    """Return a _S3Object or TextIOWrapper based in the received mode."""
+    """Return a _S3Object or TextIOWrapper based on the received mode."""
     s3obj: Optional[_S3ObjectBase] = None
     text_s3obj: Optional[io.TextIOWrapper] = None
     try:

--- a/awswrangler/s3/_read_text.py
+++ b/awswrangler/s3/_read_text.py
@@ -28,7 +28,9 @@ _logger: logging.Logger = logging.getLogger(__name__)
 def _get_read_details(path: str, pandas_kwargs: Dict[str, Any]) -> Tuple[str, Optional[str], Optional[str]]:
     if pandas_kwargs.get("compression", "infer") == "infer":
         pandas_kwargs["compression"] = infer_compression(path, compression="infer")
-    mode: str = "r" if pandas_kwargs.get("compression") is None else "rb"
+    mode: str = (
+        "r" if pandas_kwargs.get("compression") is None and pandas_kwargs.get("encoding_errors") != "ignore" else "rb"
+    )
     encoding: Optional[str] = pandas_kwargs.get("encoding", "utf-8")
     newline: Optional[str] = pandas_kwargs.get("lineterminator", None)
     return mode, encoding, newline
@@ -249,7 +251,7 @@ def read_csv(
         E.g ``lambda x: True if x["year"] == "2020" and x["month"] == "1" else False``
         https://aws-sdk-pandas.readthedocs.io/en/2.17.0/tutorials/023%20-%20Flexible%20Partitions%20Filter.html
     pandas_kwargs :
-        KEYWORD arguments forwarded to pandas.read_csv(). You can NOT pass `pandas_kwargs` explicit, just add valid
+        KEYWORD arguments forwarded to pandas.read_csv(). You can NOT pass `pandas_kwargs` explicitly, just add valid
         Pandas arguments in the function call and awswrangler will accept it.
         e.g. wr.s3.read_csv('s3://bucket/prefix/', sep='|', na_values=['null', 'none'], skip_blank_lines=True)
         https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html
@@ -292,7 +294,7 @@ def read_csv(
     """
     if "pandas_kwargs" in pandas_kwargs:
         raise exceptions.InvalidArgument(
-            "You can NOT pass `pandas_kwargs` explicit, just add valid "
+            "You can NOT pass `pandas_kwargs` explicitly, just add valid "
             "Pandas arguments in the function call and awswrangler will accept it."
             "e.g. wr.s3.read_csv('s3://bucket/prefix/', sep='|', skip_blank_lines=True)"
         )

--- a/tests/test_s3_text.py
+++ b/tests/test_s3_text.py
@@ -39,6 +39,25 @@ def test_csv_encoding(path, encoding, strings, wrong_encoding, exception, line_t
         assert df.equals(df2)
 
 
+@pytest.mark.parametrize(
+    "encoding,strings,wrong_encoding",
+    [
+        ("utf-8", ["漢字", "ãóú", "г, д, ж, з, к, л"], "ascii"),
+        ("ISO-8859-15", ["Ö, ö, Ü, ü", "ãóú", "øe"], "ascii"),
+    ],
+)
+def test_csv_ignore_encoding_errors(path, encoding, strings, wrong_encoding):
+    file_path = f"{path}0.csv"
+    df = pd.DataFrame({"c0": [1, 2, 3], "c1": strings})
+    wr.s3.to_csv(df, file_path, index=False, encoding=encoding)
+    with pytest.raises(UnicodeDecodeError):
+        df2 = wr.s3.read_csv(file_path, encoding=wrong_encoding)
+    df2 = wr.s3.read_csv(file_path, encoding=wrong_encoding, encoding_errors="ignore")
+    if isinstance(df2, pd.DataFrame) is False:
+        df2 = pd.concat(df2, ignore_index=True)
+        assert df2.shape == (3, 4)
+
+
 @pytest.mark.parametrize("use_threads", [True, False, 2])
 @pytest.mark.parametrize("chunksize", [None, 1])
 def test_read_partitioned_json_paths(path, use_threads, chunksize):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- `read_csv` chokes on encoding errors even when passing `encoding_errors='ignore'`. This happens due to ours casting the S3 object to `TextIOWrapper` after retrieving it and passing that to `pd.read_csv`.
- When specifying `encoding_errors='ignore'` we now keep the object as a set of bytes (`mode=rb`). In this case pandas is now responsible for wrapping this in a TextIOWrapper and deals with encoding and encoding errors.

I'm actually thinking we should never wrap the S3 object into a TextIOWrapper ourselves - as far as I can tell there is no advantage doing that and pandas will take care of it anyway. `mode` should always be set to `rb` in our code... but I'm curious about others' opinion!


### Relates
- #1668

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
