### PR TITLE
Update StackOverflow tag name

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,8 +174,8 @@ FROM "sampleDB"."sampleTable" ORDER BY time DESC LIMIT 3
 The best way to interact with our team is through GitHub. You can open an [issue](https://github.com/aws/aws-sdk-pandas/issues/new/choose) and choose from one of our templates for bug reports, feature requests...
 You may also find help on these community resources:
 * The #aws-sdk-pandas Slack [channel](https://join.slack.com/t/aws-sdk-pandas/shared_invite/zt-sxdx38sl-E0coRfAds8WdpxXD2Nzfrg)
-* Ask a question on [Stack Overflow](https://stackoverflow.com/questions/tagged/awswrangler)
-  and tag it with `awswrangler`
+* Ask a question on [Stack Overflow](https://stackoverflow.com/questions/tagged/aws-data-wrangler)
+  and tag it with `aws-data-wrangler`
 
 ## Community Resources
 


### PR DESCRIPTION
### Feature or Bugfix
- Fixes broken link in README

### Detail
- The [`[awswrangler]`](https://stackoverflow.com/questions/tagged/awswrangler) tag is unused, the active tag now seems to be [`[aws-data-wrangler]`](https://stackoverflow.com/questions/tagged/aws-data-wrangler).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.