### PR TITLE
(test) minor - fix mock call args error on py37

### DIFF
--- a/tests/test_athena.py
+++ b/tests/test_athena.py
@@ -1281,5 +1281,5 @@ def test_read_sql_query_ctas_write_compression(path, glue_database, glue_table, 
 
         mock_create_ctas_table.assert_called_once()
 
-        create_ctas_table_args = mock_create_ctas_table.call_args.kwargs
-        create_ctas_table_args["compression"] = compression
+        if compression:
+            assert mock_create_ctas_table.call_args[1]["write_compression"] == compression


### PR DESCRIPTION
Fixes below (only on Python 3.7):
```
            create_ctas_table_args = mock_create_ctas_table.call_args.kwargs
>           create_ctas_table_args["compression"] = compression
E           TypeError: '_Call' object does not support item assignment
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
