### PR TITLE
(docs) Add extension for ipython console highlighting

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,6 +44,7 @@ extensions = [
     "nbsphinx",
     "nbsphinx_link",
     "copy_tutorials",
+    "IPython.sphinxext.ipython_console_highlighting",
 ]
 
 language = None


### PR DESCRIPTION
### Detail
- With the latest aws sdk for pandas version we've lost color in the [tutorials](https://aws-sdk-pandas.readthedocs.io/en/stable/tutorials/033%20-%20Amazon%20Neptune.html). Adding below [extension](https://nbsphinx.readthedocs.io/en/0.8.9/installation.html#Pygments-Lexer-for-Syntax-Highlighting) OR installing IPython from conda solves the issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
