### PR TITLE
Downgrade deltalake to 0.5.8

### DIFF
--- a/awswrangler/s3/_read_deltalake.py
+++ b/awswrangler/s3/_read_deltalake.py
@@ -28,7 +28,6 @@ def read_deltalake(
     version: Optional[int] = None,
     partitions: Optional[List[Tuple[str, str, Any]]] = None,
     columns: Optional[List[str]] = None,
-    without_files: bool = False,
     boto3_session: Optional[boto3.Session] = None,
     s3_additional_kwargs: Optional[Dict[str, str]] = None,
     pyarrow_additional_kwargs: Optional[Dict[str, Any]] = None,
@@ -53,9 +52,6 @@ def read_deltalake(
     columns: Optional[List[str]]
         The columns to project. This can be a list of column names to include
         (order and duplicates are preserved).
-    without_files: bool
-        If True, load the table without tracking files (memory-friendly).
-        Some append-only applications might not need to track files.
     boto3_session: Optional[boto3.Session()]
         Boto3 Session. If None, the default boto3 session is used.
     s3_additional_kwargs: Optional[Dict[str, str]]
@@ -80,7 +76,6 @@ def read_deltalake(
             table_uri=path,
             version=version,
             storage_options=storage_options,
-            without_files=without_files,
         )
         .to_pyarrow_table(partitions=partitions, columns=columns)
         .to_pandas(**pyarrow_additional_kwargs)

--- a/poetry.lock
+++ b/poetry.lock
@@ -2388,7 +2388,7 @@ docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker
 testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [extras]
-deltalake = ["deltalake"]
+deltalake = ["deltalake", "typing-extensions"]
 oracle = ["oracledb"]
 sparql = ["SPARQLWrapper"]
 sqlserver = ["pyodbc"]
@@ -2396,7 +2396,7 @@ sqlserver = ["pyodbc"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1, <4.0"
-content-hash = "b07d1ea8716cb77958c8146e41655a1bf05da10c2dc24927696d686658eb3c3c"
+content-hash = "a87af6fc6400d93dc41f41b0f409452f748e5c2123e605e88f2def9f895af0f3"
 
 [metadata.files]
 aenum = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -391,19 +391,18 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "deltalake"
-version = "0.6.4"
+version = "0.5.8"
 description = "Native Delta Lake Python binding based on delta-rs with Pandas integration"
 category = "main"
 optional = true
-python-versions = ">=3.7"
+python-versions = ">=3.6"
 
 [package.dependencies]
-pyarrow = ">=7"
-typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
+pyarrow = ">=4"
 
 [package.extras]
-devel = ["black", "isort", "mypy", "packaging (>=20)", "pytest", "pytest-cov", "pytest-mock", "pytest-timeout", "sphinx (<=4.5)", "sphinx-rtd-theme", "toml"]
-pandas = ["pandas"]
+devel = ["black", "isort", "mypy", "pytest", "pytest-cov", "pytest-mock", "pytest-timeout", "sphinx (<=4.5)", "sphinx-rtd-theme", "toml", "typing-extensions"]
+pandas = ["pandas", "types-dataclasses"]
 pyspark = ["delta-spark", "pyspark"]
 
 [[package]]
@@ -2397,7 +2396,7 @@ sqlserver = ["pyodbc"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1, <4.0"
-content-hash = "65393f690be24ae85c5f9e5d04f2c205cae82fd0229af3bf4c319401f9e476e3"
+content-hash = "71a9057aa2849d395b05cce8cbb38ede70e451b831d0e101a03d8a02f6aa2663"
 
 [metadata.files]
 aenum = [
@@ -2779,12 +2778,12 @@ defusedxml = [
     {file = "defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69"},
 ]
 deltalake = [
-    {file = "deltalake-0.6.4-cp37-abi3-macosx_10_7_x86_64.whl", hash = "sha256:9803a4aefc1dd83024c29077725ce0892198db1e3e08b1aa0f7f3c0cadefb274"},
-    {file = "deltalake-0.6.4-cp37-abi3-macosx_10_9_arm64.whl", hash = "sha256:86c590ceac97016dd2ba9f38ea188d1fafc509c3093777ab261203ecc464fefd"},
-    {file = "deltalake-0.6.4-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:688725750097cd1d6351e44b8ebd199e69751ff4992eeb8a0156374794f5f724"},
-    {file = "deltalake-0.6.4-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f54ba14251cc4d2caf23ff36a5e1045250dcd40e5e5d330406ac3c69143fc188"},
-    {file = "deltalake-0.6.4-cp37-abi3-win_amd64.whl", hash = "sha256:200ec6316decf91f39c435d520d6c5183f24af2c990ac9154c415b0909c04e19"},
-    {file = "deltalake-0.6.4.tar.gz", hash = "sha256:2f3cf70d67c17a7d5928c7da214ff795283f628311d91643602176dc50f7099e"},
+    {file = "deltalake-0.5.8-cp37-abi3-macosx_10_7_x86_64.whl", hash = "sha256:a9bfdcf252cc697e7ca6cb16be270b2fe7aed7689eefd49b187e813ce6c3f39b"},
+    {file = "deltalake-0.5.8-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:d516c53b3a1acc6b3a39009394ae5f75abafd5a1045a1f6cf8f24e165210581e"},
+    {file = "deltalake-0.5.8-cp37-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:25da93fc520e60b3b5e97469ddd532da9ee0c1c00938b8df826eebd794559636"},
+    {file = "deltalake-0.5.8-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5f93bea8c7a25c343b9783ba09230a1205145463ab4c546a69469b3da7b97592"},
+    {file = "deltalake-0.5.8-cp37-abi3-win_amd64.whl", hash = "sha256:ef36fd94162a9ed234c3ae8487479fa58994729c038a8ee6599d1bd6d91628fa"},
+    {file = "deltalake-0.5.8.tar.gz", hash = "sha256:b386422fcc9c151b794748c9cef3fbb33debd4475bbabc6e9e288ef23ab3b87e"},
 ]
 dill = [
     {file = "dill-0.3.6-py3-none-any.whl", hash = "sha256:a07ffd2351b8c678dfc4a856a3005f8067aea51d6ba6c700796a4d9e280f39f0"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -2396,7 +2396,7 @@ sqlserver = ["pyodbc"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1, <4.0"
-content-hash = "71a9057aa2849d395b05cce8cbb38ede70e451b831d0e101a03d8a02f6aa2663"
+content-hash = "b07d1ea8716cb77958c8146e41655a1bf05da10c2dc24927696d686658eb3c3c"
 
 [metadata.files]
 aenum = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ progressbar2 = "^4.0.0"
 opensearch-py = ">=1,<3"
 gremlinpython = "^3.5.2"
 backoff = ">=1.11.1,<3.0.0"
+typing-extensions = "^4.4.0"
 SPARQLWrapper = { version = ">=1.8.5,<3.0.0", optional = true }
 pyodbc = { version = "~4.0.32", optional = true }
 oracledb = { version = "~1.0.0", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ backoff = ">=1.11.1,<3.0.0"
 SPARQLWrapper = { version = ">=1.8.5,<3.0.0", optional = true }
 pyodbc = { version = "~4.0.32", optional = true }
 oracledb = { version = "~1.0.0", optional = true }
-deltalake = { version = "~0.6.4", optional = true }
+deltalake = { version = "~0.5.8", optional = true }
 
 [tool.poetry.extras]
 sqlserver = ["pyodbc"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,17 +45,17 @@ progressbar2 = "^4.0.0"
 opensearch-py = ">=1,<3"
 gremlinpython = "^3.5.2"
 backoff = ">=1.11.1,<3.0.0"
-typing-extensions = "^4.4.0"
 SPARQLWrapper = { version = ">=1.8.5,<3.0.0", optional = true }
 pyodbc = { version = "~4.0.32", optional = true }
 oracledb = { version = "~1.0.0", optional = true }
 deltalake = { version = "~0.5.8", optional = true }
+typing-extensions = { version = "^4.4.0", optional = true }
 
 [tool.poetry.extras]
 sqlserver = ["pyodbc"]
 oracle = ["oracledb"]
 sparql = ["SPARQLWrapper"]
-deltalake = ["deltalake"]
+deltalake = ["deltalake", "typing-extensions"]
 
 [tool.poetry.dev-dependencies]
 wheel = "^0.37.1"


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Detail
- Downgrade deltalake to `0.5.8` as we can't use `0.6.x` in `release-3.0.0` due to PyArrow version issues. Deltalake version `0.6.x` insists on PyArrow version 7+, whereas Ray insists on version 6 or under. I think it's better to downgrade now, before we do a release, then set deltalake to `0.6.x` now and then be forced to downgrade when we release AWS SDK for pandas 3.0 in a few months.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
