### PR TITLE
forward use_threads to _validate_schemas_from_files

### DIFF
--- a/awswrangler/s3/_read_parquet.py
+++ b/awswrangler/s3/_read_parquet.py
@@ -787,7 +787,7 @@ def read_parquet(
             paths=paths,
             version_ids=versions,
             sampling=1.0,
-            use_threads=True,
+            use_threads=use_threads,
             boto3_session=boto3_session,
             s3_additional_kwargs=s3_additional_kwargs,
         )


### PR DESCRIPTION
### Feature or Bugfix
Bugfix

### Detail
When reading parquets from S3 and using `validate_schema=True`, `use_threads` would always be set to `True`.
In practice this is not a big deal, but I found that 40% of the time my tests were taking was spent on waiting on locks for threading in `_validate_schemas_from_files`.

### Relates
https://github.com/aws/aws-sdk-pandas/issues/1868

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
