### PR TITLE
(enhancement) Remove session serialization/deserialization

### DIFF
--- a/awswrangler/_utils.py
+++ b/awswrangler/_utils.py
@@ -1,6 +1,5 @@
 """Internal (private) Utilities Module."""
 
-import copy
 import itertools
 import logging
 import math
@@ -24,10 +23,8 @@ _logger: logging.Logger = logging.getLogger(__name__)
 Boto3PrimitivesType = Dict[str, Optional[str]]
 
 
-def ensure_session(session: Union[None, boto3.Session, Boto3PrimitivesType] = None) -> boto3.Session:
+def ensure_session(session: Union[None, boto3.Session] = None) -> boto3.Session:
     """Ensure that a valid boto3.Session will be returned."""
-    if isinstance(session, dict):  # Primitives received
-        return boto3_from_primitives(primitives=session)
     if session is not None:
         return session
     # Ensure the boto3's default session is used so that its parameters can be
@@ -48,17 +45,6 @@ def boto3_to_primitives(boto3_session: Optional[boto3.Session] = None) -> Boto3P
         "region_name": _boto3_session.region_name,
         "profile_name": _boto3_session.profile_name,
     }
-
-
-def boto3_from_primitives(primitives: Optional[Boto3PrimitivesType] = None) -> boto3.Session:
-    """Convert Python primitives to Boto3 Session."""
-    if primitives is None:
-        return ensure_session()
-    _primitives: Boto3PrimitivesType = copy.deepcopy(primitives)
-    profile_name: Optional[str] = _primitives.get("profile_name", None)
-    _primitives["profile_name"] = None if profile_name in (None, "default") else profile_name
-    args: Dict[str, str] = {k: v for k, v in _primitives.items() if v is not None}
-    return boto3.Session(**args)
 
 
 def default_botocore_config() -> botocore.config.Config:

--- a/awswrangler/athena/_read.py
+++ b/awswrangler/athena/_read.py
@@ -924,7 +924,6 @@ def read_sql_query(  # pylint: disable=too-many-arguments,too-many-locals
     if unload_parameters and unload_parameters.get("file_format") not in (None, "PARQUET"):
         raise exceptions.InvalidArgumentCombination("Only PARQUET file format is supported if unload_approach=True")
     chunksize = sys.maxsize if ctas_approach is False and chunksize is True else chunksize
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     if params is None:
         params = {}
     for key, value in params.items():
@@ -935,7 +934,7 @@ def read_sql_query(  # pylint: disable=too-many-arguments,too-many-locals
     _cache_manager.max_cache_size = max_local_cache_entries
     cache_info: _CacheInfo = _check_for_cached_results(
         sql=sql,
-        boto3_session=session,
+        boto3_session=boto3_session,
         workgroup=workgroup,
         max_cache_seconds=max_cache_seconds,
         max_cache_query_inspections=max_cache_query_inspections,
@@ -950,7 +949,7 @@ def read_sql_query(  # pylint: disable=too-many-arguments,too-many-locals
                 categories=categories,
                 chunksize=chunksize,
                 use_threads=use_threads,
-                session=session,
+                session=boto3_session,
                 s3_additional_kwargs=s3_additional_kwargs,
                 pyarrow_additional_kwargs=pyarrow_additional_kwargs,
             )
@@ -977,7 +976,7 @@ def read_sql_query(  # pylint: disable=too-many-arguments,too-many-locals
         ctas_write_compression=ctas_write_compression,
         use_threads=use_threads,
         s3_additional_kwargs=s3_additional_kwargs,
-        boto3_session=session,
+        boto3_session=boto3_session,
         pyarrow_additional_kwargs=pyarrow_additional_kwargs,
     )
 
@@ -1299,7 +1298,6 @@ def unload(
     ... )
 
     """
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     # Substitute query parameters
     if params is None:
         params = {}
@@ -1316,6 +1314,6 @@ def unload(
         database=database,
         encryption=encryption,
         kms_key=kms_key,
-        boto3_session=session,
+        boto3_session=boto3_session,
         data_source=data_source,
     )

--- a/awswrangler/athena/_utils.py
+++ b/awswrangler/athena/_utils.py
@@ -67,11 +67,10 @@ def _start_query_execution(
     boto3_session: Optional[boto3.Session] = None,
 ) -> str:
     args: Dict[str, Any] = {"QueryString": sql}
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
 
     # s3_output
     args["ResultConfiguration"] = {
-        "OutputLocation": _get_s3_output(s3_output=s3_output, wg_config=wg_config, boto3_session=session)
+        "OutputLocation": _get_s3_output(s3_output=s3_output, wg_config=wg_config, boto3_session=boto3_session)
     }
 
     # encryption
@@ -96,7 +95,7 @@ def _start_query_execution(
     if workgroup is not None:
         args["WorkGroup"] = workgroup
 
-    client_athena: boto3.client = _utils.client(service_name="athena", session=session)
+    client_athena: boto3.client = _utils.client(service_name="athena", session=boto3_session)
     _logger.debug("args: \n%s", pprint.pformat(args))
     response: Dict[str, Any] = _utils.try_it(
         f=client_athena.start_query_execution,
@@ -287,9 +286,7 @@ def get_named_query_statement(
     str
         The named query statement string
     """
-    client_athena: boto3.client = _utils.client(
-        service_name="athena", session=_utils.ensure_session(session=boto3_session)
-    )
+    client_athena: boto3.client = _utils.client(service_name="athena", session=boto3_session)
     return client_athena.get_named_query(NamedQueryId=named_query_id)["NamedQuery"]["QueryString"]  # type: ignore
 
 
@@ -317,9 +314,7 @@ def get_query_columns_types(query_execution_id: str, boto3_session: Optional[bot
     {'col0': 'int', 'col1': 'double'}
 
     """
-    client_athena: boto3.client = _utils.client(
-        service_name="athena", session=_utils.ensure_session(session=boto3_session)
-    )
+    client_athena: boto3.client = _utils.client(service_name="athena", session=boto3_session)
     response: Dict[str, Any] = client_athena.get_query_results(QueryExecutionId=query_execution_id, MaxResults=1)
     col_info: List[Dict[str, str]] = response["ResultSet"]["ResultSetMetadata"]["ColumnInfo"]
     return dict(
@@ -350,12 +345,11 @@ def create_athena_bucket(boto3_session: Optional[boto3.Session] = None) -> str:
     's3://aws-athena-query-results-ACCOUNT-REGION/'
 
     """
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
-    account_id: str = sts.get_account_id(boto3_session=session)
-    region_name: str = str(session.region_name).lower()
+    account_id: str = sts.get_account_id(boto3_session=boto3_session)
+    region_name: str = _utils.get_region_from_session(boto3_session=boto3_session).lower()
     bucket_name = f"aws-athena-query-results-{account_id}-{region_name}"
     path = f"s3://{bucket_name}/"
-    resource = _utils.resource(service_name="s3", session=session)
+    resource = _utils.resource(service_name="s3", session=boto3_session)
     bucket = resource.Bucket(bucket_name)
     args = {} if region_name == "us-east-1" else {"CreateBucketConfiguration": {"LocationConstraint": region_name}}
     try:
@@ -459,14 +453,13 @@ def start_query_execution(
         params = {}
     for key, value in params.items():
         sql = sql.replace(f":{key};", str(value))
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
 
     max_remote_cache_entries = min(max_remote_cache_entries, max_local_cache_entries)
 
     _cache_manager.max_cache_size = max_local_cache_entries
     cache_info: _CacheInfo = _check_for_cached_results(
         sql=sql,
-        boto3_session=session,
+        boto3_session=boto3_session,
         workgroup=workgroup,
         max_cache_seconds=max_cache_seconds,
         max_cache_query_inspections=max_cache_query_inspections,
@@ -478,7 +471,7 @@ def start_query_execution(
         query_execution_id = cache_info.query_execution_id
         _logger.debug("Valid cache found. Retrieving...")
     else:
-        wg_config: _WorkGroupConfig = _get_workgroup_config(session=session, workgroup=workgroup)
+        wg_config: _WorkGroupConfig = _get_workgroup_config(session=boto3_session, workgroup=workgroup)
         query_execution_id = _start_query_execution(
             sql=sql,
             wg_config=wg_config,
@@ -488,10 +481,10 @@ def start_query_execution(
             workgroup=workgroup,
             encryption=encryption,
             kms_key=kms_key,
-            boto3_session=session,
+            boto3_session=boto3_session,
         )
     if wait:
-        return wait_query(query_execution_id=query_execution_id, boto3_session=session)
+        return wait_query(query_execution_id=query_execution_id, boto3_session=boto3_session)
 
     return query_execution_id
 
@@ -553,7 +546,6 @@ def repair_table(
     query = f"MSCK REPAIR TABLE `{table}`;"
     if (database is not None) and (not database.startswith("`")):
         database = f"`{database}`"
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     query_id = cast(
         str,
         start_query_execution(
@@ -564,10 +556,10 @@ def repair_table(
             workgroup=workgroup,
             encryption=encryption,
             kms_key=kms_key,
-            boto3_session=session,
+            boto3_session=boto3_session,
         ),
     )
-    response: Dict[str, Any] = wait_query(query_execution_id=query_id, boto3_session=session)
+    response: Dict[str, Any] = wait_query(query_execution_id=query_id, boto3_session=boto3_session)
     return cast(str, response["Status"]["State"])
 
 
@@ -626,7 +618,6 @@ def describe_table(
     query = f"DESCRIBE `{table}`;"
     if (database is not None) and (not database.startswith("`")):
         database = f"`{database}`"
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     query_id = cast(
         str,
         start_query_execution(
@@ -636,12 +627,15 @@ def describe_table(
             workgroup=workgroup,
             encryption=encryption,
             kms_key=kms_key,
-            boto3_session=session,
+            boto3_session=boto3_session,
         ),
     )
-    query_metadata: _QueryMetadata = _get_query_metadata(query_execution_id=query_id, boto3_session=session)
+    query_metadata: _QueryMetadata = _get_query_metadata(query_execution_id=query_id, boto3_session=boto3_session)
     raw_result = _fetch_txt_result(
-        query_metadata=query_metadata, keep_files=True, boto3_session=session, s3_additional_kwargs=s3_additional_kwargs
+        query_metadata=query_metadata,
+        keep_files=True,
+        boto3_session=boto3_session,
+        s3_additional_kwargs=s3_additional_kwargs,
     )
     return _parse_describe_table(raw_result)
 
@@ -913,7 +907,6 @@ def show_create_table(
     query = f"SHOW CREATE TABLE `{table}`;"
     if (database is not None) and (not database.startswith("`")):
         database = f"`{database}`"
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     query_id = cast(
         str,
         start_query_execution(
@@ -923,12 +916,15 @@ def show_create_table(
             workgroup=workgroup,
             encryption=encryption,
             kms_key=kms_key,
-            boto3_session=session,
+            boto3_session=boto3_session,
         ),
     )
-    query_metadata: _QueryMetadata = _get_query_metadata(query_execution_id=query_id, boto3_session=session)
+    query_metadata: _QueryMetadata = _get_query_metadata(query_execution_id=query_id, boto3_session=boto3_session)
     raw_result = _fetch_txt_result(
-        query_metadata=query_metadata, keep_files=True, boto3_session=session, s3_additional_kwargs=s3_additional_kwargs
+        query_metadata=query_metadata,
+        keep_files=True,
+        boto3_session=boto3_session,
+        s3_additional_kwargs=s3_additional_kwargs,
     )
     return cast(str, raw_result.createtab_stmt.str.strip().str.cat(sep=" "))
 
@@ -1111,12 +1107,11 @@ def wait_query(query_execution_id: str, boto3_session: Optional[boto3.Session] =
     >>> res = wr.athena.wait_query(query_execution_id='query-execution-id')
 
     """
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
-    response: Dict[str, Any] = get_query_execution(query_execution_id=query_execution_id, boto3_session=session)
+    response: Dict[str, Any] = get_query_execution(query_execution_id=query_execution_id, boto3_session=boto3_session)
     state: str = response["Status"]["State"]
     while state not in _QUERY_FINAL_STATES:
         time.sleep(_QUERY_WAIT_POLLING_DELAY)
-        response = get_query_execution(query_execution_id=query_execution_id, boto3_session=session)
+        response = get_query_execution(query_execution_id=query_execution_id, boto3_session=boto3_session)
         state = response["Status"]["State"]
     _logger.debug("state: %s", state)
     _logger.debug("StateChangeReason: %s", response["Status"].get("StateChangeReason"))

--- a/awswrangler/catalog/_create.py
+++ b/awswrangler/catalog/_create.py
@@ -129,8 +129,7 @@ def _create_table(  # pylint: disable=too-many-branches,too-many-statements,too-
 
     _logger.debug("table_input: %s", table_input)
 
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
-    client_glue: boto3.client = _utils.client(service_name="glue", session=session)
+    client_glue: boto3.client = _utils.client(service_name="glue", session=boto3_session)
     skip_archive: bool = not catalog_versioning
     if mode not in ("overwrite", "append", "overwrite_partitions", "update"):
         raise exceptions.InvalidArgument(
@@ -149,7 +148,9 @@ def _create_table(  # pylint: disable=too-many-branches,too-many-statements,too-
         args["SkipArchive"] = skip_archive
         if mode == "overwrite":
             if table_type != "GOVERNED":
-                delete_all_partitions(table=table, database=database, catalog_id=catalog_id, boto3_session=session)
+                delete_all_partitions(
+                    table=table, database=database, catalog_id=catalog_id, boto3_session=boto3_session
+                )
             client_glue.update_table(**args)
         elif mode == "update":
             client_glue.update_table(**args)
@@ -536,16 +537,19 @@ def upsert_table_parameters(
     ...     table="...")
 
     """
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     table_input: Optional[Dict[str, str]] = _get_table_input(
-        database=database, table=table, boto3_session=session, transaction_id=transaction_id, catalog_id=catalog_id
+        database=database,
+        table=table,
+        boto3_session=boto3_session,
+        transaction_id=transaction_id,
+        catalog_id=catalog_id,
     )
     if table_input is None:
         raise exceptions.InvalidArgumentValue(f"Table {database}.{table} does not exist.")
     return _upsert_table_parameters(
         parameters=parameters,
         database=database,
-        boto3_session=session,
+        boto3_session=boto3_session,
         transaction_id=transaction_id,
         catalog_id=catalog_id,
         table_input=table_input,
@@ -597,9 +601,12 @@ def overwrite_table_parameters(
     ...     table="...")
 
     """
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     table_input: Optional[Dict[str, Any]] = _get_table_input(
-        database=database, table=table, transaction_id=transaction_id, catalog_id=catalog_id, boto3_session=session
+        database=database,
+        table=table,
+        transaction_id=transaction_id,
+        catalog_id=catalog_id,
+        boto3_session=boto3_session,
     )
     if table_input is None:
         raise exceptions.InvalidTable(f"Table {table} does not exist on database {database}.")
@@ -609,7 +616,7 @@ def overwrite_table_parameters(
         catalog_id=catalog_id,
         transaction_id=transaction_id,
         table_input=table_input,
-        boto3_session=session,
+        boto3_session=boto3_session,
         catalog_versioning=catalog_versioning,
     )
 
@@ -788,9 +795,12 @@ def create_parquet_table(
     ... )
 
     """
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     catalog_table_input: Optional[Dict[str, Any]] = _get_table_input(
-        database=database, table=table, boto3_session=session, transaction_id=transaction_id, catalog_id=catalog_id
+        database=database,
+        table=table,
+        boto3_session=boto3_session,
+        transaction_id=transaction_id,
+        catalog_id=catalog_id,
     )
     _create_parquet_table(
         database=database,
@@ -969,9 +979,12 @@ def create_csv_table(  # pylint: disable=too-many-arguments,too-many-locals
     ... )
 
     """
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     catalog_table_input: Optional[Dict[str, Any]] = _get_table_input(
-        database=database, table=table, boto3_session=session, transaction_id=transaction_id, catalog_id=catalog_id
+        database=database,
+        table=table,
+        boto3_session=boto3_session,
+        transaction_id=transaction_id,
+        catalog_id=catalog_id,
     )
     _create_csv_table(
         database=database,
@@ -1143,9 +1156,8 @@ def create_json_table(  # pylint: disable=too-many-arguments
     ... )
 
     """
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     catalog_table_input: Optional[Dict[str, Any]] = _get_table_input(
-        database=database, table=table, boto3_session=session, catalog_id=catalog_id
+        database=database, table=table, boto3_session=boto3_session, catalog_id=catalog_id
     )
     _create_json_table(
         database=database,

--- a/awswrangler/catalog/_delete.py
+++ b/awswrangler/catalog/_delete.py
@@ -179,10 +179,9 @@ def delete_all_partitions(
     ...     database='awswrangler_test',
     ... )
     """
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     _logger.debug("Fetching existing partitions...")
     partitions_values: List[List[str]] = list(
-        _get_partitions(database=database, table=table, boto3_session=session, catalog_id=catalog_id).values()
+        _get_partitions(database=database, table=table, boto3_session=boto3_session, catalog_id=catalog_id).values()
     )
     _logger.debug("Number of old partitions: %s", len(partitions_values))
     _logger.debug("Deleting existing partitions...")

--- a/awswrangler/cloudwatch.py
+++ b/awswrangler/cloudwatch.py
@@ -169,16 +169,15 @@ def run_query(
     ... )
 
     """
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     query_id: str = start_query(
         query=query,
         log_group_names=log_group_names,
         start_time=start_time,
         end_time=end_time,
         limit=limit,
-        boto3_session=session,
+        boto3_session=boto3_session,
     )
-    response: Dict[str, Any] = wait_query(query_id=query_id, boto3_session=session)
+    response: Dict[str, Any] = wait_query(query_id=query_id, boto3_session=boto3_session)
     return cast(List[List[Dict[str, str]]], response["results"])
 
 

--- a/awswrangler/data_quality/_utils.py
+++ b/awswrangler/data_quality/_utils.py
@@ -79,7 +79,6 @@ def _start_ruleset_evaluation_run(
     client_token: Optional[str] = None,
     boto3_session: Optional[boto3.Session] = None,
 ) -> str:
-    boto3_session = _utils.ensure_session(session=boto3_session)
     client_glue: boto3.client = _utils.client(service_name="glue", session=boto3_session)
 
     if not database or not table:
@@ -115,8 +114,7 @@ def _get_ruleset_run(
     run_type: str,
     boto3_session: Optional[boto3.Session] = None,
 ) -> Dict[str, Any]:
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
-    client_glue: boto3.client = _utils.client(service_name="glue", session=session)
+    client_glue: boto3.client = _utils.client(service_name="glue", session=boto3_session)
     f = (
         client_glue.get_data_quality_rule_recommendation_run
         if run_type == "recommendation"
@@ -137,12 +135,11 @@ def _wait_ruleset_run(
     run_type: str,
     boto3_session: Optional[boto3.Session] = None,
 ) -> Dict[str, Any]:
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
-    response: Dict[str, Any] = _get_ruleset_run(run_id=run_id, run_type=run_type, boto3_session=session)
+    response: Dict[str, Any] = _get_ruleset_run(run_id=run_id, run_type=run_type, boto3_session=boto3_session)
     status: str = response["Status"]
     while status not in _RULESET_EVALUATION_FINAL_STATUSES:
         time.sleep(_RULESET_EVALUATION_WAIT_POLLING_DELAY)
-        response = _get_ruleset_run(run_id=run_id, run_type=run_type, boto3_session=session)
+        response = _get_ruleset_run(run_id=run_id, run_type=run_type, boto3_session=boto3_session)
         status = response["Status"]
     _logger.debug("status: %s", status)
     if status == "FAILED":
@@ -156,7 +153,6 @@ def _get_ruleset(
     ruleset_name: str,
     boto3_session: Optional[boto3.Session] = None,
 ) -> Dict[str, Any]:
-    boto3_session = _utils.ensure_session(session=boto3_session)
     client_glue: boto3.client = _utils.client(service_name="glue", session=boto3_session)
     response = _utils.try_it(
         f=client_glue.get_data_quality_ruleset,
@@ -172,7 +168,6 @@ def _get_data_quality_results(
     result_ids: List[str],
     boto3_session: Optional[boto3.Session] = None,
 ) -> pd.DataFrame:
-    boto3_session = _utils.ensure_session(session=boto3_session)
     client_glue: boto3.client = _utils.client(service_name="glue", session=boto3_session)
 
     results: List[Dict[str, Any]] = client_glue.batch_get_data_quality_result(

--- a/awswrangler/lakeformation/_read.py
+++ b/awswrangler/lakeformation/_read.py
@@ -194,8 +194,7 @@ def read_sql_query(
     ... )
 
     """
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
-    client_lakeformation: boto3.client = _utils.client(service_name="lakeformation", session=session)
+    client_lakeformation: boto3.client = _utils.client(service_name="lakeformation", session=boto3_session)
     commit_trans: bool = False
     if params is None:
         params = {}
@@ -204,7 +203,7 @@ def read_sql_query(
 
     if not any([transaction_id, query_as_of_time]):
         _logger.debug("Neither `transaction_id` nor `query_as_of_time` were specified, starting transaction")
-        transaction_id = start_transaction(read_only=True, boto3_session=session)
+        transaction_id = start_transaction(read_only=True, boto3_session=boto3_session)
         commit_trans = True
     args: Dict[str, Optional[str]] = _catalog_id(
         catalog_id=catalog_id,
@@ -217,7 +216,7 @@ def read_sql_query(
         safe=safe,
         map_types=map_types,
         use_threads=use_threads,
-        boto3_session=session,
+        boto3_session=boto3_session,
     )
     if commit_trans:
         commit_transaction(transaction_id=transaction_id)  # type: ignore

--- a/awswrangler/lakeformation/_utils.py
+++ b/awswrangler/lakeformation/_utils.py
@@ -72,8 +72,7 @@ def _get_table_objects(
     partitions_values: Optional[List[str]] = None,
 ) -> List[Dict[str, Any]]:
     """Get Governed Table Objects from Lake Formation Engine."""
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
-    client_lakeformation: boto3.client = _utils.client(service_name="lakeformation", session=session)
+    client_lakeformation: boto3.client = _utils.client(service_name="lakeformation", session=boto3_session)
 
     scan_kwargs: Dict[str, Union[str, int]] = _catalog_id(
         catalog_id=catalog_id,
@@ -115,8 +114,7 @@ def _update_table_objects(
     del_objects: Optional[List[Dict[str, Any]]] = None,
 ) -> None:
     """Register Governed Table Objects changes to Lake Formation Engine."""
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
-    client_lakeformation: boto3.client = _utils.client(service_name="lakeformation", session=session)
+    client_lakeformation: boto3.client = _utils.client(service_name="lakeformation", session=boto3_session)
 
     update_kwargs: Dict[str, Union[str, int, List[Dict[str, Dict[str, Any]]]]] = _catalog_id(
         catalog_id=catalog_id, **_transaction_id(transaction_id=transaction_id, DatabaseName=database, TableName=table)
@@ -171,8 +169,7 @@ def describe_transaction(transaction_id: str, boto3_session: Optional[boto3.Sess
     >>> status = wr.lakeformation.describe_transaction(transaction_id="...")
 
     """
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
-    client_lakeformation: boto3.client = _utils.client(service_name="lakeformation", session=session)
+    client_lakeformation: boto3.client = _utils.client(service_name="lakeformation", session=boto3_session)
     details: Dict[str, Any] = client_lakeformation.describe_transaction(TransactionId=transaction_id)[
         "TransactionDescription"
     ]
@@ -200,8 +197,7 @@ def cancel_transaction(transaction_id: str, boto3_session: Optional[boto3.Sessio
     >>> wr.lakeformation.cancel_transaction(transaction_id="...")
 
     """
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
-    client_lakeformation: boto3.client = _utils.client(service_name="lakeformation", session=session)
+    client_lakeformation: boto3.client = _utils.client(service_name="lakeformation", session=boto3_session)
 
     client_lakeformation.cancel_transaction(TransactionId=transaction_id)
 
@@ -235,8 +231,7 @@ def start_transaction(
     >>> transaction_id = wr.lakeformation.start_transaction(read_only=False)
 
     """
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
-    client_lakeformation: boto3.client = _utils.client(service_name="lakeformation", session=session)
+    client_lakeformation: boto3.client = _utils.client(service_name="lakeformation", session=boto3_session)
     transaction_type: str = "READ_ONLY" if read_only else "READ_AND_WRITE"
     transaction_id: str = client_lakeformation.start_transaction(TransactionType=transaction_type)["TransactionId"]
     # Extend the transaction while in "active" state in a separate thread
@@ -303,8 +298,7 @@ def extend_transaction(transaction_id: str, boto3_session: Optional[boto3.Sessio
     >>> wr.lakeformation.extend_transaction(transaction_id="...")
 
     """
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
-    client_lakeformation: boto3.client = _utils.client(service_name="lakeformation", session=session)
+    client_lakeformation: boto3.client = _utils.client(service_name="lakeformation", session=boto3_session)
 
     client_lakeformation.extend_transaction(TransactionId=transaction_id)
 
@@ -330,8 +324,7 @@ def wait_query(query_id: str, boto3_session: Optional[boto3.Session] = None) -> 
     >>> res = wr.lakeformation.wait_query(query_id='query-id')
 
     """
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
-    client_lakeformation: boto3.client = _utils.client(service_name="lakeformation", session=session)
+    client_lakeformation: boto3.client = _utils.client(service_name="lakeformation", session=boto3_session)
 
     response: Dict[str, Any] = client_lakeformation.get_query_state(QueryId=query_id)
     state: str = response["State"]

--- a/awswrangler/quicksight/_cancel.py
+++ b/awswrangler/quicksight/_cancel.py
@@ -49,10 +49,9 @@ def cancel_ingestion(
     """
     if (dataset_name is None) and (dataset_id is None):
         raise exceptions.InvalidArgument("You must pass a not None name or dataset_id argument.")
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     if account_id is None:
-        account_id = sts.get_account_id(boto3_session=session)
+        account_id = sts.get_account_id(boto3_session=boto3_session)
     if (dataset_id is None) and (dataset_name is not None):
-        dataset_id = get_dataset_id(name=dataset_name, account_id=account_id, boto3_session=session)
-    client: boto3.client = _utils.client(service_name="quicksight", session=session)
+        dataset_id = get_dataset_id(name=dataset_name, account_id=account_id, boto3_session=boto3_session)
+    client: boto3.client = _utils.client(service_name="quicksight", session=boto3_session)
     client.cancel_ingestion(IngestionId=ingestion_id, AwsAccountId=account_id, DataSetId=dataset_id)

--- a/awswrangler/quicksight/_create.py
+++ b/awswrangler/quicksight/_create.py
@@ -167,10 +167,9 @@ def create_athena_data_source(
     ...     allowed_to_manage=["john"]
     ... )
     """
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
-    client: boto3.client = _utils.client(service_name="quicksight", session=session)
+    client: boto3.client = _utils.client(service_name="quicksight", session=boto3_session)
     if account_id is None:
-        account_id = sts.get_account_id(boto3_session=session)
+        account_id = sts.get_account_id(boto3_session=boto3_session)
     args: Dict[str, Any] = {
         "AwsAccountId": account_id,
         "DataSourceId": name,
@@ -182,7 +181,7 @@ def create_athena_data_source(
     permissions: List[Dict[str, Union[str, List[str]]]] = _generate_permissions(
         resource="data_source",
         account_id=account_id,
-        boto3_session=session,
+        boto3_session=boto3_session,
         allowed_to_use=allowed_to_use,
         allowed_to_manage=allowed_to_manage,
         namespace=namespace,
@@ -302,12 +301,11 @@ def create_athena_dataset(
             "If you provide sql argument, please include the database name inside the sql statement."
             "Do NOT pass in with database argument."
         )
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
-    client: boto3.client = _utils.client(service_name="quicksight", session=session)
+    client: boto3.client = _utils.client(service_name="quicksight", session=boto3_session)
     if account_id is None:
-        account_id = sts.get_account_id(boto3_session=session)
+        account_id = sts.get_account_id(boto3_session=boto3_session)
     if (data_source_arn is None) and (data_source_name is not None):
-        data_source_arn = get_data_source_arn(name=data_source_name, account_id=account_id, boto3_session=session)
+        data_source_arn = get_data_source_arn(name=data_source_name, account_id=account_id, boto3_session=boto3_session)
     if sql is not None:
         physical_table: Dict[str, Dict[str, Any]] = {
             "CustomSql": {
@@ -318,7 +316,7 @@ def create_athena_dataset(
                     sql=sql,
                     data_source_arn=data_source_arn,  # type: ignore
                     account_id=account_id,
-                    boto3_session=session,
+                    boto3_session=boto3_session,
                 ),
             }
         }
@@ -331,7 +329,7 @@ def create_athena_dataset(
                 "InputColumns": extract_athena_table_columns(
                     database=database,  # type: ignore
                     table=table,  # type: ignore
-                    boto3_session=session,
+                    boto3_session=boto3_session,
                 ),
             }
         }
@@ -353,7 +351,7 @@ def create_athena_dataset(
     permissions: List[Dict[str, Union[str, List[str]]]] = _generate_permissions(
         resource="dataset",
         account_id=account_id,
-        boto3_session=session,
+        boto3_session=boto3_session,
         allowed_to_use=allowed_to_use,
         allowed_to_manage=allowed_to_manage,
         namespace=namespace,
@@ -403,16 +401,15 @@ def create_ingestion(
     >>> import awswrangler as wr
     >>> status = wr.quicksight.create_ingestion("my_dataset")
     """
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     if account_id is None:
-        account_id = sts.get_account_id(boto3_session=session)
+        account_id = sts.get_account_id(boto3_session=boto3_session)
     if (dataset_name is None) and (dataset_id is None):
         raise exceptions.InvalidArgument("You must pass a not None dataset_name or dataset_id argument.")
     if (dataset_id is None) and (dataset_name is not None):
-        dataset_id = get_dataset_id(name=dataset_name, account_id=account_id, boto3_session=session)
+        dataset_id = get_dataset_id(name=dataset_name, account_id=account_id, boto3_session=boto3_session)
     if ingestion_id is None:
         ingestion_id = uuid.uuid4().hex
-    client: boto3.client = _utils.client(service_name="quicksight", session=session)
+    client: boto3.client = _utils.client(service_name="quicksight", session=boto3_session)
     response: Dict[str, Any] = client.create_ingestion(
         DataSetId=dataset_id, IngestionId=ingestion_id, AwsAccountId=account_id
     )

--- a/awswrangler/quicksight/_delete.py
+++ b/awswrangler/quicksight/_delete.py
@@ -24,10 +24,9 @@ _logger: logging.Logger = logging.getLogger(__name__)
 def _delete(
     func_name: str, account_id: Optional[str] = None, boto3_session: Optional[boto3.Session] = None, **kwargs: Any
 ) -> None:
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     if account_id is None:
-        account_id = sts.get_account_id(boto3_session=session)
-    client: boto3.client = _utils.client(service_name="quicksight", session=session)
+        account_id = sts.get_account_id(boto3_session=boto3_session)
+    client: boto3.client = _utils.client(service_name="quicksight", session=boto3_session)
     func: Callable[..., None] = getattr(client, func_name)
     func(AwsAccountId=account_id, **kwargs)
 
@@ -71,13 +70,12 @@ def delete_dashboard(
     """
     if (name is None) and (dashboard_id is None):
         raise exceptions.InvalidArgument("You must pass a not None name or dashboard_id argument.")
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     if (dashboard_id is None) and (name is not None):
-        dashboard_id = get_dashboard_id(name=name, account_id=account_id, boto3_session=session)
+        dashboard_id = get_dashboard_id(name=name, account_id=account_id, boto3_session=boto3_session)
     args: Dict[str, Any] = {
         "func_name": "delete_dashboard",
         "account_id": account_id,
-        "boto3_session": session,
+        "boto3_session": boto3_session,
         "DashboardId": dashboard_id,
     }
     if version_number is not None:
@@ -120,13 +118,12 @@ def delete_dataset(
     """
     if (name is None) and (dataset_id is None):
         raise exceptions.InvalidArgument("You must pass a not None name or dataset_id argument.")
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     if (dataset_id is None) and (name is not None):
-        dataset_id = get_dataset_id(name=name, account_id=account_id, boto3_session=session)
+        dataset_id = get_dataset_id(name=name, account_id=account_id, boto3_session=boto3_session)
     args: Dict[str, Any] = {
         "func_name": "delete_data_set",
         "account_id": account_id,
-        "boto3_session": session,
+        "boto3_session": boto3_session,
         "DataSetId": dataset_id,
     }
     _delete(**args)
@@ -167,13 +164,12 @@ def delete_data_source(
     """
     if (name is None) and (data_source_id is None):
         raise exceptions.InvalidArgument("You must pass a not None name or data_source_id argument.")
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     if (data_source_id is None) and (name is not None):
-        data_source_id = get_data_source_id(name=name, account_id=account_id, boto3_session=session)
+        data_source_id = get_data_source_id(name=name, account_id=account_id, boto3_session=boto3_session)
     args: Dict[str, Any] = {
         "func_name": "delete_data_source",
         "account_id": account_id,
-        "boto3_session": session,
+        "boto3_session": boto3_session,
         "DataSourceId": data_source_id,
     }
     _delete(**args)
@@ -218,13 +214,12 @@ def delete_template(
     """
     if (name is None) and (template_id is None):
         raise exceptions.InvalidArgument("You must pass a not None name or template_id argument.")
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     if (template_id is None) and (name is not None):
-        template_id = get_template_id(name=name, account_id=account_id, boto3_session=session)
+        template_id = get_template_id(name=name, account_id=account_id, boto3_session=boto3_session)
     args: Dict[str, Any] = {
         "func_name": "delete_template",
         "account_id": account_id,
-        "boto3_session": session,
+        "boto3_session": boto3_session,
         "TemplateId": template_id,
     }
     if version_number is not None:
@@ -256,14 +251,13 @@ def delete_all_dashboards(
     >>> import awswrangler as wr
     >>> wr.quicksight.delete_all_dashboards()
     """
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     if account_id is None:
-        account_id = sts.get_account_id(boto3_session=session)
-    for dashboard in list_dashboards(account_id=account_id, boto3_session=session):
+        account_id = sts.get_account_id(boto3_session=boto3_session)
+    for dashboard in list_dashboards(account_id=account_id, boto3_session=boto3_session):
         if regex_filter:
             if not re.search(f"^{regex_filter}$", dashboard["Name"]):
                 continue
-        delete_dashboard(dashboard_id=dashboard["DashboardId"], account_id=account_id, boto3_session=session)
+        delete_dashboard(dashboard_id=dashboard["DashboardId"], account_id=account_id, boto3_session=boto3_session)
 
 
 def delete_all_datasets(
@@ -290,14 +284,13 @@ def delete_all_datasets(
     >>> import awswrangler as wr
     >>> wr.quicksight.delete_all_datasets()
     """
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     if account_id is None:
-        account_id = sts.get_account_id(boto3_session=session)
-    for dataset in list_datasets(account_id=account_id, boto3_session=session):
+        account_id = sts.get_account_id(boto3_session=boto3_session)
+    for dataset in list_datasets(account_id=account_id, boto3_session=boto3_session):
         if regex_filter:
             if not re.search(f"^{regex_filter}$", dataset["Name"]):
                 continue
-        delete_dataset(dataset_id=dataset["DataSetId"], account_id=account_id, boto3_session=session)
+        delete_dataset(dataset_id=dataset["DataSetId"], account_id=account_id, boto3_session=boto3_session)
 
 
 def delete_all_data_sources(
@@ -324,14 +317,15 @@ def delete_all_data_sources(
     >>> import awswrangler as wr
     >>> wr.quicksight.delete_all_data_sources()
     """
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     if account_id is None:
-        account_id = sts.get_account_id(boto3_session=session)
-    for data_source in list_data_sources(account_id=account_id, boto3_session=session):
+        account_id = sts.get_account_id(boto3_session=boto3_session)
+    for data_source in list_data_sources(account_id=account_id, boto3_session=boto3_session):
         if regex_filter:
             if not re.search(f"^{regex_filter}$", data_source["Name"]):
                 continue
-        delete_data_source(data_source_id=data_source["DataSourceId"], account_id=account_id, boto3_session=session)
+        delete_data_source(
+            data_source_id=data_source["DataSourceId"], account_id=account_id, boto3_session=boto3_session
+        )
 
 
 def delete_all_templates(
@@ -358,11 +352,10 @@ def delete_all_templates(
     >>> import awswrangler as wr
     >>> wr.quicksight.delete_all_templates()
     """
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     if account_id is None:
-        account_id = sts.get_account_id(boto3_session=session)
-    for template in list_templates(account_id=account_id, boto3_session=session):
+        account_id = sts.get_account_id(boto3_session=boto3_session)
+    for template in list_templates(account_id=account_id, boto3_session=boto3_session):
         if regex_filter:
             if not re.search(f"^{regex_filter}$", template["Name"]):
                 continue
-        delete_template(template_id=template["TemplateId"], account_id=account_id, boto3_session=session)
+        delete_template(template_id=template["TemplateId"], account_id=account_id, boto3_session=boto3_session)

--- a/awswrangler/quicksight/_describe.py
+++ b/awswrangler/quicksight/_describe.py
@@ -46,12 +46,11 @@ def describe_dashboard(
     """
     if (name is None) and (dashboard_id is None):
         raise exceptions.InvalidArgument("You must pass a not None name or dashboard_id argument.")
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     if account_id is None:
-        account_id = sts.get_account_id(boto3_session=session)
+        account_id = sts.get_account_id(boto3_session=boto3_session)
     if (dashboard_id is None) and (name is not None):
-        dashboard_id = get_dashboard_id(name=name, account_id=account_id, boto3_session=session)
-    client: boto3.client = _utils.client(service_name="quicksight", session=session)
+        dashboard_id = get_dashboard_id(name=name, account_id=account_id, boto3_session=boto3_session)
+    client: boto3.client = _utils.client(service_name="quicksight", session=boto3_session)
     return cast(
         Dict[str, Any], client.describe_dashboard(AwsAccountId=account_id, DashboardId=dashboard_id)["Dashboard"]
     )
@@ -92,12 +91,11 @@ def describe_data_source(
     """
     if (name is None) and (data_source_id is None):
         raise exceptions.InvalidArgument("You must pass a not None name or data_source_id argument.")
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     if account_id is None:
-        account_id = sts.get_account_id(boto3_session=session)
+        account_id = sts.get_account_id(boto3_session=boto3_session)
     if (data_source_id is None) and (name is not None):
-        data_source_id = get_data_source_id(name=name, account_id=account_id, boto3_session=session)
-    client: boto3.client = _utils.client(service_name="quicksight", session=session)
+        data_source_id = get_data_source_id(name=name, account_id=account_id, boto3_session=boto3_session)
+    client: boto3.client = _utils.client(service_name="quicksight", session=boto3_session)
     return cast(
         Dict[str, Any], client.describe_data_source(AwsAccountId=account_id, DataSourceId=data_source_id)["DataSource"]
     )
@@ -138,12 +136,11 @@ def describe_data_source_permissions(
     """
     if (name is None) and (data_source_id is None):
         raise exceptions.InvalidArgument("You must pass a not None name or data_source_id argument.")
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     if account_id is None:
-        account_id = sts.get_account_id(boto3_session=session)
+        account_id = sts.get_account_id(boto3_session=boto3_session)
     if (data_source_id is None) and (name is not None):
-        data_source_id = get_data_source_id(name=name, account_id=account_id, boto3_session=session)
-    client: boto3.client = _utils.client(service_name="quicksight", session=session)
+        data_source_id = get_data_source_id(name=name, account_id=account_id, boto3_session=boto3_session)
+    client: boto3.client = _utils.client(service_name="quicksight", session=boto3_session)
     return cast(
         Dict[str, Any],
         client.describe_data_source_permissions(AwsAccountId=account_id, DataSourceId=data_source_id)["Permissions"],
@@ -185,12 +182,11 @@ def describe_dataset(
     """
     if (name is None) and (dataset_id is None):
         raise exceptions.InvalidArgument("You must pass a not None name or dataset_id argument.")
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     if account_id is None:
-        account_id = sts.get_account_id(boto3_session=session)
+        account_id = sts.get_account_id(boto3_session=boto3_session)
     if (dataset_id is None) and (name is not None):
-        dataset_id = get_dataset_id(name=name, account_id=account_id, boto3_session=session)
-    client: boto3.client = _utils.client(service_name="quicksight", session=session)
+        dataset_id = get_dataset_id(name=name, account_id=account_id, boto3_session=boto3_session)
+    client: boto3.client = _utils.client(service_name="quicksight", session=boto3_session)
     return cast(Dict[str, Any], client.describe_data_set(AwsAccountId=account_id, DataSetId=dataset_id)["DataSet"])
 
 
@@ -232,12 +228,11 @@ def describe_ingestion(
     """
     if (dataset_name is None) and (dataset_id is None):
         raise exceptions.InvalidArgument("You must pass a not None name or dataset_id argument.")
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     if account_id is None:
-        account_id = sts.get_account_id(boto3_session=session)
+        account_id = sts.get_account_id(boto3_session=boto3_session)
     if (dataset_id is None) and (dataset_name is not None):
-        dataset_id = get_dataset_id(name=dataset_name, account_id=account_id, boto3_session=session)
-    client: boto3.client = _utils.client(service_name="quicksight", session=session)
+        dataset_id = get_dataset_id(name=dataset_name, account_id=account_id, boto3_session=boto3_session)
+    client: boto3.client = _utils.client(service_name="quicksight", session=boto3_session)
     return cast(
         Dict[str, Any],
         client.describe_ingestion(IngestionId=ingestion_id, AwsAccountId=account_id, DataSetId=dataset_id)["Ingestion"],

--- a/awswrangler/quicksight/_get_list.py
+++ b/awswrangler/quicksight/_get_list.py
@@ -21,10 +21,9 @@ def _list(
     boto3_session: Optional[boto3.Session] = None,
     **kwargs: Any,
 ) -> List[Dict[str, Any]]:
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     if account_id is None:
-        account_id = sts.get_account_id(boto3_session=session)
-    client: boto3.client = _utils.client(service_name="quicksight", session=session)
+        account_id = sts.get_account_id(boto3_session=boto3_session)
+    client: boto3.client = _utils.client(service_name="quicksight", session=boto3_session)
     func: Callable[..., Dict[str, Any]] = getattr(client, func_name)
     response: Dict[str, Any] = func(AwsAccountId=account_id, **kwargs)
     next_token: str = response.get("NextToken", None)
@@ -406,11 +405,10 @@ def list_ingestions(
     """
     if (dataset_name is None) and (dataset_id is None):
         raise exceptions.InvalidArgument("You must pass a not None name or dataset_id argument.")
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     if account_id is None:
-        account_id = sts.get_account_id(boto3_session=session)
+        account_id = sts.get_account_id(boto3_session=boto3_session)
     if (dataset_id is None) and (dataset_name is not None):
-        dataset_id = get_dataset_id(name=dataset_name, account_id=account_id, boto3_session=session)
+        dataset_id = get_dataset_id(name=dataset_name, account_id=account_id, boto3_session=boto3_session)
     return _list(
         func_name="list_ingestions",
         attr_name="Ingestions",

--- a/awswrangler/redshift.py
+++ b/awswrangler/redshift.py
@@ -266,7 +266,6 @@ def _redshift_types_from_path(
 ) -> Dict[str, str]:
     """Extract Redshift data types from a Pandas DataFrame."""
     _varchar_lengths: Dict[str, int] = {} if varchar_lengths is None else varchar_lengths
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     _logger.debug("Scanning parquet schemas on s3...")
     athena_types, _ = s3.read_parquet_metadata(
         path=path,
@@ -275,7 +274,7 @@ def _redshift_types_from_path(
         path_ignore_suffix=path_ignore_suffix,
         dataset=False,
         use_threads=use_threads,
-        boto3_session=session,
+        boto3_session=boto3_session,
         s3_additional_kwargs=s3_additional_kwargs,
     )
     _logger.debug("athena_types: %s", athena_types)
@@ -1051,7 +1050,6 @@ def unload_to_files(
     """
     if unload_format not in [None, "CSV", "PARQUET"]:
         raise exceptions.InvalidArgumentValue("<unload_format> argument must be 'CSV' or 'PARQUET'")
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     with con.cursor() as cursor:
         format_str: str = unload_format or "PARQUET"
         partition_str: str = f"\nPARTITION BY ({','.join(partition_cols)})" if partition_cols else ""
@@ -1065,7 +1063,7 @@ def unload_to_files(
             aws_access_key_id=aws_access_key_id,
             aws_secret_access_key=aws_secret_access_key,
             aws_session_token=aws_session_token,
-            boto3_session=session,
+            boto3_session=boto3_session,
         )
 
         sql = (
@@ -1204,7 +1202,6 @@ def unload(
 
     """
     path = path if path.endswith("/") else f"{path}/"
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     unload_to_files(
         sql=sql,
         path=path,
@@ -1217,7 +1214,7 @@ def unload(
         max_file_size=max_file_size,
         kms_key_id=kms_key_id,
         manifest=False,
-        boto3_session=session,
+        boto3_session=boto3_session,
     )
     if chunked is False:
         df: pd.DataFrame = s3.read_parquet(
@@ -1226,12 +1223,15 @@ def unload(
             chunked=chunked,
             dataset=False,
             use_threads=use_threads,
-            boto3_session=session,
+            boto3_session=boto3_session,
             s3_additional_kwargs=s3_additional_kwargs,
         )
         if keep_files is False:
             s3.delete_objects(
-                path=path, use_threads=use_threads, boto3_session=session, s3_additional_kwargs=s3_additional_kwargs
+                path=path,
+                use_threads=use_threads,
+                boto3_session=boto3_session,
+                s3_additional_kwargs=s3_additional_kwargs,
             )
         return df
     return _read_parquet_iterator(
@@ -1239,7 +1239,7 @@ def unload(
         categories=categories,
         chunked=chunked,
         use_threads=use_threads,
-        boto3_session=session,
+        boto3_session=boto3_session,
         s3_additional_kwargs=s3_additional_kwargs,
         keep_files=keep_files,
     )
@@ -1631,8 +1631,7 @@ def copy(  # pylint: disable=too-many-arguments,too-many-locals
     path = path[:-1] if path.endswith("*") else path
     path = path if path.endswith("/") else f"{path}/"
     column_names = [f'"{column}"' for column in df.columns] if use_column_names else []
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
-    if s3.list_objects(path=path, boto3_session=session, s3_additional_kwargs=s3_additional_kwargs):
+    if s3.list_objects(path=path, boto3_session=boto3_session, s3_additional_kwargs=s3_additional_kwargs):
         raise exceptions.InvalidArgument(
             f"The received S3 path ({path}) is not empty. "
             "Please, provide a different path or use wr.s3.delete_objects() to clean up the current one."
@@ -1646,7 +1645,7 @@ def copy(  # pylint: disable=too-many-arguments,too-many-locals
             mode="append",
             dtype=dtype,
             use_threads=use_threads,
-            boto3_session=session,
+            boto3_session=boto3_session,
             s3_additional_kwargs=s3_additional_kwargs,
             max_rows_by_file=max_rows_by_file,
         )
@@ -1672,7 +1671,7 @@ def copy(  # pylint: disable=too-many-arguments,too-many-locals
             use_threads=use_threads,
             lock=lock,
             commit_transaction=commit_transaction,
-            boto3_session=session,
+            boto3_session=boto3_session,
             s3_additional_kwargs=s3_additional_kwargs,
             sql_copy_extra_params=sql_copy_extra_params,
             precombine_key=precombine_key,
@@ -1681,5 +1680,8 @@ def copy(  # pylint: disable=too-many-arguments,too-many-locals
     finally:
         if keep_files is False:
             s3.delete_objects(
-                path=path, use_threads=use_threads, boto3_session=session, s3_additional_kwargs=s3_additional_kwargs
+                path=path,
+                use_threads=use_threads,
+                boto3_session=boto3_session,
+                s3_additional_kwargs=s3_additional_kwargs,
             )

--- a/awswrangler/s3/_copy.py
+++ b/awswrangler/s3/_copy.py
@@ -123,10 +123,9 @@ def merge_datasets(
     """
     source_path = source_path[:-1] if source_path[-1] == "/" else source_path
     target_path = target_path[:-1] if target_path[-1] == "/" else target_path
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
 
     paths: List[str] = list_objects(  # type: ignore
-        path=f"{source_path}/", ignore_empty=ignore_empty, boto3_session=session
+        path=f"{source_path}/", ignore_empty=ignore_empty, boto3_session=boto3_session
     )
     _logger.debug("len(paths): %s", len(paths))
     if len(paths) < 1:
@@ -134,7 +133,7 @@ def merge_datasets(
 
     if mode == "overwrite":
         _logger.debug("Deleting to overwrite: %s/", target_path)
-        delete_objects(path=f"{target_path}/", use_threads=use_threads, boto3_session=session)
+        delete_objects(path=f"{target_path}/", use_threads=use_threads, boto3_session=boto3_session)
     elif mode == "overwrite_partitions":
         paths_wo_prefix: List[str] = [x.replace(f"{source_path}/", "") for x in paths]
         paths_wo_filename: List[str] = [f"{x.rpartition('/')[0]}/" for x in paths_wo_prefix]
@@ -142,7 +141,7 @@ def merge_datasets(
         target_partitions_paths = [f"{target_path}/{x}" for x in partitions_paths]
         for path in target_partitions_paths:
             _logger.debug("Deleting to overwrite_partitions: %s", path)
-            delete_objects(path=path, use_threads=use_threads, boto3_session=session)
+            delete_objects(path=path, use_threads=use_threads, boto3_session=boto3_session)
     elif mode != "append":
         raise exceptions.InvalidArgumentValue(f"{mode} is a invalid mode option.")
 
@@ -151,7 +150,7 @@ def merge_datasets(
         source_path=source_path,
         target_path=target_path,
         use_threads=use_threads,
-        boto3_session=session,
+        boto3_session=boto3_session,
         s3_additional_kwargs=s3_additional_kwargs,
     )
     _logger.debug("len(new_objects): %s", len(new_objects))
@@ -231,7 +230,6 @@ def copy_objects(
         return []
     source_path = source_path[:-1] if source_path[-1] == "/" else source_path
     target_path = target_path[:-1] if target_path[-1] == "/" else target_path
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     batch: List[Tuple[str, str]] = []
     new_objects: List[str] = []
     for path in paths:
@@ -250,6 +248,6 @@ def copy_objects(
         batch.append((path, path_final))
     _logger.debug("len(new_objects): %s", len(new_objects))
     _copy_objects(
-        batch=batch, use_threads=use_threads, boto3_session=session, s3_additional_kwargs=s3_additional_kwargs
+        batch=batch, use_threads=use_threads, boto3_session=boto3_session, s3_additional_kwargs=s3_additional_kwargs
     )
     return new_objects

--- a/awswrangler/s3/_describe.py
+++ b/awswrangler/s3/_describe.py
@@ -17,11 +17,10 @@ _logger: logging.Logger = logging.getLogger(__name__)
 
 def _describe_object(
     path: str,
-    boto3_session: boto3.Session,
+    s3_client: boto3.client,
     s3_additional_kwargs: Optional[Dict[str, Any]],
     version_id: Optional[str] = None,
 ) -> Tuple[str, Dict[str, Any]]:
-    client_s3: boto3.client = _utils.client(service_name="s3", session=boto3_session)
     bucket: str
     key: str
     bucket, key = _utils.parse_path(path=path)
@@ -35,21 +34,75 @@ def _describe_object(
     if version_id:
         extra_kwargs["VersionId"] = version_id
     desc = _utils.try_it(
-        f=client_s3.head_object, ex=client_s3.exceptions.NoSuchKey, Bucket=bucket, Key=key, **extra_kwargs
+        f=s3_client.head_object, ex=s3_client.exceptions.NoSuchKey, Bucket=bucket, Key=key, **extra_kwargs
     )
     return path, desc
 
 
 def _describe_object_concurrent(
     path: str,
-    boto3_primitives: _utils.Boto3PrimitivesType,
+    s3_client: boto3.client,
     s3_additional_kwargs: Optional[Dict[str, Any]],
     version_id: Optional[str] = None,
 ) -> Tuple[str, Dict[str, Any]]:
-    boto3_session = _utils.boto3_from_primitives(primitives=boto3_primitives)
     return _describe_object(
-        path=path, boto3_session=boto3_session, s3_additional_kwargs=s3_additional_kwargs, version_id=version_id
+        path=path, s3_client=s3_client, s3_additional_kwargs=s3_additional_kwargs, version_id=version_id
     )
+
+
+def _describe_objects(
+    path: Union[str, List[str]],
+    s3_client: boto3.client,
+    version_id: Optional[Union[str, Dict[str, str]]] = None,
+    use_threads: Union[bool, int] = True,
+    last_modified_begin: Optional[datetime.datetime] = None,
+    last_modified_end: Optional[datetime.datetime] = None,
+    s3_additional_kwargs: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Dict[str, Any]]:
+    paths: List[str] = _path2list(
+        path=path,
+        last_modified_begin=last_modified_begin,
+        last_modified_end=last_modified_end,
+        s3_client=s3_client,
+        s3_additional_kwargs=s3_additional_kwargs,
+    )
+    if len(paths) < 1:
+        return {}
+    resp_list: List[Tuple[str, Dict[str, Any]]]
+    if len(paths) == 1:
+        resp_list = [
+            _describe_object(
+                path=paths[0],
+                version_id=version_id.get(paths[0]) if isinstance(version_id, dict) else version_id,
+                s3_client=s3_client,
+                s3_additional_kwargs=s3_additional_kwargs,
+            )
+        ]
+    elif use_threads is False:
+        resp_list = [
+            _describe_object(
+                path=p,
+                version_id=version_id.get(p) if isinstance(version_id, dict) else version_id,
+                s3_client=s3_client,
+                s3_additional_kwargs=s3_additional_kwargs,
+            )
+            for p in paths
+        ]
+    else:
+        cpus: int = _utils.ensure_cpu_count(use_threads=use_threads)
+        versions = [version_id.get(p) if isinstance(version_id, dict) else version_id for p in paths]
+        with concurrent.futures.ThreadPoolExecutor(max_workers=cpus) as executor:
+            resp_list = list(
+                executor.map(
+                    _describe_object_concurrent,
+                    paths,
+                    itertools.repeat(s3_client),
+                    itertools.repeat(s3_additional_kwargs),
+                    versions,
+                )
+            )
+    desc_dict: Dict[str, Dict[str, Any]] = dict(resp_list)
+    return desc_dict
 
 
 def describe_objects(
@@ -120,50 +173,34 @@ def describe_objects(
     >>> descs1 = wr.s3.describe_objects('s3://bucket/prefix')  # Describe all objects under the prefix
 
     """
-    paths: List[str] = _path2list(
+    s3_client: boto3.client = _utils.client(service_name="s3", session=boto3_session)
+    return _describe_objects(
         path=path,
-        boto3_session=boto3_session,
+        s3_client=s3_client,
+        version_id=version_id,
+        use_threads=use_threads,
         last_modified_begin=last_modified_begin,
         last_modified_end=last_modified_end,
         s3_additional_kwargs=s3_additional_kwargs,
     )
-    if len(paths) < 1:
-        return {}
-    resp_list: List[Tuple[str, Dict[str, Any]]]
-    if len(paths) == 1:
-        resp_list = [
-            _describe_object(
-                path=paths[0],
-                version_id=version_id.get(paths[0]) if isinstance(version_id, dict) else version_id,
-                boto3_session=boto3_session,
-                s3_additional_kwargs=s3_additional_kwargs,
-            )
-        ]
-    elif use_threads is False:
-        resp_list = [
-            _describe_object(
-                path=p,
-                version_id=version_id.get(p) if isinstance(version_id, dict) else version_id,
-                boto3_session=boto3_session,
-                s3_additional_kwargs=s3_additional_kwargs,
-            )
-            for p in paths
-        ]
-    else:
-        cpus: int = _utils.ensure_cpu_count(use_threads=use_threads)
-        versions = [version_id.get(p) if isinstance(version_id, dict) else version_id for p in paths]
-        with concurrent.futures.ThreadPoolExecutor(max_workers=cpus) as executor:
-            resp_list = list(
-                executor.map(
-                    _describe_object_concurrent,
-                    paths,
-                    versions,
-                    itertools.repeat(_utils.boto3_to_primitives(boto3_session=boto3_session)),
-                    itertools.repeat(s3_additional_kwargs),
-                )
-            )
-    desc_dict: Dict[str, Dict[str, Any]] = dict(resp_list)
-    return desc_dict
+
+
+def _size_objects(
+    path: Union[str, List[str]],
+    s3_client: boto3.client,
+    version_id: Optional[Union[str, Dict[str, str]]] = None,
+    use_threads: Union[bool, int] = True,
+    s3_additional_kwargs: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Optional[int]]:
+    desc_list: Dict[str, Dict[str, Any]] = _describe_objects(
+        path=path,
+        s3_client=s3_client,
+        version_id=version_id,
+        use_threads=use_threads,
+        s3_additional_kwargs=s3_additional_kwargs,
+    )
+    size_dict: Dict[str, Optional[int]] = {k: d.get("ContentLength", None) for k, d in desc_list.items()}
+    return size_dict
 
 
 def size_objects(
@@ -216,15 +253,14 @@ def size_objects(
     >>> sizes1 = wr.s3.size_objects('s3://bucket/prefix')  # Get the sizes of all objects under the received prefix
 
     """
-    desc_list: Dict[str, Dict[str, Any]] = describe_objects(
+    s3_client: boto3.client = _utils.client(service_name="s3", session=boto3_session)
+    return _size_objects(
         path=path,
+        s3_client=s3_client,
         version_id=version_id,
         use_threads=use_threads,
-        boto3_session=boto3_session,
         s3_additional_kwargs=s3_additional_kwargs,
     )
-    size_dict: Dict[str, Optional[int]] = {k: d.get("ContentLength", None) for k, d in desc_list.items()}
-    return size_dict
 
 
 def get_bucket_region(bucket: str, boto3_session: Optional[boto3.Session] = None) -> str:

--- a/awswrangler/s3/_download.py
+++ b/awswrangler/s3/_download.py
@@ -62,7 +62,6 @@ def download(
     >>>     wr.s3.download(path='s3://bucket/key', local_file=local_f)
 
     """
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     _logger.debug("path: %s", path)
     with open_s3_object(
         path=path,
@@ -71,7 +70,7 @@ def download(
         version_id=version_id,
         s3_block_size=-1,  # One shot download
         s3_additional_kwargs=s3_additional_kwargs,
-        boto3_session=session,
+        boto3_session=boto3_session,
     ) as s3_f:
         if isinstance(local_file, str):
             _logger.debug("Downloading local_file: %s", local_file)

--- a/awswrangler/s3/_download.py
+++ b/awswrangler/s3/_download.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, Optional, Union, cast
 
 import boto3
 
-from awswrangler import _utils
 from awswrangler.s3._fs import open_s3_object
 
 _logger: logging.Logger = logging.getLogger(__name__)

--- a/awswrangler/s3/_fs.py
+++ b/awswrangler/s3/_fs.py
@@ -555,8 +555,7 @@ def open_s3_object(
     """Return a _S3Object or TextIOWrapper based on the received mode."""
     s3obj: Optional[_S3ObjectBase] = None
     text_s3obj: Optional[io.TextIOWrapper] = None
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
-    s3_client = _utils.client(service_name="s3", session=session) if not s3_client else s3_client
+    s3_client = _utils.client(service_name="s3", session=boto3_session) if not s3_client else s3_client
     try:
         s3obj = _S3ObjectBase(
             path=path,

--- a/awswrangler/s3/_list.pyi
+++ b/awswrangler/s3/_list.pyi
@@ -5,7 +5,7 @@ import boto3
 
 def _path2list(
     path: Union[str, Sequence[str]],
-    boto3_session: boto3.Session,
+    s3_client: boto3.client,
     s3_additional_kwargs: Optional[Dict[str, Any]] = ...,
     last_modified_begin: Optional[datetime.datetime] = ...,
     last_modified_end: Optional[datetime.datetime] = ...,

--- a/awswrangler/s3/_read.py
+++ b/awswrangler/s3/_read.py
@@ -10,7 +10,7 @@ import pandas as pd
 from pandas.api.types import union_categoricals
 
 from awswrangler import exceptions
-from awswrangler._utils import boto3_to_primitives, ensure_cpu_count
+from awswrangler._utils import ensure_cpu_count
 from awswrangler.s3._list import _prefix_cleanup
 
 _logger: logging.Logger = logging.getLogger(__name__)
@@ -145,7 +145,6 @@ def _read_dfs_from_multiple_paths(
         ]
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=ensure_cpu_count(use_threads)) as executor:
-        kwargs["boto3_session"] = boto3_to_primitives(kwargs["boto3_session"])
         partial_read_func = partial(read_func, **kwargs)
         versions = [version_ids.get(p) if isinstance(version_ids, dict) else None for p in paths]
         return list(df for df in executor.map(partial_read_func, paths, versions))

--- a/awswrangler/s3/_read_deltalake.py
+++ b/awswrangler/s3/_read_deltalake.py
@@ -13,9 +13,9 @@ if _deltalake_found:
 
 
 def _set_default_storage_options_kwargs(
-    session: boto3.Session, s3_additional_kwargs: Optional[Dict[str, Any]]
+    boto3_session: boto3.Session, s3_additional_kwargs: Optional[Dict[str, Any]]
 ) -> Dict[str, Any]:
-    defaults = {key.upper(): value for key, value in _utils.boto3_to_primitives(boto3_session=session).items()}
+    defaults = {key.upper(): value for key, value in _utils.boto3_to_primitives(boto3_session=boto3_session).items()}
     s3_additional_kwargs = s3_additional_kwargs or {}
     return {
         **defaults,
@@ -73,8 +73,7 @@ def read_deltalake(
     deltalake.DeltaTable : Create a DeltaTable instance with the deltalake library.
     """
     pyarrow_additional_kwargs = pyarrow_additional_kwargs or {}  # TODO: Use defaults in 3.0.0 # pylint: disable=fixme
-    storage_options = _set_default_storage_options_kwargs(_utils.ensure_session(boto3_session), s3_additional_kwargs)
-
+    storage_options = _set_default_storage_options_kwargs(boto3_session, s3_additional_kwargs)
     return (
         DeltaTable(
             table_uri=path,

--- a/awswrangler/s3/_read_excel.py
+++ b/awswrangler/s3/_read_excel.py
@@ -77,7 +77,6 @@ def read_excel(
             "Pandas arguments in the function call and awswrangler will accept it."
             "e.g. wr.s3.read_excel('s3://bucket/key.xlsx', na_rep='', verbose=True)"
         )
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     with open_s3_object(
         path=path,
         mode="rb",
@@ -85,7 +84,7 @@ def read_excel(
         use_threads=use_threads,
         s3_block_size=-1,  # One shot download
         s3_additional_kwargs=s3_additional_kwargs,
-        boto3_session=session,
+        boto3_session=boto3_session,
     ) as f:
         _logger.debug("pandas_kwargs: %s", pandas_kwargs)
         return pd.read_excel(f, **pandas_kwargs)

--- a/awswrangler/s3/_read_excel.py
+++ b/awswrangler/s3/_read_excel.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Optional, Union
 import boto3
 import pandas as pd
 
-from awswrangler import _utils, exceptions
+from awswrangler import exceptions
 from awswrangler.s3._fs import open_s3_object
 
 _logger: logging.Logger = logging.getLogger(__name__)

--- a/awswrangler/s3/_read_parquet.py
+++ b/awswrangler/s3/_read_parquet.py
@@ -731,8 +731,7 @@ def read_parquet(
     >>> df = wr.s3.read_parquet(path, dataset=True, partition_filter=my_filter)
 
     """
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
-    s3_client: boto3.client = _utils.client(service_name="s3", session=session)
+    s3_client: boto3.client = _utils.client(service_name="s3", session=boto3_session)
     paths: List[str] = _path2list(
         path=path,
         s3_client=s3_client,
@@ -1119,7 +1118,7 @@ def read_parquet_metadata(
         dataset=dataset,
         use_threads=use_threads,
         s3_additional_kwargs=s3_additional_kwargs,
-        boto3_session=_utils.ensure_session(session=boto3_session),
+        boto3_session=boto3_session,
         pyarrow_additional_kwargs=pyarrow_additional_kwargs,
     )[:2]
 

--- a/awswrangler/s3/_read_parquet.py
+++ b/awswrangler/s3/_read_parquet.py
@@ -56,7 +56,7 @@ def _pyarrow_parquet_file_wrapper(
 
 def _read_parquet_metadata_file(
     path: str,
-    boto3_session: boto3.Session,
+    s3_client: boto3.client,
     s3_additional_kwargs: Optional[Dict[str, str]],
     use_threads: Union[bool, int],
     version_id: Optional[str] = None,
@@ -70,8 +70,8 @@ def _read_parquet_metadata_file(
         version_id=version_id,
         use_threads=use_threads,
         s3_block_size=131_072,  # 128 KB (128 * 2**10)
+        s3_client=s3_client,
         s3_additional_kwargs=s3_additional_kwargs,
-        boto3_session=boto3_session,
     ) as f:
         pq_file: Optional[pyarrow.parquet.ParquetFile] = _pyarrow_parquet_file_wrapper(
             source=f, coerce_int96_timestamp_unit=pyarrow_args["coerce_int96_timestamp_unit"]
@@ -87,7 +87,7 @@ def _read_schemas_from_files(
     paths: List[str],
     sampling: float,
     use_threads: Union[bool, int],
-    boto3_session: boto3.Session,
+    s3_client: boto3.client,
     s3_additional_kwargs: Optional[Dict[str, str]],
     version_ids: Optional[Dict[str, str]] = None,
     ignore_null: bool = False,
@@ -102,7 +102,7 @@ def _read_schemas_from_files(
         schemas = tuple(
             _read_parquet_metadata_file(
                 path=p,
-                boto3_session=boto3_session,
+                s3_client=s3_client,
                 s3_additional_kwargs=s3_additional_kwargs,
                 use_threads=use_threads,
                 version_id=version_ids.get(p) if isinstance(version_ids, dict) else None,
@@ -118,7 +118,7 @@ def _read_schemas_from_files(
                 executor.map(
                     _read_parquet_metadata_file,
                     paths,
-                    itertools.repeat(_utils.boto3_to_primitives(boto3_session=boto3_session)),  # Boto3.Session
+                    itertools.repeat(s3_client),
                     itertools.repeat(s3_additional_kwargs),
                     itertools.repeat(use_threads),
                     versions,
@@ -147,7 +147,7 @@ def _validate_schemas_from_files(
     paths: List[str],
     sampling: float,
     use_threads: Union[bool, int],
-    boto3_session: boto3.Session,
+    s3_client: boto3.client,
     s3_additional_kwargs: Optional[Dict[str, str]],
     version_ids: Optional[Dict[str, str]] = None,
     pyarrow_additional_kwargs: Optional[Dict[str, Any]] = None,
@@ -156,7 +156,7 @@ def _validate_schemas_from_files(
         paths=paths,
         sampling=sampling,
         use_threads=use_threads,
-        boto3_session=boto3_session,
+        s3_client=s3_client,
         s3_additional_kwargs=s3_additional_kwargs,
         version_ids=version_ids,
         pyarrow_additional_kwargs=pyarrow_additional_kwargs,
@@ -192,22 +192,22 @@ def _read_parquet_metadata(
     pyarrow_additional_kwargs: Optional[Dict[str, Any]] = None,
 ) -> Tuple[Dict[str, str], Optional[Dict[str, str]], Optional[Dict[str, List[str]]]]:
     """Handle wr.s3.read_parquet_metadata internally."""
+    s3_client: boto3.client = _utils.client(service_name="s3", session=boto3_session)
     path_root: Optional[str] = _get_path_root(path=path, dataset=dataset)
     paths: List[str] = _path2list(
         path=path,
-        boto3_session=boto3_session,
+        s3_client=s3_client,
         suffix=path_suffix,
         ignore_suffix=_get_path_ignore_suffix(path_ignore_suffix=path_ignore_suffix),
         ignore_empty=ignore_empty,
         s3_additional_kwargs=s3_additional_kwargs,
     )
-
     # Files
     schemas: Tuple[Dict[str, str], ...] = _read_schemas_from_files(
         paths=paths,
         sampling=sampling,
         use_threads=use_threads,
-        boto3_session=boto3_session,
+        s3_client=s3_client,
         s3_additional_kwargs=s3_additional_kwargs,
         version_ids=version_id
         if isinstance(version_id, dict)
@@ -372,7 +372,7 @@ def _read_parquet_chunked(  # pylint: disable=too-many-branches
     categories: Optional[List[str]],
     safe: bool,
     map_types: bool,
-    boto3_session: boto3.Session,
+    s3_client: boto3.client,
     dataset: bool,
     path_root: Optional[str],
     s3_additional_kwargs: Optional[Dict[str, str]],
@@ -392,8 +392,8 @@ def _read_parquet_chunked(  # pylint: disable=too-many-branches
             mode="rb",
             use_threads=use_threads,
             s3_block_size=10_485_760,  # 10 MB (10 * 2**20)
+            s3_client=s3_client,
             s3_additional_kwargs=s3_additional_kwargs,
-            boto3_session=boto3_session,
         ) as f:
             pq_file: Optional[pyarrow.parquet.ParquetFile] = _pyarrow_parquet_file_wrapper(
                 source=f,
@@ -462,7 +462,7 @@ def _read_parquet_file(
     path: str,
     columns: Optional[List[str]],
     categories: Optional[List[str]],
-    boto3_session: boto3.Session,
+    s3_client: boto3.client,
     s3_additional_kwargs: Optional[Dict[str, str]],
     use_threads: Union[bool, int],
     version_id: Optional[str] = None,
@@ -477,7 +477,7 @@ def _read_parquet_file(
         use_threads=use_threads,
         s3_block_size=s3_block_size,
         s3_additional_kwargs=s3_additional_kwargs,
-        boto3_session=boto3_session,
+        s3_client=s3_client,
     ) as f:
         pq_file: Optional[pyarrow.parquet.ParquetFile] = _pyarrow_parquet_file_wrapper(
             source=f,
@@ -522,22 +522,21 @@ def _read_parquet(
     categories: Optional[List[str]],
     safe: bool,
     map_types: bool,
-    boto3_session: Union[boto3.Session, _utils.Boto3PrimitivesType],
     dataset: bool,
     validate_schema: Optional[bool],
     path_root: Optional[str],
+    s3_client: boto3.client,
     s3_additional_kwargs: Optional[Dict[str, str]],
     use_threads: Union[bool, int],
     pyarrow_additional_kwargs: Optional[Dict[str, Any]] = None,
 ) -> pd.DataFrame:
     pyarrow_args = _set_default_pyarrow_additional_kwargs(pyarrow_additional_kwargs)
-    boto3_session = _utils.ensure_session(boto3_session)
     df: pd.DataFrame = _arrowtable2df(
         table=_read_parquet_file(
             path=path,
             columns=columns,
             categories=categories,
-            boto3_session=boto3_session,
+            s3_client=s3_client,
             s3_additional_kwargs=s3_additional_kwargs,
             use_threads=use_threads,
             version_id=version_id,
@@ -733,9 +732,10 @@ def read_parquet(
 
     """
     session: boto3.Session = _utils.ensure_session(session=boto3_session)
+    s3_client: boto3.client = _utils.client(service_name="s3", session=session)
     paths: List[str] = _path2list(
         path=path,
-        boto3_session=session,
+        s3_client=s3_client,
         suffix=path_suffix,
         ignore_suffix=_get_path_ignore_suffix(path_ignore_suffix=path_ignore_suffix),
         last_modified_begin=last_modified_begin,
@@ -759,10 +759,10 @@ def read_parquet(
         "categories": categories,
         "safe": safe,
         "map_types": map_types,
-        "boto3_session": session,
         "dataset": dataset,
         "path_root": path_root,
         "validate_schema": validate_schema,
+        "s3_client": s3_client,
         "s3_additional_kwargs": s3_additional_kwargs,
         "use_threads": use_threads,
         "pyarrow_additional_kwargs": pyarrow_additional_kwargs,
@@ -788,7 +788,7 @@ def read_parquet(
             version_ids=versions,
             sampling=1.0,
             use_threads=use_threads,
-            boto3_session=boto3_session,
+            s3_client=s3_client,
             s3_additional_kwargs=s3_additional_kwargs,
         )
     return _union(
@@ -937,6 +937,7 @@ def read_parquet_table(
 
     """
     client_glue: boto3.client = _utils.client(service_name="glue", session=boto3_session)
+    s3_client: boto3.client = _utils.client(service_name="s3", session=boto3_session)
     args: Dict[str, Any] = {"DatabaseName": database, "Name": table}
     if catalog_id is not None:
         args["CatalogId"] = catalog_id
@@ -967,7 +968,7 @@ def read_parquet_table(
             for partition in partitions:
                 paths += _path2list(
                     path=partition,
-                    boto3_session=boto3_session,
+                    s3_client=s3_client,
                     suffix=filename_suffix,
                     ignore_suffix=_get_path_ignore_suffix(path_ignore_suffix=filename_ignore_suffix),
                     s3_additional_kwargs=s3_additional_kwargs,

--- a/awswrangler/s3/_upload.py
+++ b/awswrangler/s3/_upload.py
@@ -58,7 +58,6 @@ def upload(
     >>>     wr.s3.upload(local_file=local_f, path='s3://bucket/key')
 
     """
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     _logger.debug("path: %s", path)
     with open_s3_object(
         path=path,
@@ -66,7 +65,7 @@ def upload(
         use_threads=use_threads,
         s3_block_size=-1,  # One shot download
         s3_additional_kwargs=s3_additional_kwargs,
-        boto3_session=session,
+        boto3_session=boto3_session,
     ) as s3_f:
         if isinstance(local_file, str):
             _logger.debug("Uploading local_file: %s", local_file)

--- a/awswrangler/s3/_upload.py
+++ b/awswrangler/s3/_upload.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, Optional, Union
 
 import boto3
 
-from awswrangler import _utils
 from awswrangler.s3._fs import open_s3_object
 
 _logger: logging.Logger = logging.getLogger(__name__)

--- a/awswrangler/s3/_write_concurrent.py
+++ b/awswrangler/s3/_write_concurrent.py
@@ -4,7 +4,6 @@ import concurrent.futures
 import logging
 from typing import Any, Callable, Dict, List, Optional, Union
 
-import boto3
 import pandas as pd
 
 from awswrangler import _utils
@@ -24,15 +23,11 @@ class _WriteProxy:
             self._exec = None
 
     @staticmethod
-    def _caller(
-        func: Callable[..., pd.DataFrame], boto3_primitives: _utils.Boto3PrimitivesType, func_kwargs: Dict[str, Any]
-    ) -> pd.DataFrame:
-        boto3_session: boto3.Session = _utils.boto3_from_primitives(primitives=boto3_primitives)
-        func_kwargs["boto3_session"] = boto3_session
+    def _caller(func: Callable[..., pd.DataFrame], func_kwargs: Dict[str, Any]) -> pd.DataFrame:
         _logger.debug("Calling: %s", func)
         return func(**func_kwargs)
 
-    def write(self, func: Callable[..., List[str]], boto3_session: boto3.Session, **func_kwargs: Any) -> None:
+    def write(self, func: Callable[..., List[str]], **func_kwargs: Any) -> None:
         """Write File."""
         if self._exec is not None:
             _utils.block_waiting_available_thread(seq=self._futures, max_workers=self._cpus)
@@ -40,12 +35,11 @@ class _WriteProxy:
             future = self._exec.submit(
                 _WriteProxy._caller,
                 func=func,
-                boto3_primitives=_utils.boto3_to_primitives(boto3_session=boto3_session),
                 func_kwargs=func_kwargs,
             )
             self._futures.append(future)
         else:
-            self._results += func(boto3_session=boto3_session, **func_kwargs)
+            self._results += func(**func_kwargs)
 
     def close(self) -> List[str]:
         """Close the proxy."""

--- a/awswrangler/s3/_write_excel.py
+++ b/awswrangler/s3/_write_excel.py
@@ -79,13 +79,12 @@ def to_excel(
             "e.g. wr.s3.to_excel(df, path, na_rep="
             ", index=False)"
         )
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     with open_s3_object(
         path=path,
         mode="wb",
         use_threads=use_threads,
         s3_additional_kwargs=s3_additional_kwargs,
-        boto3_session=session,
+        boto3_session=boto3_session,
     ) as f:
         _logger.debug("pandas_kwargs: %s", pandas_kwargs)
         df.to_excel(f, **pandas_kwargs)

--- a/awswrangler/s3/_write_excel.py
+++ b/awswrangler/s3/_write_excel.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Optional, Union
 import boto3
 import pandas as pd
 
-from awswrangler import _utils, exceptions
+from awswrangler import exceptions
 from awswrangler.s3._fs import open_s3_object
 
 _logger: logging.Logger = logging.getLogger(__name__)

--- a/awswrangler/s3/_write_parquet.py
+++ b/awswrangler/s3/_write_parquet.py
@@ -551,7 +551,6 @@ def to_parquet(  # pylint: disable=too-many-arguments,too-many-locals,too-many-b
         table_type = "GOVERNED"
     filename_prefix = filename_prefix + uuid.uuid4().hex if filename_prefix else uuid.uuid4().hex
     cpus: int = _utils.ensure_cpu_count(use_threads=use_threads)
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     s3_client: boto3.client = _utils.client(service_name="s3", session=boto3_session)
 
     # Sanitize table to respect Athena's standards
@@ -562,7 +561,11 @@ def to_parquet(  # pylint: disable=too-many-arguments,too-many-locals,too-many-b
     catalog_table_input: Optional[Dict[str, Any]] = None
     if database is not None and table is not None:
         catalog_table_input = catalog._get_table_input(  # pylint: disable=protected-access
-            database=database, table=table, boto3_session=session, transaction_id=transaction_id, catalog_id=catalog_id
+            database=database,
+            table=table,
+            boto3_session=boto3_session,
+            transaction_id=transaction_id,
+            catalog_id=catalog_id,
         )
         catalog_path: Optional[str] = None
         if catalog_table_input:
@@ -629,7 +632,7 @@ def to_parquet(  # pylint: disable=too-many-arguments,too-many-locals,too-many-b
                     description=description,
                     parameters=parameters,
                     columns_comments=columns_comments,
-                    boto3_session=session,
+                    boto3_session=boto3_session,
                     mode=mode,
                     transaction_id=transaction_id,
                     catalog_versioning=catalog_versioning,
@@ -647,7 +650,7 @@ def to_parquet(  # pylint: disable=too-many-arguments,too-many-locals,too-many-b
                 catalog_table_input = catalog._get_table_input(  # pylint: disable=protected-access
                     database=database,
                     table=table,
-                    boto3_session=session,
+                    boto3_session=boto3_session,
                     transaction_id=transaction_id,
                     catalog_id=catalog_id,
                 )
@@ -674,7 +677,7 @@ def to_parquet(  # pylint: disable=too-many-arguments,too-many-locals,too-many-b
             bucketing_info=bucketing_info,
             dtype=dtype,
             mode=mode,
-            boto3_session=session,
+            boto3_session=boto3_session,
             s3_additional_kwargs=s3_additional_kwargs,
             schema=schema,
             max_rows_by_file=max_rows_by_file,
@@ -693,7 +696,7 @@ def to_parquet(  # pylint: disable=too-many-arguments,too-many-locals,too-many-b
                     description=description,
                     parameters=parameters,
                     columns_comments=columns_comments,
-                    boto3_session=session,
+                    boto3_session=boto3_session,
                     mode=mode,
                     transaction_id=transaction_id,
                     catalog_versioning=catalog_versioning,
@@ -716,7 +719,7 @@ def to_parquet(  # pylint: disable=too-many-arguments,too-many-locals,too-many-b
                         partitions_values=partitions_values,
                         bucketing_info=bucketing_info,
                         compression=compression,
-                        boto3_session=session,
+                        boto3_session=boto3_session,
                         catalog_id=catalog_id,
                         columns_types=columns_types,
                     )
@@ -729,7 +732,7 @@ def to_parquet(  # pylint: disable=too-many-arguments,too-many-locals,too-many-b
                 delete_objects(
                     path=paths,
                     use_threads=use_threads,
-                    boto3_session=session,
+                    boto3_session=boto3_session,
                     s3_additional_kwargs=s3_additional_kwargs,
                 )
                 raise
@@ -899,7 +902,6 @@ def store_parquet_metadata(  # pylint: disable=too-many-arguments,too-many-local
     ... )
 
     """
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     columns_types: Dict[str, str]
     partitions_types: Optional[Dict[str, str]]
     partitions_values: Optional[Dict[str, List[str]]]
@@ -914,7 +916,7 @@ def store_parquet_metadata(  # pylint: disable=too-many-arguments,too-many-local
         ignore_null=False,
         use_threads=use_threads,
         s3_additional_kwargs=s3_additional_kwargs,
-        boto3_session=session,
+        boto3_session=boto3_session,
     )
     _logger.debug("columns_types: %s", columns_types)
     _logger.debug("partitions_types: %s", partitions_types)
@@ -939,7 +941,7 @@ def store_parquet_metadata(  # pylint: disable=too-many-arguments,too-many-local
         projection_digits=projection_digits,
         projection_formats=projection_formats,
         projection_storage_location_template=projection_storage_location_template,
-        boto3_session=session,
+        boto3_session=boto3_session,
         catalog_id=catalog_id,
     )
     if (partitions_types is not None) and (partitions_values is not None) and (regular_partitions is True):
@@ -948,7 +950,7 @@ def store_parquet_metadata(  # pylint: disable=too-many-arguments,too-many-local
             table=table,
             partitions_values=partitions_values,
             compression=compression,
-            boto3_session=session,
+            boto3_session=boto3_session,
             catalog_id=catalog_id,
             columns_types=columns_types,
         )

--- a/awswrangler/s3/_write_text.py
+++ b/awswrangler/s3/_write_text.py
@@ -443,7 +443,6 @@ def to_csv(  # pylint: disable=too-many-arguments,too-many-locals,too-many-state
     if transaction_id:
         table_type = "GOVERNED"
     filename_prefix = filename_prefix + uuid.uuid4().hex if filename_prefix else uuid.uuid4().hex
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     s3_client: boto3.client = _utils.client(service_name="s3", session=boto3_session)
 
     # Sanitize table to respect Athena's standards
@@ -454,7 +453,11 @@ def to_csv(  # pylint: disable=too-many-arguments,too-many-locals,too-many-state
     catalog_table_input: Optional[Dict[str, Any]] = None
     if database and table:
         catalog_table_input = catalog._get_table_input(  # pylint: disable=protected-access
-            database=database, table=table, boto3_session=session, transaction_id=transaction_id, catalog_id=catalog_id
+            database=database,
+            table=table,
+            boto3_session=boto3_session,
+            transaction_id=transaction_id,
+            catalog_id=catalog_id,
         )
 
         catalog_path: Optional[str] = None
@@ -543,7 +546,7 @@ def to_csv(  # pylint: disable=too-many-arguments,too-many-locals,too-many-state
                     description=description,
                     parameters=parameters,
                     columns_comments=columns_comments,
-                    boto3_session=session,
+                    boto3_session=boto3_session,
                     mode=mode,
                     transaction_id=transaction_id,
                     schema_evolution=schema_evolution,
@@ -567,7 +570,7 @@ def to_csv(  # pylint: disable=too-many-arguments,too-many-locals,too-many-state
                 catalog_table_input = catalog._get_table_input(  # pylint: disable=protected-access
                     database=database,
                     table=table,
-                    boto3_session=session,
+                    boto3_session=boto3_session,
                     transaction_id=transaction_id,
                     catalog_id=catalog_id,
                 )
@@ -591,7 +594,7 @@ def to_csv(  # pylint: disable=too-many-arguments,too-many-locals,too-many-state
             partitions_types=partitions_types,
             bucketing_info=bucketing_info,
             mode=mode,
-            boto3_session=session,
+            boto3_session=boto3_session,
             s3_additional_kwargs=s3_additional_kwargs,
             file_format="csv",
             quoting=quoting,
@@ -618,7 +621,7 @@ def to_csv(  # pylint: disable=too-many-arguments,too-many-locals,too-many-state
                     description=description,
                     parameters=parameters,
                     columns_comments=columns_comments,
-                    boto3_session=session,
+                    boto3_session=boto3_session,
                     mode=mode,
                     transaction_id=transaction_id,
                     catalog_versioning=catalog_versioning,
@@ -646,7 +649,7 @@ def to_csv(  # pylint: disable=too-many-arguments,too-many-locals,too-many-state
                         table=table,
                         partitions_values=partitions_values,
                         bucketing_info=bucketing_info,
-                        boto3_session=session,
+                        boto3_session=boto3_session,
                         sep=sep,
                         serde_library=serde_library,
                         serde_parameters=serde_parameters,
@@ -663,7 +666,7 @@ def to_csv(  # pylint: disable=too-many-arguments,too-many-locals,too-many-state
                 delete_objects(
                     path=paths,
                     use_threads=use_threads,
-                    boto3_session=session,
+                    boto3_session=boto3_session,
                     s3_additional_kwargs=s3_additional_kwargs,
                 )
                 raise
@@ -905,7 +908,6 @@ def to_json(  # pylint: disable=too-many-arguments,too-many-locals,too-many-stat
     if transaction_id:
         table_type = "GOVERNED"
     filename_prefix = filename_prefix + uuid.uuid4().hex if filename_prefix else uuid.uuid4().hex
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
     s3_client: boto3.client = _utils.client(service_name="s3", session=boto3_session)
 
     # Sanitize table to respect Athena's standards
@@ -917,7 +919,11 @@ def to_json(  # pylint: disable=too-many-arguments,too-many-locals,too-many-stat
 
     if database and table:
         catalog_table_input = catalog._get_table_input(  # pylint: disable=protected-access
-            database=database, table=table, boto3_session=session, transaction_id=transaction_id, catalog_id=catalog_id
+            database=database,
+            table=table,
+            boto3_session=boto3_session,
+            transaction_id=transaction_id,
+            catalog_id=catalog_id,
         )
         catalog_path: Optional[str] = None
         if catalog_table_input:
@@ -982,7 +988,7 @@ def to_json(  # pylint: disable=too-many-arguments,too-many-locals,too-many-stat
                 description=description,
                 parameters=parameters,
                 columns_comments=columns_comments,
-                boto3_session=session,
+                boto3_session=boto3_session,
                 mode=mode,
                 transaction_id=transaction_id,
                 catalog_versioning=catalog_versioning,
@@ -1004,7 +1010,7 @@ def to_json(  # pylint: disable=too-many-arguments,too-many-locals,too-many-stat
             catalog_table_input = catalog._get_table_input(  # pylint: disable=protected-access
                 database=database,
                 table=table,
-                boto3_session=session,
+                boto3_session=boto3_session,
                 transaction_id=transaction_id,
                 catalog_id=catalog_id,
             )
@@ -1027,7 +1033,7 @@ def to_json(  # pylint: disable=too-many-arguments,too-many-locals,too-many-stat
         partitions_types=partitions_types,
         bucketing_info=bucketing_info,
         mode=mode,
-        boto3_session=session,
+        boto3_session=boto3_session,
         s3_additional_kwargs=s3_additional_kwargs,
         file_format="json",
         **pandas_kwargs,
@@ -1050,7 +1056,7 @@ def to_json(  # pylint: disable=too-many-arguments,too-many-locals,too-many-stat
                 description=description,
                 parameters=parameters,
                 columns_comments=columns_comments,
-                boto3_session=session,
+                boto3_session=boto3_session,
                 mode=mode,
                 transaction_id=transaction_id,
                 catalog_versioning=catalog_versioning,
@@ -1076,7 +1082,7 @@ def to_json(  # pylint: disable=too-many-arguments,too-many-locals,too-many-stat
                     table=table,
                     partitions_values=partitions_values,
                     bucketing_info=bucketing_info,
-                    boto3_session=session,
+                    boto3_session=boto3_session,
                     serde_library=serde_library,
                     serde_parameters=serde_parameters,
                     catalog_id=catalog_id,
@@ -1092,7 +1098,7 @@ def to_json(  # pylint: disable=too-many-arguments,too-many-locals,too-many-stat
             delete_objects(
                 path=paths,
                 use_threads=use_threads,
-                boto3_session=session,
+                boto3_session=boto3_session,
                 s3_additional_kwargs=s3_additional_kwargs,
             )
             raise

--- a/awswrangler/secretsmanager.py
+++ b/awswrangler/secretsmanager.py
@@ -34,8 +34,7 @@ def get_secret(name: str, boto3_session: Optional[boto3.Session] = None) -> Unio
     >>> value = wr.secretsmanager.get_secret("my-secret")
 
     """
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
-    client: boto3.client = _utils.client(service_name="secretsmanager", session=session)
+    client: boto3.client = _utils.client(service_name="secretsmanager", session=boto3_session)
     response: Dict[str, Any] = client.get_secret_value(SecretId=name)
     if "SecretString" in response:
         return cast(str, response["SecretString"])

--- a/awswrangler/sts.py
+++ b/awswrangler/sts.py
@@ -29,8 +29,7 @@ def get_account_id(boto3_session: Optional[boto3.Session] = None) -> str:
     >>> account_id = wr.sts.get_account_id()
 
     """
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
-    return cast(str, _utils.client(service_name="sts", session=session).get_caller_identity().get("Account"))
+    return cast(str, _utils.client(service_name="sts", session=boto3_session).get_caller_identity().get("Account"))
 
 
 def get_current_identity_arn(boto3_session: Optional[boto3.Session] = None) -> str:
@@ -52,8 +51,7 @@ def get_current_identity_arn(boto3_session: Optional[boto3.Session] = None) -> s
     >>> arn = wr.sts.get_current_identity_arn()
 
     """
-    session: boto3.Session = _utils.ensure_session(session=boto3_session)
-    return cast(str, _utils.client(service_name="sts", session=session).get_caller_identity().get("Arn"))
+    return cast(str, _utils.client(service_name="sts", session=boto3_session).get_caller_identity().get("Arn"))
 
 
 def get_current_identity_name(boto3_session: Optional[boto3.Session] = None) -> str:


### PR DESCRIPTION
### Detail
- Remove session serialization/deserialization in each thread due to huge memory impact of creating new session objects (due to boto3 loading service model from disk) & replace it with passing ready clients to threads
- Remove obsolete `_utils.ensure_session`

## Many small files

Memory profiler results on reading 15K x 1.2KB of Parquet files:

Before - 8GB resident tops:
<img width="870" alt="before" src="https://user-images.githubusercontent.com/3997468/214353986-698d8a39-d45c-4076-b1b6-c7c9ccdcae12.png">

After - 150MB resident tops:
<img width="865" alt="after" src="https://user-images.githubusercontent.com/3997468/214354060-b32e3443-bcb0-4f4c-9cd1-85d6289e194a.png">

## Couple large files

Just to make sure this doesn't have an impact with large files, below are memory profiler results on reading 3 large ±130MB Parquet files (25139500 rows):

<img width="869" alt="before_3x_large" src="https://user-images.githubusercontent.com/3997468/214357211-10746a0f-0499-4082-9e93-0edda9f22fd3.png">

<img width="870" alt="after_3x_large" src="https://user-images.githubusercontent.com/3997468/214357229-ac89b7a1-fc81-40fb-82bf-62b1b6110fb5.png">


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.