### PR TITLE
Add xfail to test_read_parquet_schema_validation_with_index_column

### DIFF
--- a/tests/unit/test_s3_parquet.py
+++ b/tests/unit/test_s3_parquet.py
@@ -600,6 +600,7 @@ def test_read_parquet_versioned(path) -> None:
         assert version_id == wr.s3.describe_objects(path=path_file, version_id=version_id)[path_file]["VersionId"]
 
 
+# TODO https://github.com/aws/aws-sdk-pandas/issues/1775
 @pytest.mark.xfail(reason="The `ignore_index` is not implemented")
 def test_read_parquet_schema_validation_with_index_column(path) -> None:
     path_file = f"{path}file.parquet"

--- a/tests/unit/test_s3_parquet.py
+++ b/tests/unit/test_s3_parquet.py
@@ -600,11 +600,7 @@ def test_read_parquet_versioned(path) -> None:
         assert version_id == wr.s3.describe_objects(path=path_file, version_id=version_id)[path_file]["VersionId"]
 
 
-@pytest.mark.xfail(
-    is_ray_modin,
-    raises=wr.exceptions.InvalidArgumentCombination,
-    reason="Index not working when repartitioning to a single file",
-)
+@pytest.mark.xfail(reason="The `ignore_index` is not implemented")
 def test_read_parquet_schema_validation_with_index_column(path) -> None:
     path_file = f"{path}file.parquet"
     df = pd.DataFrame({"idx": [1], "col": [2]})


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Add xfail to `test_read_parquet_schema_validation_with_index_column` since `ignore_index` was removed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
