### PR TITLE
Document the create_csv_table function's sensitivity to column order

### DIFF
--- a/awswrangler/catalog/_create.py
+++ b/awswrangler/catalog/_create.py
@@ -857,6 +857,11 @@ def create_csv_table(  # pylint: disable=too-many-arguments,too-many-locals
 
     'https://docs.aws.amazon.com/athena/latest/ug/data-types.html'
 
+    Note
+    ----
+    Athena requires the columns in the underlying CSV files in S3 to be in the same order
+    as the columns in the Glue data catalog.
+
     Parameters
     ----------
     database : str


### PR DESCRIPTION
### Detail
Document the create_csv_table function's sensitivity to column order

### Relates
- https://github.com/aws/aws-sdk-pandas/issues/1918

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
