### PR TITLE
Bug: Replace extra_registries with extra_public_registries

### DIFF
--- a/awswrangler/emr.py
+++ b/awswrangler/emr.py
@@ -159,7 +159,9 @@ def _build_cluster_args(**pars: Any) -> Dict[str, Any]:  # pylint: disable=too-m
             extra_public_registries: List[str] = []
         else:
             extra_public_registries = pars["extra_public_registries"]
-        registries: str = f"local,centos,{account_id}.dkr.ecr.{region}.amazonaws.com,{','.join(extra_public_registries)}"
+        registries: str = (
+            f"local,centos,{account_id}.dkr.ecr.{region}.amazonaws.com,{','.join(extra_public_registries)}"
+        )
         registries = registries[:-1] if registries.endswith(",") else registries
         args["Configurations"].append(
             {

--- a/awswrangler/emr.py
+++ b/awswrangler/emr.py
@@ -155,11 +155,11 @@ def _build_cluster_args(**pars: Any) -> Dict[str, Any]:  # pylint: disable=too-m
         {"Classification": "spark-log4j", "Properties": {"log4j.rootCategory": f"{pars['spark_log_level']}, console"}}
     ]
     if pars["docker"] is True:
-        if pars.get("extra_registries") is None:
-            extra_registries: List[str] = []
+        if pars.get("extra_public_registries") is None:
+            extra_public_registries: List[str] = []
         else:
-            extra_registries = pars["extra_registries"]
-        registries: str = f"local,centos,{account_id}.dkr.ecr.{region}.amazonaws.com,{','.join(extra_registries)}"
+            extra_public_registries = pars["extra_public_registries"]
+        registries: str = f"local,centos,{account_id}.dkr.ecr.{region}.amazonaws.com,{','.join(extra_public_registries)}"
         registries = registries[:-1] if registries.endswith(",") else registries
         args["Configurations"].append(
             {


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Replace `extra_registries` with `extra_public_registries` in `emr.py` to conform to the arguments. 

### Relates
- https://github.com/aws/aws-sdk-pandas/issues/1755

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
