### PR TITLE
Add describe_log_streams and filter_log_events to the CloudWatch module

### DIFF
--- a/awswrangler/cloudwatch.py
+++ b/awswrangler/cloudwatch.py
@@ -339,7 +339,7 @@ def _filter_log_events(
     if start_timestamp:
         args["startTime"] = start_timestamp
     if end_timestamp:
-        args["endTime"] = start_timestamp
+        args["endTime"] = end_timestamp
     if filter_pattern:
         args["filterPattern"] = filter_pattern
     response: Dict[str, Any] = client_logs.filter_log_events(**args)

--- a/awswrangler/cloudwatch.py
+++ b/awswrangler/cloudwatch.py
@@ -255,7 +255,7 @@ def describe_log_streams(
     limit: Optional[int] = 50,
     boto3_session: Optional[boto3.Session] = None,
 ) -> pd.DataFrame:
-    """Lists the log streams for the specified log group, return results as a Pandas DataFrame
+    """List the log streams for the specified log group, return results as a Pandas DataFrame.
 
     https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/logs.html#CloudWatchLogs.Client.describe_log_streams
 
@@ -362,7 +362,7 @@ def filter_log_events(
     end_time: Optional[datetime.datetime] = None,
     boto3_session: Optional[boto3.Session] = None,
 ) -> pd.DataFrame:
-    """Lists log events from the specified log group. The results are returned as Pandas DataFrame.
+    """List log events from the specified log group. The results are returned as Pandas DataFrame.
 
     https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/logs.html#CloudWatchLogs.Client.filter_log_events
 

--- a/awswrangler/cloudwatch.py
+++ b/awswrangler/cloudwatch.py
@@ -287,8 +287,8 @@ def describe_log_streams(
     --------
     >>> import awswrangler as wr
     >>> df = wr.cloudwatch.describe_log_streams(
-    ...     log_group_name="loggroup",
-    ...     log_stream_name_prefix="test",
+    ...     log_group_name="aws_sdk_pandas_log_group",
+    ...     log_stream_name_prefix="aws_sdk_pandas_log_stream",
     ... )
 
     """
@@ -394,10 +394,23 @@ def filter_log_events(
 
     Examples
     --------
+    Get all log events from log group 'aws_sdk_pandas_log_group' that have log stream prefix 'aws_sdk_pandas_log_stream'
+
     >>> import awswrangler as wr
     >>> df = wr.cloudwatch.filter_log_events(
-    ...     log_group_name="loggroup",
-    ...     log_stream_name_prefix="test",
+    ...     log_group_name="aws_sdk_pandas_log_group",
+    ...     log_stream_name_prefix="aws_sdk_pandas_log_stream",
+    ... )
+
+    Get all log events contains 'REPORT' from log stream
+    'aws_sdk_pandas_log_stream_one' and 'aws_sdk_pandas_log_stream_two'
+    from log group 'aws_sdk_pandas_log_group'
+
+    >>> import awswrangler as wr
+    >>> df = wr.cloudwatch.filter_log_events(
+    ...     log_group_name="aws_sdk_pandas_log_group",
+    ...     log_stream_names=["aws_sdk_pandas_log_stream_one","aws_sdk_pandas_log_stream_two"],
+    ...     filter_pattern='REPORT',
     ... )
 
     """

--- a/awswrangler/cloudwatch.py
+++ b/awswrangler/cloudwatch.py
@@ -421,7 +421,14 @@ def filter_log_events(
     _logger.debug("log_group_name: %s", log_group_name)
 
     events: List[Dict[str, Any]] = []
-    if log_stream_name_prefix and not log_stream_names:
+    if not log_stream_names:
+        describe_log_streams_args: Dict[str, Any] = {
+            "log_group_name": log_group_name,
+        }
+        if boto3_session:
+            describe_log_streams_args["boto3_session"] = boto3_session
+        if log_stream_name_prefix:
+            describe_log_streams_args["log_stream_name_prefix"] = log_stream_name_prefix
         log_stream_names = describe_log_streams(
             log_group_name=log_group_name, log_stream_name_prefix=log_stream_name_prefix, boto3_session=boto3_session
         )["logStreamName"].tolist()

--- a/awswrangler/cloudwatch.py
+++ b/awswrangler/cloudwatch.py
@@ -250,7 +250,7 @@ def read_logs(
 def describe_log_streams(
     log_group_name: str,
     log_stream_name_prefix: Optional[str] = None,
-    order_by: Optional[Union[Literal["LogStreamName"], Literal["LastEventTime"]]] = "LogStreamName",
+    order_by: Optional[str] = "LogStreamName",
     descending: Optional[bool] = False,
     limit: Optional[int] = 50,
     boto3_session: Optional[boto3.Session] = None,

--- a/awswrangler/cloudwatch.py
+++ b/awswrangler/cloudwatch.py
@@ -3,7 +3,7 @@
 import datetime
 import logging
 import time
-from typing import Any, Dict, List, Literal, Optional, Union, cast
+from typing import Any, Dict, List, Optional, cast
 
 import boto3
 import pandas as pd

--- a/awswrangler/cloudwatch.py
+++ b/awswrangler/cloudwatch.py
@@ -315,9 +315,11 @@ def describe_log_streams(
             nextToken=response["nextToken"],
         )
         log_streams += response["logStreams"]
-    df: pd.DataFrame = pd.DataFrame(log_streams)
-    df["logGroupName"] = log_group_name
-    return df
+    if log_streams:
+        df: pd.DataFrame = pd.DataFrame(log_streams)
+        df["logGroupName"] = log_group_name
+        return df
+    return pd.DataFrame()
 
 
 def _filter_log_events(

--- a/awswrangler/cloudwatch.py
+++ b/awswrangler/cloudwatch.py
@@ -431,10 +431,9 @@ def filter_log_events(
             describe_log_streams_args["boto3_session"] = boto3_session
         if log_stream_name_prefix:
             describe_log_streams_args["log_stream_name_prefix"] = log_stream_name_prefix
-        log_stream_names = describe_log_streams(
-            log_group_name=log_group_name, log_stream_name_prefix=log_stream_name_prefix, boto3_session=boto3_session
-        )["logStreamName"].tolist()
-    assert log_stream_names is not None
+        log_streams = describe_log_streams(**describe_log_streams_args)
+        log_stream_names = log_streams["logStreamName"].tolist() if len(log_streams.index) else []
+
     args: Dict[str, Any] = {
         "log_group_name": log_group_name,
     }

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -338,6 +338,7 @@ Amazon CloudWatch Logs
     run_query
     start_query
     wait_query
+    describe_log_streams
 
 Amazon QuickSight
 -----------------

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -339,6 +339,7 @@ Amazon CloudWatch Logs
     start_query
     wait_query
     describe_log_streams
+    filter_log_events
 
 Amazon QuickSight
 -----------------

--- a/tests/test_cloudwatch.py
+++ b/tests/test_cloudwatch.py
@@ -93,6 +93,6 @@ def test_describe_log_streams_and_filter_log_events(loggroup):
     assert len(log_events_df.index) >= 4
 
     filtered_log_events_df = wr.cloudwatch.filter_log_events(
-        log_group_name=loggroup, log_stream_names=log_stream_names, filter_pattern='"REPORT"'
+        log_group_name=loggroup, log_stream_names=log_streams_df["logStreamName"].tolist(), filter_pattern="REPORT"
     )
-    assert len(filtered_log_events_df.index) >= 4
+    assert len(filtered_log_events_df.index) > 0

--- a/tests/test_cloudwatch.py
+++ b/tests/test_cloudwatch.py
@@ -1,5 +1,5 @@
-from datetime import datetime
 import logging
+from datetime import datetime
 
 import boto3
 import pytest

--- a/tests/test_cloudwatch.py
+++ b/tests/test_cloudwatch.py
@@ -71,6 +71,7 @@ def test_describe_log_streams_and_filter_log_events(loggroup):
     assert len(log_streams_df.index) >= 4
     assert "logGroupName" in log_streams_df.columns
 
+    log_streams_df.dropna(inplace=True)
     for log_stream in log_streams_df.to_dict("records"):
         events = []
         token = log_stream.get("uploadSequenceToken")

--- a/tests/test_cloudwatch.py
+++ b/tests/test_cloudwatch.py
@@ -61,7 +61,10 @@ def test_describe_log_streams_and_filter_log_events(loggroup):
         "aws_sdk_pandas_log_stream_four",
     ]
     for log_stream in log_stream_names:
-        cloudwatch_log_client.create_log_stream(logGroupName=loggroup, logStreamName=log_stream)
+        try:
+            cloudwatch_log_client.create_log_stream(logGroupName=loggroup, logStreamName=log_stream)
+        except cloudwatch_log_client.Client.exceptions.ResourceAlreadyExistsException:
+            continue
     log_streams_df = wr.cloudwatch.describe_log_streams(
         log_group_name=loggroup, order_by="LastEventTime", descending=False
     )

--- a/tests/test_cloudwatch.py
+++ b/tests/test_cloudwatch.py
@@ -70,6 +70,7 @@ def test_describe_log_streams_and_filter_log_events(loggroup):
     )
     assert len(log_streams_df.index) >= 4
     assert "logGroupName" in log_streams_df.columns
+
     for log_stream in log_streams_df.to_dict("records"):
         events = []
         token = log_stream.get("uploadSequenceToken")

--- a/tests/test_cloudwatch.py
+++ b/tests/test_cloudwatch.py
@@ -89,9 +89,7 @@ def test_describe_log_streams_and_filter_log_events(loggroup):
         except cloudwatch_log_client.exceptions.DataAlreadyAcceptedException:
             pass
 
-    log_events_df = wr.cloudwatch.filter_log_events(
-        log_group_name=loggroup, log_stream_name_prefix="aws_sdk_pandas_log_stream"
-    )
+    log_events_df = wr.cloudwatch.filter_log_events(log_group_name=loggroup)
     assert len(log_events_df.index) >= 4
 
     filtered_log_events_df = wr.cloudwatch.filter_log_events(

--- a/tests/test_cloudwatch.py
+++ b/tests/test_cloudwatch.py
@@ -91,8 +91,10 @@ def test_describe_log_streams_and_filter_log_events(loggroup):
 
     log_events_df = wr.cloudwatch.filter_log_events(log_group_name=loggroup)
     assert len(log_events_df.index) >= 4
+    assert "logGroupName" in log_events_df.columns
 
     filtered_log_events_df = wr.cloudwatch.filter_log_events(
         log_group_name=loggroup, log_stream_names=log_streams_df["logStreamName"].tolist(), filter_pattern="REPORT"
     )
-    assert len(filtered_log_events_df.index) > 0
+    assert len(filtered_log_events_df.index) >= 4
+    assert "logStreamName" in log_events_df.columns

--- a/tests/test_cloudwatch.py
+++ b/tests/test_cloudwatch.py
@@ -66,6 +66,14 @@ def test_describe_log_streams_and_filter_log_events(loggroup):
         except cloudwatch_log_client.exceptions.ResourceAlreadyExistsException:
             continue
 
+    with pytest.raises(exceptions.InvalidArgumentCombination):
+        wr.cloudwatch.describe_log_streams(
+            log_group_name=loggroup,
+            log_stream_name_prefix="aws_sdk_pandas_log_stream",
+            order_by="LastEventTime",
+            descending=False,
+        )
+
     log_streams_df = wr.cloudwatch.describe_log_streams(
         log_group_name=loggroup, order_by="LastEventTime", descending=False
     )
@@ -90,6 +98,13 @@ def test_describe_log_streams_and_filter_log_events(loggroup):
             cloudwatch_log_client.put_log_events(**args)
         except cloudwatch_log_client.exceptions.DataAlreadyAcceptedException:
             pass
+
+    with pytest.raises(exceptions.InvalidArgumentCombination):
+        wr.cloudwatch.filter_log_events(
+            log_group_name=loggroup,
+            log_stream_name_prefix="aws_sdk_pandas_log_stream",
+            log_stream_names=log_streams_df["logStreamName"].tolist(),
+        )
 
     log_events_df = wr.cloudwatch.filter_log_events(log_group_name=loggroup)
     assert len(log_events_df.index) >= 4

--- a/tests/test_cloudwatch.py
+++ b/tests/test_cloudwatch.py
@@ -63,7 +63,7 @@ def test_describe_log_streams_and_filter_log_events(loggroup):
     for log_stream in log_stream_names:
         try:
             cloudwatch_log_client.create_log_stream(logGroupName=loggroup, logStreamName=log_stream)
-        except cloudwatch_log_client.Client.exceptions.ResourceAlreadyExistsException:
+        except cloudwatch_log_client.exceptions.ResourceAlreadyExistsException:
             continue
     log_streams_df = wr.cloudwatch.describe_log_streams(
         log_group_name=loggroup, order_by="LastEventTime", descending=False

--- a/tests/test_cloudwatch.py
+++ b/tests/test_cloudwatch.py
@@ -65,9 +65,11 @@ def test_describe_log_streams_and_filter_log_events(loggroup):
             cloudwatch_log_client.create_log_stream(logGroupName=loggroup, logStreamName=log_stream)
         except cloudwatch_log_client.exceptions.ResourceAlreadyExistsException:
             continue
+
     log_streams_df = wr.cloudwatch.describe_log_streams(
         log_group_name=loggroup, order_by="LastEventTime", descending=False
     )
+
     assert len(log_streams_df.index) >= 4
     assert "logGroupName" in log_streams_df.columns
 

--- a/tests/test_cloudwatch.py
+++ b/tests/test_cloudwatch.py
@@ -92,10 +92,9 @@ def test_describe_log_streams_and_filter_log_events(loggroup):
     log_events_df = wr.cloudwatch.filter_log_events(
         log_group_name=loggroup, log_stream_name_prefix="aws_sdk_pandas_log_stream"
     )
-    assert len(set(log_events_df["logStreamName"].tolist())) >= 4
+    assert len(log_events_df.index) >= 4
 
     filtered_log_events_df = wr.cloudwatch.filter_log_events(
         log_group_name=loggroup, log_stream_names=log_stream_names, filter_pattern='"REPORT"'
     )
     assert len(filtered_log_events_df.index) >= 4
-    assert set(log_events_df["logStreamName"].tolist()) == set(log_stream_names)

--- a/tests/test_cloudwatch.py
+++ b/tests/test_cloudwatch.py
@@ -87,7 +87,7 @@ def test_describe_log_streams_and_filter_log_events(loggroup):
         try:
             cloudwatch_log_client.put_log_events(**args)
         except cloudwatch_log_client.exceptions.DataAlreadyAcceptedException:
-            pass  # Concurrency
+            pass
 
     log_events_df = wr.cloudwatch.filter_log_events(
         log_group_name=loggroup, log_stream_name_prefix="aws_sdk_pandas_log_stream"


### PR DESCRIPTION
### Feature
- Feature

### Detail
- Add `describe_log_streams` to CloudWatch module for getting log streams' details from specified log group.
- Add `filter_log_events` to CloudWatch module for returning filtered log events from specified log group's log streams.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
