### PR TITLE
(enhancement): Increase polling delay to 1 second

### DIFF
--- a/awswrangler/athena/_utils.py
+++ b/awswrangler/athena/_utils.py
@@ -22,7 +22,7 @@ from awswrangler.catalog._utils import _catalog_id, _transaction_id
 from ._cache import _cache_manager, _CacheInfo, _check_for_cached_results, _LocalMetadataCacheManager
 
 _QUERY_FINAL_STATES: List[str] = ["FAILED", "SUCCEEDED", "CANCELLED"]
-_QUERY_WAIT_POLLING_DELAY: float = 0.25  # SECONDS
+_QUERY_WAIT_POLLING_DELAY: float = 1.0  # SECONDS
 
 _logger: logging.Logger = logging.getLogger(__name__)
 

--- a/awswrangler/data_quality/_utils.py
+++ b/awswrangler/data_quality/_utils.py
@@ -16,7 +16,7 @@ from awswrangler import _utils, exceptions
 _logger: logging.Logger = logging.getLogger(__name__)
 
 _RULESET_EVALUATION_FINAL_STATUSES: List[str] = ["STOPPED", "SUCCEEDED", "FAILED", "TIMEOUT"]
-_RULESET_EVALUATION_WAIT_POLLING_DELAY: float = 0.25  # SECONDS
+_RULESET_EVALUATION_WAIT_POLLING_DELAY: float = 1.0  # SECONDS
 
 
 def _parse_rules(rules: List[str]) -> List[Tuple[str, Optional[str], Optional[str]]]:


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Enhancement

### Detail
- Current polling delay (0.25s) is too short and causes throttling too often. Increasing to 1 s instead


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
