### PR TITLE
Remove `awswrangler.distributed` from coverage report

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,3 +138,10 @@ addopts = "--log-cli-format \"[%(name)s][%(funcName)s] %(message)s\" --verbose -
 markers = [
     "distributed: tests againsts methods with distributed functionality",
 ]
+
+[tool.coverage.run]
+branch = true
+omit = ["awswrangler/distributed/*"]
+
+[tool.coverage.report]
+show_missing = true


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
- Remove `awswrangler.distributed` from coverage report

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
