### PR TITLE
Add deltalake support in AWS S3 with Pandas

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ or
 
 * Install dependencies:
 
-``poetry install --extras "sqlserver oracle sparql"``
+``poetry install --extras "sqlserver oracle sparql deltalake"``
 
 * Run the validation script:
 
@@ -135,7 +135,7 @@ or
 
 * Install dependencies:
 
-``poetry install --extras "sqlserver oracle sparql"``
+``poetry install --extras "sqlserver oracle sparql deltalake"``
 
 * Go to the ``test_infra`` directory
 

--- a/awswrangler/s3/__init__.py
+++ b/awswrangler/s3/__init__.py
@@ -6,6 +6,7 @@ from awswrangler.s3._describe import describe_objects, get_bucket_region, size_o
 from awswrangler.s3._download import download  # noqa
 from awswrangler.s3._list import does_object_exist, list_buckets, list_directories, list_objects  # noqa
 from awswrangler.s3._merge_upsert_table import merge_upsert_table  # noqa
+from awswrangler.s3._read_deltalake import read_deltalake, read_deltalake_from_glue  # noqa
 from awswrangler.s3._read_excel import read_excel  # noqa
 from awswrangler.s3._read_parquet import read_parquet, read_parquet_metadata, read_parquet_table  # noqa
 from awswrangler.s3._read_text import read_csv, read_fwf, read_json  # noqa
@@ -27,6 +28,8 @@ __all__ = [
     "list_buckets",
     "list_directories",
     "list_objects",
+    "read_deltalake",
+    "read_deltalake_from_glue",
     "read_parquet",
     "read_parquet_metadata",
     "read_parquet_table",

--- a/awswrangler/s3/_read_deltalake.py
+++ b/awswrangler/s3/_read_deltalake.py
@@ -1,0 +1,124 @@
+"""Amazon S3 Read Delta Lake Module (PRIVATE)."""
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import pandas as pd
+import pyarrow.fs as pa_fs
+from deltalake import DataCatalog, DeltaTable
+
+_logger: logging.Logger = logging.getLogger(__name__)
+
+
+def read_deltalake(
+    path: str,
+    version: Optional[int] = None,
+    storage_options: Optional[Dict[str, str]] = None,
+    without_files: bool = False,
+    partitions: Optional[List[Tuple[str, str, Any]]] = None,
+    columns: Optional[List[str]] = None,
+    filesystem: Optional[Union[str, pa_fs.FileSystem]] = None,
+) -> pd.DataFrame:
+    """
+    Load data from Deltalake.
+    This function requires the `deltalake package
+    <https://delta-io.github.io/delta-rs/python>`__.
+    See the `How to load a Delta table
+    <https://delta-io.github.io/delta-rs/python/usage.html#loading-a-delta-table>`__
+    guide for loading instructions.
+
+    Parameters
+    ----------
+    path: str
+        The path of the DeltaTable.
+    version: Optional[int]
+        The version of the DeltaTable.
+    storage_options: Optional[Dict[str, str]]
+        A dictionary of the options to use for the storage backend.
+    without_files: bool
+        If True, will load table without tracking files.
+        Some append-only applications might have no need of tracking any files.
+        So, the DeltaTable will be loaded with a significant memory reduction.
+    partitions: Optional[List[Tuple[str, str, Any]]
+        A list of partition filters, see help(DeltaTable.files_by_partitions)
+        for filter syntax.
+    columns: Optional[List[str]]
+        The columns to project. This can be a list of column names to include
+        (order and duplicates will be preserved).
+    filesystem: Optional[Union[str, pa_fs.FileSystem]]
+        A concrete implementation of the Pyarrow FileSystem or
+        a fsspec-compatible interface. If None, the first file path will be used
+        to determine the right FileSystem.
+
+    Returns
+    -------
+    df: DataFrame
+        DataFrame including the results.
+
+    See Also
+    --------
+    deltalake.DeltaTable : Create a DeltaTable instance with the deltalake library.
+    """
+    table = DeltaTable(
+        table_uri=path,
+        version=version,
+        storage_options=storage_options,
+        without_files=without_files,
+    )
+    return table.to_pandas(partitions=partitions, columns=columns, filesystem=filesystem)
+
+
+def read_deltalake_from_glue(
+    database: str,
+    table: str,
+    catalog_id: Optional[str] = None,
+    version: Optional[int] = None,
+    partitions: Optional[List[Tuple[str, str, Any]]] = None,
+    columns: Optional[List[str]] = None,
+    filesystem: Optional[Union[str, pa_fs.FileSystem]] = None,
+) -> pd.DataFrame:
+    """
+    Load data from Deltalake from AWS Glue.
+    This function requires the `deltalake package
+    <https://delta-io.github.io/delta-rs/python>`__.
+    See the `How to load a Delta table
+    <https://delta-io.github.io/delta-rs/python/usage.html#loading-a-delta-table>`__
+    guide for loading instructions.
+
+    Parameters
+    ----------
+    database : str
+        Glue/Athena catalog: Database name.
+    table : str
+        Glue/Athena catalog: Table name.
+    catalog_id: Optional[str]
+        The optional Glue catalog id.
+    version: Optional[int]
+        The version of the DeltaTable.
+    partitions: Optional[List[Tuple[str, str, Any]]
+        A list of partition filters, see help(DeltaTable.files_by_partitions)
+        for filter syntax.
+    columns: Optional[List[str]]
+        The columns to project. This can be a list of column names to include
+        (order and duplicates will be preserved).
+    filesystem: Optional[Union[str, pa_fs.FileSystem]]
+        A concrete implementation of the Pyarrow FileSystem or
+        a fsspec-compatible interface. If None, the first file path will be used
+        to determine the right FileSystem.
+
+    Returns
+    -------
+    df: DataFrame
+        DataFrame including the results.
+
+    See Also
+    --------
+    deltalake.DeltaTable : Create a DeltaTable instance with the deltalake library.
+    """
+    return DeltaTable.from_data_catalog(
+        data_catalog=DataCatalog.AWS.value,
+        data_catalog_id=catalog_id,
+        database_name=database,
+        table_name=table,
+        version=version,
+    ).to_pandas(partitions=partitions, columns=columns, filesystem=filesystem)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,11 +45,13 @@ backoff = ">=1.11.1,<3.0.0"
 SPARQLWrapper = { version = ">=1.8.5,<3.0.0", optional = true }
 pyodbc = { version = "~4.0.32", optional = true }
 oracledb = { version = "~1.0.0", optional = true }
+deltalake = { version = "~0.6.4", optional = true }
 
 [tool.poetry.extras]
 sqlserver = ["pyodbc"]
 oracle = ["oracledb"]
 sparql = ["SPARQLWrapper"]
+deltalake = ["deltalake"]
 
 [tool.poetry.dev-dependencies]
 wheel = "^0.37.1"

--- a/test_infra/poetry.lock
+++ b/test_infra/poetry.lock
@@ -13,61 +13,103 @@ tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900
 tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
 
 [[package]]
+name = "aws-cdk-asset-awscli-v1"
+version = "2.2.25"
+description = "A library that contains the AWS CLI for use in Lambda Layers"
+category = "main"
+optional = false
+python-versions = "~=3.7"
+
+[package.dependencies]
+jsii = ">=1.71.0,<2.0.0"
+publication = ">=0.0.3"
+typeguard = ">=2.13.3,<2.14.0"
+
+[[package]]
+name = "aws-cdk-asset-kubectl-v20"
+version = "2.1.1"
+description = "A library that contains kubectl for use in Lambda Layers"
+category = "main"
+optional = false
+python-versions = "~=3.7"
+
+[package.dependencies]
+jsii = ">=1.70.0,<2.0.0"
+publication = ">=0.0.3"
+typeguard = ">=2.13.3,<2.14.0"
+
+[[package]]
+name = "aws-cdk-asset-node-proxy-agent-v5"
+version = "2.0.31"
+description = "@aws-cdk/asset-node-proxy-agent-v5"
+category = "main"
+optional = false
+python-versions = "~=3.7"
+
+[package.dependencies]
+jsii = ">=1.71.0,<2.0.0"
+publication = ">=0.0.3"
+typeguard = ">=2.13.3,<2.14.0"
+
+[[package]]
 name = "aws-cdk-aws-glue-alpha"
-version = "2.47.0a0"
+version = "2.53.0a0"
 description = "The CDK Construct Library for AWS::Glue"
 category = "main"
 optional = false
 python-versions = "~=3.7"
 
 [package.dependencies]
-aws-cdk-lib = ">=2.47.0,<3.0.0"
+aws-cdk-lib = ">=2.53.0,<3.0.0"
 constructs = ">=10.0.0,<11.0.0"
-jsii = ">=1.69.0,<2.0.0"
+jsii = ">=1.71.0,<2.0.0"
 publication = ">=0.0.3"
 typeguard = ">=2.13.3,<2.14.0"
 
 [[package]]
 name = "aws-cdk-aws-neptune-alpha"
-version = "2.47.0a0"
+version = "2.53.0a0"
 description = "The CDK Construct Library for AWS::Neptune"
 category = "main"
 optional = false
 python-versions = "~=3.7"
 
 [package.dependencies]
-aws-cdk-lib = ">=2.47.0,<3.0.0"
+aws-cdk-lib = ">=2.53.0,<3.0.0"
 constructs = ">=10.0.0,<11.0.0"
-jsii = ">=1.69.0,<2.0.0"
+jsii = ">=1.71.0,<2.0.0"
 publication = ">=0.0.3"
 typeguard = ">=2.13.3,<2.14.0"
 
 [[package]]
 name = "aws-cdk-aws-redshift-alpha"
-version = "2.47.0a0"
+version = "2.53.0a0"
 description = "The CDK Construct Library for AWS::Redshift"
 category = "main"
 optional = false
 python-versions = "~=3.7"
 
 [package.dependencies]
-aws-cdk-lib = ">=2.47.0,<3.0.0"
+aws-cdk-lib = ">=2.53.0,<3.0.0"
 constructs = ">=10.0.0,<11.0.0"
-jsii = ">=1.69.0,<2.0.0"
+jsii = ">=1.71.0,<2.0.0"
 publication = ">=0.0.3"
 typeguard = ">=2.13.3,<2.14.0"
 
 [[package]]
 name = "aws-cdk-lib"
-version = "2.47.0"
+version = "2.53.0"
 description = "Version 2 of the AWS Cloud Development Kit library"
 category = "main"
 optional = false
 python-versions = "~=3.7"
 
 [package.dependencies]
+"aws-cdk.asset-awscli-v1" = ">=2.2.9,<3.0.0"
+"aws-cdk.asset-kubectl-v20" = ">=2.1.1,<3.0.0"
+"aws-cdk.asset-node-proxy-agent-v5" = ">=2.0.15,<3.0.0"
 constructs = ">=10.0.0,<11.0.0"
-jsii = ">=1.69.0,<2.0.0"
+jsii = ">=1.71.0,<2.0.0"
 publication = ">=0.0.3"
 typeguard = ">=2.13.3,<2.14.0"
 
@@ -86,20 +128,20 @@ typing_extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "constructs"
-version = "10.1.134"
+version = "10.1.177"
 description = "A programming model for software-defined state"
 category = "main"
 optional = false
 python-versions = "~=3.7"
 
 [package.dependencies]
-jsii = ">=1.70.0,<2.0.0"
+jsii = ">=1.71.0,<2.0.0"
 publication = ">=0.0.3"
 typeguard = ">=2.13.3,<2.14.0"
 
 [[package]]
 name = "exceptiongroup"
-version = "1.0.0rc9"
+version = "1.0.4"
 description = "Backport of PEP 654 (exception groups)"
 category = "main"
 optional = false
@@ -110,7 +152,7 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "jsii"
-version = "1.70.0"
+version = "1.71.0"
 description = "Python client for jsii runtime"
 category = "main"
 optional = false
@@ -181,37 +223,49 @@ attrs = [
     {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},
     {file = "attrs-22.1.0.tar.gz", hash = "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"},
 ]
+aws-cdk-asset-awscli-v1 = [
+    {file = "aws-cdk.asset-awscli-v1-2.2.25.tar.gz", hash = "sha256:292b0a664d71302090fe29b4dcdca622d026ea76cbe0b8de4cad1b82403ff5b2"},
+    {file = "aws_cdk.asset_awscli_v1-2.2.25-py3-none-any.whl", hash = "sha256:617f3438a58c4ffc618a76c6a93b4d2a7aed71ba193705e873aa9214547d33a6"},
+]
+aws-cdk-asset-kubectl-v20 = [
+    {file = "aws-cdk.asset-kubectl-v20-2.1.1.tar.gz", hash = "sha256:9834cdb150c5590aea4e5eba6de2a89b4c60617451181c524810c5a75154565c"},
+    {file = "aws_cdk.asset_kubectl_v20-2.1.1-py3-none-any.whl", hash = "sha256:a2fad1a5a35a94a465efe60859f91e45dacc33261fb9bbf1cf9bbc6e2f70e9d6"},
+]
+aws-cdk-asset-node-proxy-agent-v5 = [
+    {file = "aws-cdk.asset-node-proxy-agent-v5-2.0.31.tar.gz", hash = "sha256:c9724a9dd85f1a10016f78562ab20d0030eec5213782eedca67f8290e0875058"},
+    {file = "aws_cdk.asset_node_proxy_agent_v5-2.0.31-py3-none-any.whl", hash = "sha256:c370f6a04a34f7a8a6418922886fb9402d57ad4431354d3ce1c7b3acc5a498b7"},
+]
 aws-cdk-aws-glue-alpha = [
-    {file = "aws-cdk.aws-glue-alpha-2.47.0a0.tar.gz", hash = "sha256:176793bfee548dd15dbbcaebeee773d2179ecbb811470260dd96061937e54486"},
-    {file = "aws_cdk.aws_glue_alpha-2.47.0a0-py3-none-any.whl", hash = "sha256:9decde5316d16eaf4d2ffd4237f472db859bb0da474de54af590f0da000f5923"},
+    {file = "aws-cdk.aws-glue-alpha-2.53.0a0.tar.gz", hash = "sha256:cc92e383c203d6c1529c3b0807b0d3fe92082db6e059bbd4b0c90fe6c4f253b3"},
+    {file = "aws_cdk.aws_glue_alpha-2.53.0a0-py3-none-any.whl", hash = "sha256:0e21547910a0d2680276d88f98e1efd0ffe8f801623d23a0135af7d26699502b"},
 ]
 aws-cdk-aws-neptune-alpha = [
-    {file = "aws-cdk.aws-neptune-alpha-2.47.0a0.tar.gz", hash = "sha256:3e37f8e314a6218a6b6bf2d98e09183f8c224bb546891a277c47076e70701fb3"},
-    {file = "aws_cdk.aws_neptune_alpha-2.47.0a0-py3-none-any.whl", hash = "sha256:a6cd73084762b937e518862257339c1b6a3a957f88f9f8e06f620b335af46a15"},
+    {file = "aws-cdk.aws-neptune-alpha-2.53.0a0.tar.gz", hash = "sha256:fc704fe11cedcfefc3cd243d654877e91ad7c7a05647a8f56d401c05b2a527e8"},
+    {file = "aws_cdk.aws_neptune_alpha-2.53.0a0-py3-none-any.whl", hash = "sha256:0a67f0edba56824e4a2c236dacf175454697329c780f16261c985edfa8b28fd0"},
 ]
 aws-cdk-aws-redshift-alpha = [
-    {file = "aws-cdk.aws-redshift-alpha-2.47.0a0.tar.gz", hash = "sha256:852494fb4295a40947750cc46c93a12245ab464e05bcd5d7bb048bc5643e5685"},
-    {file = "aws_cdk.aws_redshift_alpha-2.47.0a0-py3-none-any.whl", hash = "sha256:a8956bc4a3e91f59b5412d1565dde1366199d67836018152ec252f8d1d9cae47"},
+    {file = "aws-cdk.aws-redshift-alpha-2.53.0a0.tar.gz", hash = "sha256:ccbac0533a4779593ae211d55f1c5dd2a6f185c830443f830dc7e8bd4fdab418"},
+    {file = "aws_cdk.aws_redshift_alpha-2.53.0a0-py3-none-any.whl", hash = "sha256:aff390f807768dbc6617b3eebb435794961ea4d7e54ea7a8f3a3228b59db4928"},
 ]
 aws-cdk-lib = [
-    {file = "aws-cdk-lib-2.47.0.tar.gz", hash = "sha256:c9b1626c7afc42ceaee547558efe88439dd1447b18c7837db153e03fb8186167"},
-    {file = "aws_cdk_lib-2.47.0-py3-none-any.whl", hash = "sha256:1f1a2e2309625d304a14b388ee0fedb0dffc15eef14dac65e33b10f6c73bf75c"},
+    {file = "aws-cdk-lib-2.53.0.tar.gz", hash = "sha256:6c4df94b74176ffdb7072d2be383608567816c918978f006f984299c04beb141"},
+    {file = "aws_cdk_lib-2.53.0-py3-none-any.whl", hash = "sha256:7fafb2ef55a66467e77dd44f03d533e8abde3729b247916dfdc5cf4ce1fe516d"},
 ]
 cattrs = [
     {file = "cattrs-22.2.0-py3-none-any.whl", hash = "sha256:bc12b1f0d000b9f9bee83335887d532a1d3e99a833d1bf0882151c97d3e68c21"},
     {file = "cattrs-22.2.0.tar.gz", hash = "sha256:f0eed5642399423cf656e7b66ce92cdc5b963ecafd041d1b24d136fdde7acf6d"},
 ]
 constructs = [
-    {file = "constructs-10.1.134-py3-none-any.whl", hash = "sha256:b3f05ad138af83473cc9bd5f8949558bd31d38fb32c09fcc56d0de9057c2e61d"},
-    {file = "constructs-10.1.134.tar.gz", hash = "sha256:4ab253a74e62a2c918456d20dff42ec0abb2e4393a6bab0218c81c09e19c1a41"},
+    {file = "constructs-10.1.177-py3-none-any.whl", hash = "sha256:c7e40391aed81539a4f1e591c5f5a1078399131f28b77128181dfeae00112fac"},
+    {file = "constructs-10.1.177.tar.gz", hash = "sha256:d1e51cbc6b39476da9e6ac263728be3b605f0a822d5e43a6f0302b44e41c5e3e"},
 ]
 exceptiongroup = [
-    {file = "exceptiongroup-1.0.0rc9-py3-none-any.whl", hash = "sha256:2e3c3fc1538a094aab74fad52d6c33fc94de3dfee3ee01f187c0e0c72aec5337"},
-    {file = "exceptiongroup-1.0.0rc9.tar.gz", hash = "sha256:9086a4a21ef9b31c72181c77c040a074ba0889ee56a7b289ff0afb0d97655f96"},
+    {file = "exceptiongroup-1.0.4-py3-none-any.whl", hash = "sha256:542adf9dea4055530d6e1279602fa5cb11dab2395fa650b8674eaec35fc4a828"},
+    {file = "exceptiongroup-1.0.4.tar.gz", hash = "sha256:bd14967b79cd9bdb54d97323216f8fdf533e278df937aa2a90089e7d6e06e5ec"},
 ]
 jsii = [
-    {file = "jsii-1.70.0-py3-none-any.whl", hash = "sha256:d0867c0d2f60ceda1664c026033ae34ea36178c7027315e577ded13043827664"},
-    {file = "jsii-1.70.0.tar.gz", hash = "sha256:9fc57ff37868364ba3417b26dc97189cd0cc71282196a3f4765768c067354be0"},
+    {file = "jsii-1.71.0-py3-none-any.whl", hash = "sha256:0f081498d9f2a12850577caedebe604e4b6e98e7fb20c3bbcca05a5ab8bd0f0b"},
+    {file = "jsii-1.71.0.tar.gz", hash = "sha256:e8fedaf077c192917f1d43100b2bbb5d107e4393b713f8ca2814d7653d64a026"},
 ]
 publication = [
     {file = "publication-0.0.3-py2.py3-none-any.whl", hash = "sha256:0248885351febc11d8a1098d5c8e3ab2dabcf3e8c0c96db1e17ecd12b53afbe6"},

--- a/tests/test_s3_read_deltalake.py
+++ b/tests/test_s3_read_deltalake.py
@@ -1,0 +1,15 @@
+import logging
+
+import pandas as pd
+from deltalake import write_deltalake
+
+import awswrangler as wr
+
+logging.getLogger("awswrangler").setLevel(logging.DEBUG)
+
+
+def test_read_deltalake(path):
+    df = pd.DataFrame({"c0": [0, 1, 2], "c1": [0, 1, 2], "c2": [0, 0, 1]})
+    write_deltalake(table_or_uri=path, data=df)
+    results = wr.s3.read_deltalake(path=path)
+    assert results == df


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
- [Delta Lake](https://delta.io/) is an open-source storage framework, a Python library [delta-rs](https://github.com/delta-io/delta-rs) is available to access it using Pandas. Integrating `deltalake` in pandas makes the support work out of the box for pandas users in lambda.
- The first version is only a read operation converting into a Pandas DataFrame from AWS S3 or AWS Glue, other methods could be added (the writer is still experimental atm).

### Relates
- https://github.com/aws/aws-sdk-pandas/issues/873
- https://github.com/delta-io/delta-rs/issues/870

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.