### PR TITLE
fix: map datatype issue of athena

### DIFF
--- a/awswrangler/_data_types.py
+++ b/awswrangler/_data_types.py
@@ -54,7 +54,7 @@ def pyarrow2athena(  # pylint: disable=too-many-branches,too-many-return-stateme
     if pa.types.is_struct(dtype):
         return f"struct<{','.join([f'{f.name}:{pyarrow2athena(dtype=f.type)}' for f in dtype])}>"
     if pa.types.is_map(dtype):
-        return f"map<{pyarrow2athena(dtype=dtype.key_type)}, {pyarrow2athena(dtype=dtype.item_type)}>"
+        return f"map<{pyarrow2athena(dtype=dtype.key_type)},{pyarrow2athena(dtype=dtype.item_type)}>"
     if dtype == pa.null():
         if ignore_null:
             return ""


### PR DESCRIPTION

- Bugfix

### Detail
- Athena does not allow space between map types.
e.g. map<STRING, STRING> will give error while querying but map<STRING,STRING> won't


### Relates
- <URL or Ticket>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
