### PR TITLE
(Breaking Change): Use ExecuteStatement instead of Scan for DynamoDB read_partiql

### DIFF
--- a/awswrangler/dynamodb/__init__.py
+++ b/awswrangler/dynamodb/__init__.py
@@ -1,12 +1,13 @@
-"""Amazon DynamoDB Write Module."""
+"""Amazon DynamoDB Module."""
 
 from awswrangler.dynamodb._delete import delete_items
 from awswrangler.dynamodb._read import read_items, read_partiql_query
-from awswrangler.dynamodb._utils import get_table
+from awswrangler.dynamodb._utils import execute_statement, get_table
 from awswrangler.dynamodb._write import put_csv, put_df, put_items, put_json
 
 __all__ = [
     "delete_items",
+    "execute_statement",
     "get_table",
     "put_csv",
     "put_df",

--- a/awswrangler/dynamodb/_read.py
+++ b/awswrangler/dynamodb/_read.py
@@ -1,124 +1,79 @@
 """Amazon DynamoDB Read Module (PRIVATE)."""
 
 import logging
-import re
 from functools import wraps
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, TypeVar, Union, cast
+from typing import Any, Callable, Dict, Iterator, List, Literal, Optional, Sequence, TypeVar, Union, cast, overload
 
 import boto3
 import pandas as pd
 from boto3.dynamodb.conditions import ConditionBase
-from boto3.dynamodb.types import TypeDeserializer
 from botocore.exceptions import ClientError
 
 from awswrangler import _utils, exceptions
-from awswrangler.dynamodb._utils import get_table
+from awswrangler.dynamodb._utils import execute_statement, get_table
 
 _logger: logging.Logger = logging.getLogger(__name__)
 
 
-def _get_terms_groups(terms: List[str]) -> Tuple[List[str], List[str], List[str]]:
-    """Determine to which group of a PartiQL query each term belongs, e.g. it describes a column, table or filter."""
-    is_select_term = False
-    is_from_term = False
-    is_where_term = False
-    select_terms, from_terms, where_terms = [], [], []
-    for term in terms:
-        if term.upper() == "SELECT":
-            is_select_term = True
-            continue
-        if term.upper() == "FROM":
-            is_select_term = False
-            is_from_term = True
-            continue
-        if term.upper() == "WHERE":
-            is_from_term = False
-            is_where_term = True
-            continue
-        if is_select_term:
-            select_terms.append(term)
-        if is_from_term:
-            from_terms.append(term)
-        if is_where_term:
-            where_terms.append(term)
-    return select_terms, from_terms, where_terms
+def _read_chunked(iterator: Iterator[Dict[str, Any]]) -> Iterator[pd.DataFrame]:
+    for item in iterator:
+        yield pd.DataFrame(item)
 
 
-def _get_scan_response(
-    table_name: str, select_terms: List[str], boto3_session: Optional[boto3.Session] = None
-) -> List[Dict[str, Any]]:
-    """Perform a scan to the Dynamo DB table and returns the data fetched."""
-    client_dynamodb = _utils.client(service_name="dynamodb", session=boto3_session)
-    scan_config: Dict[str, Any] = {"TableName": table_name}
-    if len(select_terms) > 1 or select_terms[0] != "*":
-        scan_config["AttributesToGet"] = select_terms
-    # get all responses even if pagination is necessary
-    response = client_dynamodb.scan(**scan_config)
-    data: List[Dict[str, Any]] = response["Items"]
-    while "LastEvaluatedKey" in response:
-        scan_config["ExclusiveStartKey"] = response["LastEvaluatedKey"]
-        response = client_dynamodb.scan(**scan_config)
-        data.extend(response["Items"])
-    return data
-
-
-def _get_items(query: str, boto3_session: Optional[boto3.Session] = None) -> List[Dict[str, Any]]:
-    # clean input query from possible excessive whitespace
-    query = re.sub(" +", " ", query).strip()
-    # generate terms list from query
-    terms = re.split(" |,", query)
-    if terms[0].upper() != "SELECT":
-        raise ValueError("The PartiQL query does not start with a 'SELECT'.")
-    select_terms, from_terms, _ = _get_terms_groups(terms)
-    if len(from_terms) > 1:
-        raise ValueError("The PartiQL query contains multiple tables but only one needed.")
-    if len(from_terms) == 0:
-        raise ValueError("The PartiQL query contains no tables.")
-    table_name = from_terms[0]
-    return _get_scan_response(table_name=table_name, select_terms=select_terms, boto3_session=boto3_session)
-
-
-def _deserialize_value(value: Any) -> Any:
-    if not pd.isna(value):
-        return TypeDeserializer().deserialize(value)
-    return value
-
-
-def _deserialize_data(df: pd.DataFrame, columns: pd.Index) -> pd.DataFrame:
-    if df.shape[0] > 0:
-        for column in columns:
-            df[column] = df[column].apply(_deserialize_value)
-    return df
-
-
-def _parse_dynamodb_items(
-    items: List[Dict[str, Any]],
-    dtype: Optional[Dict[str, str]] = None,
+@overload
+def read_partiql_query(
+    query: str,
+    parameters: Optional[List[Any]] = ...,
+    chunked: Literal[False] = ...,
+    boto3_session: Optional[boto3.Session] = ...,
 ) -> pd.DataFrame:
-    df = pd.DataFrame(items)
-    df = _deserialize_data(df, df.columns)
-    return df.astype(dtype=dtype) if dtype else df
+    ...
+
+
+@overload
+def read_partiql_query(
+    query: str,
+    *,
+    parameters: Optional[List[Any]] = ...,
+    chunked: Literal[True],
+    boto3_session: Optional[boto3.Session] = ...,
+) -> Iterator[pd.DataFrame]:
+    ...
+
+
+@overload
+def read_partiql_query(
+    query: str,
+    *,
+    parameters: Optional[List[Any]] = ...,
+    chunked: bool,
+    boto3_session: Optional[boto3.Session] = ...,
+) -> Union[pd.DataFrame, Iterator[pd.DataFrame]]:
+    ...
 
 
 def read_partiql_query(
     query: str,
-    dtype: Optional[Dict[str, str]] = None,
+    parameters: Optional[List[Any]] = None,
+    chunked: bool = False,
     boto3_session: Optional[boto3.Session] = None,
-) -> pd.DataFrame:
+) -> Union[pd.DataFrame, Iterator[pd.DataFrame]]:
     """Read data from a DynamoDB table via a PartiQL query.
 
     Parameters
     ----------
     query : str
-        The PartiQL query that will be executed.
-    dtype : Dict, optional
-        The data types of the DataFrame columns.
-    boto3_session : boto3.Session(), optional
-        Boto3 Session. The default boto3 Session will be used if boto3_session receive None.
+        The PartiQL statement.
+    parameters : Optional[List[Any]]
+        The list of PartiQL parameters. These are applied to the statement in the order they are listed.
+    chunked : bool
+        If `True` an iterable of DataFrames is returned. False by default.
+    boto3_session : Optional[boto3.Session]
+        Boto3 Session. If None, the default boto3 Session is used.
 
     Returns
     -------
-    pd.DataFrame
+    Union[pd.DataFrame, Iterator[pd.DataFrame]]
         Result as Pandas DataFrame.
 
     Examples
@@ -127,27 +82,23 @@ def read_partiql_query(
 
     >>> import awswrangler as wr
     >>> wr.dynamodb.read_partiql_query(
-    ...     query='SELECT * FROM table'
+    ...     query="SELECT * FROM my_table WHERE title=? AND year=?",
+    ...     parameters=[title, year],
     ... )
 
     Select specific columns from a table
 
-    >>> import awswrangler as wr
     >>> wr.dynamodb.read_partiql_query(
-    ...     query='SELECT key FROM table'
-    ... )
-
-    Select all contents with dtype set
-
-    >>> import awswrangler as wr
-    >>> wr.dynamodb.read_partiql_query(
-    ...     query='SELECT * FROM table',
-    ...     dtype={'key': int}
+    ...     query="SELECT id FROM table"
     ... )
     """
-    _logger.debug("Reading results for PartiQL query:  %s", query)
-    items = _get_items(query=query, boto3_session=boto3_session)
-    return _parse_dynamodb_items(items=items, dtype=dtype)
+    _logger.debug("Reading results for PartiQL query:  '%s'", query)
+    iterator: Iterator[Dict[str, Any]] = execute_statement(  # type: ignore
+        query, parameters=parameters, boto3_session=boto3_session
+    )
+    if chunked:
+        return _read_chunked(iterator=iterator)
+    return pd.DataFrame([item for sublist in iterator for item in sublist])
 
 
 def _get_invalid_kwarg(msg: str) -> Optional[str]:
@@ -270,6 +221,68 @@ def _read_items(
             items.extend(response.get("Items", []))
 
     return items
+
+
+@overload
+def read_items(
+    table_name: str,
+    index_name: Optional[str] = ...,
+    partition_values: Optional[Sequence[Any]] = ...,
+    sort_values: Optional[Sequence[Any]] = ...,
+    filter_expression: Optional[Union[ConditionBase, str]] = ...,
+    key_condition_expression: Optional[Union[ConditionBase, str]] = ...,
+    expression_attribute_names: Optional[Dict[str, str]] = ...,
+    expression_attribute_values: Optional[Dict[str, Any]] = ...,
+    consistent: bool = ...,
+    columns: Optional[Sequence[str]] = ...,
+    allow_full_scan: bool = ...,
+    max_items_evaluated: Optional[int] = ...,
+    as_dataframe: Literal[True] = ...,
+    boto3_session: Optional[boto3.Session] = ...,
+) -> pd.DataFrame:
+    ...
+
+
+@overload
+def read_items(
+    table_name: str,
+    *,
+    index_name: Optional[str] = ...,
+    partition_values: Optional[Sequence[Any]] = ...,
+    sort_values: Optional[Sequence[Any]] = ...,
+    filter_expression: Optional[Union[ConditionBase, str]] = ...,
+    key_condition_expression: Optional[Union[ConditionBase, str]] = ...,
+    expression_attribute_names: Optional[Dict[str, str]] = ...,
+    expression_attribute_values: Optional[Dict[str, Any]] = ...,
+    consistent: bool = ...,
+    columns: Optional[Sequence[str]] = ...,
+    allow_full_scan: bool = ...,
+    max_items_evaluated: Optional[int] = ...,
+    as_dataframe: Literal[False],
+    boto3_session: Optional[boto3.Session] = ...,
+) -> List[Dict[str, Any]]:
+    ...
+
+
+@overload
+def read_items(
+    table_name: str,
+    *,
+    index_name: Optional[str] = ...,
+    partition_values: Optional[Sequence[Any]] = ...,
+    sort_values: Optional[Sequence[Any]] = ...,
+    filter_expression: Optional[Union[ConditionBase, str]] = ...,
+    key_condition_expression: Optional[Union[ConditionBase, str]] = ...,
+    expression_attribute_names: Optional[Dict[str, str]] = ...,
+    expression_attribute_values: Optional[Dict[str, Any]] = ...,
+    consistent: bool = ...,
+    columns: Optional[Sequence[str]] = ...,
+    allow_full_scan: bool = ...,
+    max_items_evaluated: Optional[int] = ...,
+    as_dataframe: bool,
+    boto3_session: Optional[boto3.Session] = ...,
+) -> Union[pd.DataFrame, List[Dict[str, Any]]]:
+    ...
 
 
 def read_items(  # pylint: disable=too-many-branches

--- a/awswrangler/dynamodb/_read.py
+++ b/awswrangler/dynamodb/_read.py
@@ -2,7 +2,7 @@
 
 import logging
 from functools import wraps
-from typing import Any, Callable, Dict, Iterator, List, Literal, Optional, Sequence, TypeVar, Union, cast, overload
+from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence, TypeVar, Union, cast
 
 import boto3
 import pandas as pd
@@ -18,38 +18,6 @@ _logger: logging.Logger = logging.getLogger(__name__)
 def _read_chunked(iterator: Iterator[Dict[str, Any]]) -> Iterator[pd.DataFrame]:
     for item in iterator:
         yield pd.DataFrame(item)
-
-
-@overload
-def read_partiql_query(
-    query: str,
-    parameters: Optional[List[Any]] = ...,
-    chunked: Literal[False] = ...,
-    boto3_session: Optional[boto3.Session] = ...,
-) -> pd.DataFrame:
-    ...
-
-
-@overload
-def read_partiql_query(
-    query: str,
-    *,
-    parameters: Optional[List[Any]] = ...,
-    chunked: Literal[True],
-    boto3_session: Optional[boto3.Session] = ...,
-) -> Iterator[pd.DataFrame]:
-    ...
-
-
-@overload
-def read_partiql_query(
-    query: str,
-    *,
-    parameters: Optional[List[Any]] = ...,
-    chunked: bool,
-    boto3_session: Optional[boto3.Session] = ...,
-) -> Union[pd.DataFrame, Iterator[pd.DataFrame]]:
-    ...
 
 
 def read_partiql_query(
@@ -221,68 +189,6 @@ def _read_items(
             items.extend(response.get("Items", []))
 
     return items
-
-
-@overload
-def read_items(
-    table_name: str,
-    index_name: Optional[str] = ...,
-    partition_values: Optional[Sequence[Any]] = ...,
-    sort_values: Optional[Sequence[Any]] = ...,
-    filter_expression: Optional[Union[ConditionBase, str]] = ...,
-    key_condition_expression: Optional[Union[ConditionBase, str]] = ...,
-    expression_attribute_names: Optional[Dict[str, str]] = ...,
-    expression_attribute_values: Optional[Dict[str, Any]] = ...,
-    consistent: bool = ...,
-    columns: Optional[Sequence[str]] = ...,
-    allow_full_scan: bool = ...,
-    max_items_evaluated: Optional[int] = ...,
-    as_dataframe: Literal[True] = ...,
-    boto3_session: Optional[boto3.Session] = ...,
-) -> pd.DataFrame:
-    ...
-
-
-@overload
-def read_items(
-    table_name: str,
-    *,
-    index_name: Optional[str] = ...,
-    partition_values: Optional[Sequence[Any]] = ...,
-    sort_values: Optional[Sequence[Any]] = ...,
-    filter_expression: Optional[Union[ConditionBase, str]] = ...,
-    key_condition_expression: Optional[Union[ConditionBase, str]] = ...,
-    expression_attribute_names: Optional[Dict[str, str]] = ...,
-    expression_attribute_values: Optional[Dict[str, Any]] = ...,
-    consistent: bool = ...,
-    columns: Optional[Sequence[str]] = ...,
-    allow_full_scan: bool = ...,
-    max_items_evaluated: Optional[int] = ...,
-    as_dataframe: Literal[False],
-    boto3_session: Optional[boto3.Session] = ...,
-) -> List[Dict[str, Any]]:
-    ...
-
-
-@overload
-def read_items(
-    table_name: str,
-    *,
-    index_name: Optional[str] = ...,
-    partition_values: Optional[Sequence[Any]] = ...,
-    sort_values: Optional[Sequence[Any]] = ...,
-    filter_expression: Optional[Union[ConditionBase, str]] = ...,
-    key_condition_expression: Optional[Union[ConditionBase, str]] = ...,
-    expression_attribute_names: Optional[Dict[str, str]] = ...,
-    expression_attribute_values: Optional[Dict[str, Any]] = ...,
-    consistent: bool = ...,
-    columns: Optional[Sequence[str]] = ...,
-    allow_full_scan: bool = ...,
-    max_items_evaluated: Optional[int] = ...,
-    as_dataframe: bool,
-    boto3_session: Optional[boto3.Session] = ...,
-) -> Union[pd.DataFrame, List[Dict[str, Any]]]:
-    ...
 
 
 def read_items(  # pylint: disable=too-many-branches

--- a/awswrangler/dynamodb/_utils.py
+++ b/awswrangler/dynamodb/_utils.py
@@ -1,11 +1,15 @@
 """Amazon DynamoDB Utils Module (PRIVATE)."""
 
-from typing import Any, Dict, List, Mapping, Optional, Union
+import logging
+from typing import Any, Dict, Iterator, List, Mapping, Optional, Union
 
 import boto3
+from botocore.exceptions import ClientError
 
 from awswrangler import _utils, exceptions
 from awswrangler._config import apply_configs
+
+_logger: logging.Logger = logging.getLogger(__name__)
 
 
 @apply_configs
@@ -20,7 +24,7 @@ def get_table(
     table_name : str
         Name of the Amazon DynamoDB table.
     boto3_session : Optional[boto3.Session()]
-        Boto3 Session. The default boto3 Session will be used if boto3_session receive None.
+        Boto3 Session. If None, the default boto3 Session is used.
 
     Returns
     -------
@@ -32,6 +36,103 @@ def get_table(
     dynamodb_table = dynamodb_resource.Table(table_name)
 
     return dynamodb_table
+
+
+def _execute_statement(
+    kwargs: Dict[str, Union[str, bool, List[Any]]],
+    boto3_session: Optional[boto3.Session],
+) -> Dict[str, Any]:
+    dynamodb_resource = _utils.resource(service_name="dynamodb", session=boto3_session)
+    try:
+        response: Dict[str, Any] = dynamodb_resource.meta.client.execute_statement(**kwargs)
+    except ClientError as err:
+        if err.response["Error"]["Code"] == "ResourceNotFoundException":
+            _logger.error("Couldn't execute PartiQL: '%s' because the table does not exist.", kwargs["Statement"])
+        else:
+            _logger.error(
+                "Couldn't execute PartiQL: '%s'. %s: %s",
+                kwargs["Statement"],
+                err.response["Error"]["Code"],
+                err.response["Error"]["Message"],
+            )
+        raise
+    return response
+
+
+def _read_execute_statement(
+    kwargs: Dict[str, Union[str, bool, List[Any]]], boto3_session: Optional[boto3.Session]
+) -> Iterator[Dict[str, Any]]:
+    next_token: str = "init_token"  # Dummy token
+    while next_token:
+        response = _execute_statement(kwargs=kwargs, boto3_session=boto3_session)
+        next_token = response.get("NextToken", None)
+        kwargs["NextToken"] = next_token
+        yield response["Items"]
+
+
+def execute_statement(
+    statement: str,
+    parameters: Optional[List[Any]] = None,
+    consistent_read: bool = False,
+    boto3_session: Optional[boto3.Session] = None,
+) -> Optional[Iterator[Dict[str, Any]]]:
+    """Run a PartiQL statement against a DynamoDB table.
+
+    Parameters
+    ----------
+    statement : str
+        The PartiQL statement.
+    parameters : Optional[List[Any]]
+        The list of PartiQL parameters. These are applied to the statement in the order they are listed.
+    consistent_read: bool
+        The consistency of a read operation. If `True`, then a strongly consistent read is used. False by default.
+    boto3_session : Optional[boto3.Session]
+        Boto3 Session. If None, the default boto3 Session is used.
+
+    Returns
+    -------
+    Optional[Iterator[Dict[str, Any]]]
+        An iterator of the items from the statement response, if any.
+
+    Examples
+    --------
+    Insert an item
+
+    >>> import awswrangler as wr
+    >>> wr.dynamodb.execute_statement(
+    ...     statement="INSERT INTO movies VALUE {'title': ?, 'year': ?, 'info': ?}",
+    ...     parameters=[title, year, {"plot": plot, "rating": rating}],
+    ... )
+
+    Select items
+
+    >>> wr.dynamodb.execute_statement(
+    ...     statement="SELECT * FROM movies WHERE title=? AND year=?",
+    ...     parameters=[title, year],
+    ... )
+
+    Update items
+
+    >>> wr.dynamodb.execute_statement(
+    ...     statement="UPDATE movies SET info.rating=? WHERE title=? AND year=?",
+    ...     parameters=[rating, title, year],
+    ... )
+
+    Delete items
+
+    >>> wr.dynamodb.execute_statement(
+    ...     statement="DELETE FROM movies WHERE title=? AND year=?",
+    ...     parameters=[title, year],
+    ... )
+    """
+    kwargs: Dict[str, Union[str, bool, List[Any]]] = {"Statement": statement, "ConsistentRead": consistent_read}
+    if parameters:
+        kwargs["Parameters"] = parameters
+
+    if not statement.strip().upper().startswith("SELECT"):
+        _execute_statement(kwargs=kwargs, boto3_session=boto3_session)
+        return None
+    return _read_execute_statement(kwargs=kwargs, boto3_session=boto3_session)
 
 
 def _validate_items(

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -302,12 +302,14 @@ DynamoDB
     :toctree: stubs
 
     delete_items
+    execute_statement
     get_table
-    read_items
     put_csv
     put_df
     put_items
     put_json
+    read_items
+    read_partiql_query
 
 Amazon Timestream
 -----------------

--- a/tests/test_dynamodb.py
+++ b/tests/test_dynamodb.py
@@ -1,4 +1,5 @@
 import tempfile
+from datetime import datetime
 from decimal import Decimal
 
 import pandas as pd
@@ -30,7 +31,7 @@ def test_write(params, dynamodb_table):
         }
     )
     path = tempfile.gettempdir()
-    query = f"SELECT * FROM {dynamodb_table}"
+    query = f'SELECT * FROM "{dynamodb_table}"'
 
     # JSON
     file_path = f"{path}/movies.json"
@@ -46,6 +47,143 @@ def test_write(params, dynamodb_table):
     wr.dynamodb.put_csv(file_path, dynamodb_table)
     df3 = wr.dynamodb.read_partiql_query(query)
     assert df.shape == df3.shape
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {
+            "KeySchema": [{"AttributeName": "par0", "KeyType": "HASH"}, {"AttributeName": "par1", "KeyType": "RANGE"}],
+            "AttributeDefinitions": [
+                {"AttributeName": "par0", "AttributeType": "N"},
+                {"AttributeName": "par1", "AttributeType": "S"},
+            ],
+        }
+    ],
+)
+def test_read_partiql(params, dynamodb_table):
+    df = pd.DataFrame(
+        {
+            "par0": [1, 1, 2],
+            "par1": ["a", "b", "b"],
+            "iint64": [1, 2, 3],
+            "string": ["Seattle", "New York", "Washington"],
+            "decimal": [Decimal(1.0), Decimal(2.0), Decimal(3.0)],
+            "bool": [True, False, False],
+            "binary": [b"0", b"1", b"2"],
+        }
+    )
+
+    wr.dynamodb.put_df(df=df, table_name=dynamodb_table)
+
+    query: str = f'SELECT * FROM "{dynamodb_table}"'
+    df2 = wr.dynamodb.read_partiql_query(
+        query=f'SELECT * FROM "{dynamodb_table}" WHERE par0=? AND par1=?',
+        parameters=[2, "b"],
+    )
+    assert df2.shape == (1, len(df.columns))
+
+    dfs = wr.dynamodb.read_partiql_query(query, chunked=True)
+    assert df.shape == pd.concat(dfs).shape
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {
+            "KeySchema": [{"AttributeName": "title", "KeyType": "HASH"}, {"AttributeName": "year", "KeyType": "RANGE"}],
+            "AttributeDefinitions": [
+                {"AttributeName": "title", "AttributeType": "S"},
+                {"AttributeName": "year", "AttributeType": "N"},
+            ],
+        }
+    ],
+)
+def test_execute_statement(params, dynamodb_table):
+    df = pd.DataFrame(
+        {
+            "title": ["Titanic", "Snatch", "The Godfather"],
+            "year": [1997, 2000, 1972],
+            "genre": ["drama", "caper story", "crime"],
+        }
+    )
+
+    wr.dynamodb.put_df(df=df, table_name=dynamodb_table)
+
+    title = "The Lord of the Rings: The Fellowship of the Ring"
+    year = datetime.now().year
+    genre = "epic"
+    rating = Decimal("9.9")
+    plot = "The fate of Middle-earth hangs in the balance as Frodo and his companions begin their journey to Mount Doom"
+
+    # Insert items
+    wr.dynamodb.execute_statement(
+        statement=f"INSERT INTO {dynamodb_table} VALUE {{'title': ?, 'year': ?, 'genre': ?, 'info': ?}}",
+        parameters=[title, year, genre, {"plot": plot, "rating": rating}],
+    )
+
+    # Select items
+    items = wr.dynamodb.execute_statement(
+        statement=f'SELECT * FROM "{dynamodb_table}" WHERE title=? AND year=?',
+        parameters=[title, year],
+    )
+    assert len(list(items)) == 1
+
+    # Update items
+    wr.dynamodb.execute_statement(
+        statement=f'UPDATE "{dynamodb_table}" SET info.rating=? WHERE title=? AND year=?',
+        parameters=[Decimal(10), title, year],
+    )
+    df2 = wr.dynamodb.read_partiql_query(
+        query=f'SELECT info FROM "{dynamodb_table}" WHERE title=? AND year=?',
+        parameters=[title, year],
+    )
+    info = df2.iloc[0, 0]
+    assert info["rating"] == 10
+
+    # Delete items
+    wr.dynamodb.execute_statement(
+        statement=f'DELETE FROM "{dynamodb_table}" WHERE title=? AND year=?',
+        parameters=[title, year],
+    )
+    df3 = wr.dynamodb.read_partiql_query(f'SELECT * FROM "{dynamodb_table}"')
+    assert df.shape == df3.shape
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {
+            "KeySchema": [{"AttributeName": "par0", "KeyType": "HASH"}, {"AttributeName": "par1", "KeyType": "RANGE"}],
+            "AttributeDefinitions": [
+                {"AttributeName": "par0", "AttributeType": "N"},
+                {"AttributeName": "par1", "AttributeType": "S"},
+            ],
+        }
+    ],
+)
+@pytest.mark.parametrize("format", ["csv", "json"])
+def test_dynamodb_put_from_file(format, params, dynamodb_table, local_filename) -> None:
+    df = pd.DataFrame({"par0": [1, 2], "par1": ["foo", "boo"]})
+
+    if format == "csv":
+        df.to_csv(local_filename, index=False)
+        wr.dynamodb.put_csv(
+            path=local_filename,
+            table_name=dynamodb_table,
+        )
+    elif format == "json":
+        df.to_json(local_filename, orient="records")
+        wr.dynamodb.put_json(
+            path=local_filename,
+            table_name=dynamodb_table,
+        )
+    else:
+        raise RuntimeError(f"Unknown format {format}")
+
+    df2 = wr.dynamodb.read_partiql_query(query=f"SELECT * FROM {dynamodb_table}")
+
+    assert df.shape == df2.shape
 
 
 @pytest.mark.parametrize(

--- a/tests/test_moto.py
+++ b/tests/test_moto.py
@@ -1,6 +1,5 @@
 import logging
 import os
-from typing import Any
 from unittest import mock
 from unittest.mock import ANY
 
@@ -513,52 +512,9 @@ def test_dynamodb_basic_usage(moto_dynamodb):
     table = wr.dynamodb.get_table(table_name=table_name)
     assert table.item_count == len(items)
 
-    query: str = "SELECT * FROM table"
-    df = wr.dynamodb.read_partiql_query(query)
-    assert df.shape[0] == len(items)
-
     wr.dynamodb.delete_items(items=items, table_name=table_name)
     table = wr.dynamodb.get_table(table_name=table_name)
     assert table.item_count == 0
-
-
-@pytest.mark.parametrize("format", ["csv", "json"])
-def test_dynamodb_put_from_file(moto_dynamodb: Any, local_filename: str, format: str) -> None:
-    table_name = "table"
-    df = pd.DataFrame({"key": [1, 2], "value": ["foo", "boo"]})
-
-    if format == "csv":
-        df.to_csv(local_filename, index=False)
-        wr.dynamodb.put_csv(
-            path=local_filename,
-            table_name=table_name,
-        )
-    elif format == "json":
-        df.to_json(local_filename, orient="records")
-        wr.dynamodb.put_json(
-            path=local_filename,
-            table_name=table_name,
-        )
-    else:
-        raise RuntimeError(f"Unknown format {format}")
-
-    df2 = wr.dynamodb.read_partiql_query(query="SELECT * FROM table")
-
-    assert df.shape == df2.shape
-
-
-def test_dynamodb_partiql(moto_dynamodb):
-    table_name = "table"
-    items = [{"key": 1}, {"key": 2, "my_value": "Hello"}]
-
-    wr.dynamodb.put_items(items=items, table_name=table_name)
-    query: str = "SELECT * FROM table"
-    df = wr.dynamodb.read_partiql_query(query)
-    assert df.shape[0] == len(items)
-
-    dtype = {"key": int, "my_value": str}
-    df = wr.dynamodb.read_partiql_query(query, dtype=dtype)
-    assert df.shape[0] == len(items)
 
 
 def test_dynamodb_fail_on_invalid_items(moto_dynamodb):

--- a/tutorials/028 - DynamoDB.ipynb
+++ b/tutorials/028 - DynamoDB.ipynb
@@ -16,174 +16,288 @@
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "## Writing Data"
-   ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "source": [
+    "## Writing Data"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 23,
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
+    "from datetime import datetime\n",
+    "from decimal import Decimal\n",
+    "from pathlib import Path\n",
+    "\n",
     "import awswrangler as wr\n",
     "import pandas as pd\n",
-    "from pathlib import Path"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+    "from boto3.dynamodb.conditions import Attr, Key"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "### Writing DataFrame"
-   ],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "### Writing DataFrame"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "outputs": [],
-   "source": [
-    "df = pd.DataFrame({\n",
-    "    \"key\": [1, 2],\n",
-    "    \"value\": [\"foo\", \"boo\"]\n",
-    "})\n",
-    "wr.dynamodb.put_df(df=df, table_name=\"table\")"
-   ],
+   "execution_count": 27,
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "table_name = \"movies\"\n",
+    "\n",
+    "df = pd.DataFrame({\n",
+    "    \"title\": [\"Titanic\", \"Snatch\", \"The Godfather\"],\n",
+    "    \"year\": [1997, 2000, 1972],\n",
+    "    \"genre\": [\"drama\", \"caper story\", \"crime\"],\n",
+    "})\n",
+    "wr.dynamodb.put_df(df=df, table_name=table_name)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "### Writing CSV file"
-   ],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "### Writing CSV file"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "filepath = Path(\"items.csv\")\n",
     "df.to_csv(filepath, index=False)\n",
-    "wr.dynamodb.put_csv(path=filepath, table_name=\"table\")\n",
+    "wr.dynamodb.put_csv(path=filepath, table_name=table_name)\n",
     "filepath.unlink()"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "### Writing JSON files"
-   ],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "### Writing JSON files"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "filepath = Path(\"items.json\")\n",
     "df.to_json(filepath, orient=\"records\")\n",
-    "wr.dynamodb.put_json(path=\"items.json\", table_name=\"table\")\n",
+    "wr.dynamodb.put_json(path=\"items.json\", table_name=table_name)\n",
     "filepath.unlink()"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "### Writing list of items"
-   ],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "### Writing list of items"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "outputs": [],
-   "source": [
-    "items = df.to_dict(orient=\"records\")\n",
-    "wr.dynamodb.put_items(items=items, table_name=\"table\")"
-   ],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "items = df.to_dict(orient=\"records\")\n",
+    "wr.dynamodb.put_items(items=items, table_name=table_name)"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
-    "## Deleting items"
+    "## Reading Data"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Read PartiQL"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# PartiQL Query\n",
+    "wr.dynamodb.read_partiql_query(\n",
+    "    query=f\"SELECT * FROM {table_name} WHERE title=? AND year=?\",\n",
+    "    parameters=[\"Snatch\", 2000],\n",
+    ")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Read Items"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Limit Read to 5 items\n",
+    "wr.dynamodb.read_items(table_name=table_name, max_items_evaluated=5)\n",
+    "\n",
+    "# Limit Read to Key expression\n",
+    "wr.dynamodb.read_items(\n",
+    "    table_name=table_name,\n",
+    "    key_condition_expression=(Key(\"title\").eq(\"Snatch\") & Key(\"year\").eq(2000))\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Executing statements"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[]"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
    ],
+   "source": [
+    "title = \"The Lord of the Rings: The Fellowship of the Ring\"\n",
+    "year = datetime.now().year\n",
+    "genre = \"epic\"\n",
+    "rating = Decimal('9.9')\n",
+    "plot = \"The fate of Middle-earth hangs in the balance as Frodo and eight companions begin their journey to Mount Doom in the land of Mordor.\"\n",
+    "\n",
+    "# Insert items\n",
+    "wr.dynamodb.execute_statement(\n",
+    "    statement=f\"INSERT INTO {table_name} VALUE {{'title': ?, 'year': ?, 'genre': ?, 'info': ?}}\",\n",
+    "    parameters=[title, year, genre, {\"plot\": plot, \"rating\": rating}],\n",
+    ")\n",
+    "\n",
+    "# Select items\n",
+    "wr.dynamodb.execute_statement(\n",
+    "    statement=f\"SELECT * FROM \\\"{table_name}\\\" WHERE title=? AND year=?\",\n",
+    "    parameters=[title, year],\n",
+    ")\n",
+    "\n",
+    "# Update items\n",
+    "wr.dynamodb.execute_statement(\n",
+    "    statement=f\"UPDATE \\\"{table_name}\\\" SET info.rating=? WHERE title=? AND year=?\",\n",
+    "    parameters=[Decimal(10), title, year],\n",
+    ")\n",
+    "\n",
+    "# Delete items\n",
+    "wr.dynamodb.execute_statement(\n",
+    "    statement=f\"DELETE FROM \\\"{table_name}\\\" WHERE title=? AND year=?\",\n",
+    "    parameters=[title, year],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "## Deleting items"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "outputs": [],
-   "source": [
-    "wr.dynamodb.delete_items(items=items, table_name=\"table\")"
-   ],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "wr.dynamodb.delete_items(items=items, table_name=\"table\")"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.9.14",
+   "display_name": "Python 3.8.5 ('awswrangler-mo8sEp3D-py3.8')",
    "language": "python",
    "name": "python3"
   },
@@ -197,7 +311,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.14"
+   "version": "3.8.5"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "350d68fa765a50d15f89103ff6102f3b96ae3e7bdc6e5e7a4956e4c1d21b94bd"
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Breaking Change

### Detail
- Use ExecuteStatement instead of Scan for DynamoDB `read_partiql`
- Add `execute_statement` method

### Relates
- #1571

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
