### PR TITLE
add support for boto3 kwargs to timestream.create_table

### DIFF
--- a/awswrangler/timestream.py
+++ b/awswrangler/timestream.py
@@ -9,10 +9,16 @@ from typing import Any, Dict, Iterator, List, Optional, Union, cast
 import boto3
 import pandas as pd
 from botocore.config import Config
+from botocore.loaders import Loader
+from botocore.model import ServiceModel
 
 from awswrangler import _data_types, _utils
 
 _logger: logging.Logger = logging.getLogger(__name__)
+
+_BOTOCORE_LOADER = Loader()
+_TIMESTREAM_JSON_MODEL = _BOTOCORE_LOADER.load_service_model(service_name="timestream-write", type_name="service-2")
+_TIMESTREAM_SERVICE_MODEL = ServiceModel(_TIMESTREAM_JSON_MODEL, service_name="timestream-write")
 
 
 def _df2list(df: pd.DataFrame) -> List[List[Any]]:
@@ -385,12 +391,24 @@ def delete_database(
     client.delete_database(DatabaseName=database)
 
 
+def _snake_to_camel_case(s: str) -> str:
+    return "".join(c.title() for c in s.split("_"))
+
+
+def get_botocore_valid_kwargs(function_name: str, timestream_additional_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    """Filter and keep only the valid botocore key arguments."""
+    timestream_operation_model = _TIMESTREAM_SERVICE_MODEL.operation_model(_snake_to_camel_case(function_name))
+    allowed_kwargs = timestream_operation_model.input_shape.members.keys()  # pylint: disable=E1101
+    return {k: v for k, v in timestream_additional_kwargs.items() if k in allowed_kwargs}
+
+
 def create_table(
     database: str,
     table: str,
     memory_retention_hours: int,
     magnetic_retention_days: int,
     tags: Optional[Dict[str, str]] = None,
+    timestream_additional_kwargs: Optional[Dict[str, Any]] = None,
     boto3_session: Optional[boto3.Session] = None,
 ) -> str:
     """Create a new Timestream database.
@@ -415,6 +433,9 @@ def create_table(
         Tags enable you to categorize databases and/or tables, for example,
         by purpose, owner, or environment.
         e.g. {"foo": "boo", "bar": "xoo"})
+    timestream_additional_kwargs : Optional[Dict[str, Any]]
+        Forwarded to botocore requests.
+        e.g. timestream_additional_kwargs={'MagneticStoreWriteProperties': {'EnableMagneticStoreWrites': True}}
     boto3_session : boto3.Session(), optional
         Boto3 Session. The default boto3 Session will be used if boto3_session receive None.
 
@@ -437,6 +458,11 @@ def create_table(
 
     """
     client: boto3.client = _utils.client(service_name="timestream-write", session=boto3_session)
+    boto3_kwargs = {}
+    if timestream_additional_kwargs:
+        boto3_kwargs = get_botocore_valid_kwargs(
+            function_name="create_table", timestream_additional_kwargs=timestream_additional_kwargs
+        )
     args: Dict[str, Any] = {
         "DatabaseName": database,
         "TableName": table,
@@ -444,6 +470,7 @@ def create_table(
             "MemoryStoreRetentionPeriodInHours": memory_retention_hours,
             "MagneticStoreRetentionPeriodInDays": magnetic_retention_days,
         },
+        **boto3_kwargs,
     }
     if tags is not None:
         args["Tags"] = [{"Key": k, "Value": v} for k, v in tags.items()]

--- a/tests/test_timestream.py
+++ b/tests/test_timestream.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import datetime
 
+import boto3
 import pandas as pd
 import pytest
 
@@ -282,3 +283,30 @@ def test_list_tables(timestream_database_and_table):
 
     tables_in_db = wr.timestream.list_tables(database=timestream_database_and_table)
     assert f"{timestream_database_and_table}_2" not in tables_in_db
+
+
+@pytest.mark.parametrize(
+    "timestream_additional_kwargs",
+    [None, {"MagneticStoreWriteProperties": {"EnableMagneticStoreWrites": True}}],
+)
+def test_create_table_additional_kwargs(timestream_database_and_table, timestream_additional_kwargs):
+    client_timestream = boto3.client("timestream-write")
+    wr.timestream.create_table(
+        database=timestream_database_and_table,
+        table=f"{timestream_database_and_table}_3",
+        memory_retention_hours=1,
+        magnetic_retention_days=1,
+        timestream_additional_kwargs=timestream_additional_kwargs,
+    )
+
+    desc = client_timestream.describe_table(
+        DatabaseName=timestream_database_and_table, TableName=f"{timestream_database_and_table}_3"
+    )["Table"]
+    if timestream_additional_kwargs is None:
+        assert desc["MagneticStoreWriteProperties"].get("EnableMagneticStoreWrites") is False
+    elif timestream_additional_kwargs["MagneticStoreWriteProperties"]["EnableMagneticStoreWrites"] is True:
+        assert desc["MagneticStoreWriteProperties"].get("EnableMagneticStoreWrites") is True
+
+    wr.timestream.delete_table(database=timestream_database_and_table, table=f"{timestream_database_and_table}_3")
+    tables_in_db = wr.timestream.list_tables(database=timestream_database_and_table)
+    assert f"{timestream_database_and_table}_3" not in tables_in_db


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
- ability to pass boto3 arguments to timestream.create_table
- associated test case

### Relates
- #1629

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
