### PR TITLE
(fix): missing timestamp data type in Timestream

### DIFF
--- a/awswrangler/_data_types.py
+++ b/awswrangler/_data_types.py
@@ -263,6 +263,12 @@ def pyarrow2timestream(dtype: pa.DataType) -> str:  # pylint: disable=too-many-b
         return "BOOLEAN"
     if pa.types.is_string(dtype):
         return "VARCHAR"
+    if pa.types.is_date(dtype):
+        return "DATE"
+    if pa.types.is_time(dtype):
+        return "TIME"
+    if pa.types.is_timestamp(dtype):
+        return "TIMESTAMP"
     raise exceptions.UnsupportedType(f"Unsupported Amazon Timestream measure type: {dtype}")
 
 

--- a/awswrangler/timestream.py
+++ b/awswrangler/timestream.py
@@ -27,6 +27,14 @@ def _df2list(df: pd.DataFrame) -> List[List[Any]]:
     return parameters
 
 
+def _format_measure(measure_name: str, measure_value: Any, measure_type: str) -> Dict[str, str]:
+    return {
+        "Name": measure_name,
+        "Value": str(round(measure_value.timestamp() * 1_000) if measure_type == "TIMESTAMP" else measure_value),
+        "Type": measure_type,
+    }
+
+
 def _write_batch(
     database: str,
     table: str,
@@ -66,7 +74,7 @@ def _write_batch(
                 record["MeasureName"] = measure_cols_names[0]
                 record["MeasureValueType"] = "MULTI"
                 record["MeasureValues"] = [
-                    {"Name": measure_name, "Value": str(measure_value), "Type": measure_value_type}
+                    _format_measure(measure_name, measure_value, measure_value_type)
                     for measure_name, measure_value, measure_value_type in zip(
                         measure_cols_names, rec[measure_cols_loc:dimensions_cols_loc], measure_types
                     )


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Add datetime related data types to pyarrow2timestream conversion method
- Handle edge case of timestamp conversion
- Add test

### Relates
- #1853

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
