### PR TITLE
Unify return values for write json

### DIFF
--- a/tests/unit/test_s3_text.py
+++ b/tests/unit/test_s3_text.py
@@ -235,7 +235,7 @@ def test_to_text_filename_prefix(compare_filename_prefix, path, filename_prefix,
 
     # If Dataset is False, csv/json file should never start with prefix
     file_path = f"{path}0.json"
-    filename = wr.s3.to_json(df=df, path=file_path, use_threads=use_threads)[0].split("/")[-1]
+    filename = wr.s3.to_json(df=df, path=file_path, use_threads=use_threads)["paths"][0].split("/")[-1]
     assert not filename.startswith(test_prefix)
     file_path = f"{path}0.csv"
     filename = wr.s3.to_csv(


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Detail
Currently, `s3.to_parquet` and `s3.to_csv` return a dictionary containing the written paths along with the partition values. If the data was not written into partitions, the latter is empty.

Meanwhile, `s3.to_json` uses a different mechanism. If there are no partitions, the function returns a list. Otherwise, it returns the same dictionary as `s3.to_csv` and `s3.to_parquet`.

Since we are doing a major release, we are able to make a breaking change that will make this behavior consistent. In this PR, I've made `to_json` always return a dictionary. Alternatively, we can have `to_csv` and `to_parquet` have the same behavior as `to_json` currently has.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
