### PR TITLE
(tests) minor - add Glue DQ role name

### DIFF
--- a/test_infra/stacks/base_stack.py
+++ b/test_infra/stacks/base_stack.py
@@ -77,6 +77,7 @@ class BaseStack(Stack):  # type: ignore
         glue_data_quality_role = iam.Role(
             self,
             "aws-sdk-pandas-glue-data-quality-role",
+            role_name="GlueDataQualityRole",
             assumed_by=iam.ServicePrincipal("glue.amazonaws.com"),
             managed_policies=[
                 iam.ManagedPolicy.from_aws_managed_policy_name("AmazonS3FullAccess"),


### PR DESCRIPTION
### Detail
- CB needs `iam:PassRole` permissions to Glue DQ role and it's manual process if the role name is dynamic

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
