### PR TITLE
(fix) Distrib S3 Select - check row count before creating the Ray dataset

### DIFF
--- a/tests/load/test_s3.py
+++ b/tests/load/test_s3.py
@@ -48,13 +48,14 @@ def _modin_repartition(df: pd.DataFrame, num_blocks: int) -> pd.DataFrame:
 def test_s3_select(benchmark_time):
     path = "s3://ursa-labs-taxi-data/2018/1*.parquet"
     with ExecutionTimer("elapsed time of wr.s3.select_query()") as timer:
-        wr.s3.select_query(
+        df = wr.s3.select_query(
             sql="SELECT * FROM s3object",
             path=path,
             input_serialization="Parquet",
             input_serialization_params={},
             scan_range_chunk_size=16 * 1024 * 1024,
         )
+        assert df.shape == (25139500, 17)
 
     assert timer.elapsed_time < benchmark_time
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Ray dataset with multiple empty blocks messes up resulting modin data frame

### Relates
- #1783 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
