### PR TITLE
Add coverage section to pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,3 +132,6 @@ warn_unused_ignores = true
 log_cli = false
 filterwarnings = "ignore::DeprecationWarning"
 addopts = "--log-cli-format \"[%(name)s][%(funcName)s] %(message)s\" --verbose --capture=sys"
+
+[tool.coverage.run]
+omit = ["awswrangler/neptune/_utils.py"]


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Enhancement

### Detail
- Add coverage section to pyproject
- Methods in neptune/_utils.py are not public. As no test is referencing them, they are skewing the coverage 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
