### PR TITLE
(feat): Distribute DynamoDB Parallel Scan

### DIFF
--- a/awswrangler/_utils.py
+++ b/awswrangler/_utils.py
@@ -27,6 +27,11 @@ _logger: logging.Logger = logging.getLogger(__name__)
 Boto3PrimitivesType = Dict[str, Optional[str]]
 
 
+def flatten_list(elements: List[List[Any]]) -> List[Any]:
+    """Flatten a list of lists."""
+    return [item for sublist in elements for item in sublist]
+
+
 def ensure_session(session: Union[None, boto3.Session] = None) -> boto3.Session:
     """Ensure that a valid boto3.Session will be returned."""
     if session is not None:

--- a/awswrangler/distributed/ray/_register.py
+++ b/awswrangler/distributed/ray/_register.py
@@ -4,6 +4,7 @@ from awswrangler._data_types import pyarrow_types_from_pandas
 from awswrangler._distributed import MemoryFormatEnum, engine, memory_format
 from awswrangler._utils import copy_df_shallow, is_pandas_frame, split_pandas_frame, table_refs_to_df
 from awswrangler.distributed.ray import ray_remote
+from awswrangler.dynamodb._read import _read_scan
 from awswrangler.lakeformation._read import _get_work_unit_results
 from awswrangler.s3._delete import _delete_objects
 from awswrangler.s3._read_parquet import _read_parquet, _read_parquet_metadata_file
@@ -22,6 +23,7 @@ def register_ray() -> None:
         _get_work_unit_results,
         _delete_objects,
         _read_parquet_metadata_file,
+        _read_scan,
         _select_query,
         _select_object_content,
         _wait_object_batch,

--- a/awswrangler/dynamodb/_read.py
+++ b/awswrangler/dynamodb/_read.py
@@ -1,16 +1,22 @@
 """Amazon DynamoDB Read Module (PRIVATE)."""
 
+import itertools
 import logging
 from functools import wraps
 from typing import Any, Callable, Dict, Iterator, List, Literal, Optional, Sequence, TypeVar, Union, cast, overload
 
 import boto3
 import pandas as pd
+import pyarrow as pa
 from boto3.dynamodb.conditions import ConditionBase
+from boto3.dynamodb.types import Binary
 from botocore.exceptions import ClientError
 
-from awswrangler import _utils, exceptions
-from awswrangler.dynamodb._utils import execute_statement, get_table
+from awswrangler import _data_types, _utils, exceptions
+from awswrangler._distributed import engine
+from awswrangler._threading import _get_executor
+from awswrangler.distributed.ray import ray_get
+from awswrangler.dynamodb._utils import _serialize_kwargs, execute_statement, get_table
 
 _logger: logging.Logger = logging.getLogger(__name__)
 
@@ -121,7 +127,7 @@ def _get_invalid_kwarg(msg: str) -> Optional[str]:
 
 
 # SEE: https://stackoverflow.com/a/72295070
-CustomCallable = TypeVar("CustomCallable", bound=Callable[[Any], Sequence[Dict[str, Any]]])
+CustomCallable = TypeVar("CustomCallable", bound=Callable[[Any], List[Dict[str, Any]]])
 
 
 def _handle_reserved_keyword_error(func: CustomCallable) -> CustomCallable:
@@ -132,12 +138,12 @@ def _handle_reserved_keyword_error(func: CustomCallable) -> CustomCallable:
     """
 
     @wraps(func)
-    def wrapper(*args: Any, **kwargs: Any) -> Sequence[Dict[str, Any]]:
+    def wrapper(*args: Any, **kwargs: Any) -> List[Dict[str, Any]]:
         try:
             return func(*args, **kwargs)
         except ClientError as e:
             error_code, error_message = (e.response["Error"]["Code"], e.response["Error"]["Message"])
-            # Check catched error to verify its message
+            # Check caught error to verify its message
             kwarg = _get_invalid_kwarg(error_message)
             if (error_code == "ValidationException") and kwarg:
                 reserved_keyword = error_message.split("keyword: ")[-1]
@@ -157,30 +163,106 @@ def _handle_reserved_keyword_error(func: CustomCallable) -> CustomCallable:
     return cast(CustomCallable, wrapper)
 
 
+def _convert_items(
+    items: List[Dict[str, Any]], as_dataframe: bool, arrow_kwargs: Dict[str, Any]
+) -> Union[pd.DataFrame, List[Dict[str, Any]]]:
+    return (
+        _utils.table_refs_to_df(
+            [
+                _utils.list_to_arrow_table(
+                    # Must convert DynamoDb "Binary" type as it is not a native Python data type
+                    mapping=[{k: v.value if isinstance(v, Binary) else v for k, v in d.items()} for d in items]
+                )
+            ],
+            arrow_kwargs,
+        )
+        if as_dataframe
+        else items
+    )
+
+
+@engine.dispatch_on_engine
+@_utils.retry(
+    ex=ClientError,
+    ex_code="ProvisionedThroughputExceededException",
+)
+def _read_scan(
+    dynamodb_client: Optional[boto3.client],
+    as_dataframe: bool,
+    kwargs: Dict[str, Any],
+    segment: int,
+) -> Union[pa.Table, List[Dict[str, Any]]]:
+    # SEE: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.ParallelScan
+    client_dynamodb: boto3.client = dynamodb_client if dynamodb_client else _utils.client(service_name="dynamodb")
+
+    deserializer = boto3.dynamodb.types.TypeDeserializer()
+    next_token: str = "init_token"  # Dummy token
+    items: List[Dict[str, Any]] = []
+
+    while next_token:
+        _logger.debug("segment: %s", segment)
+        response = _handle_reserved_keyword_error(client_dynamodb.scan)(**kwargs, Segment=segment)
+        # Unlike a resource, the DynamoDB client returns serialized results, so they must be deserialized
+        # Must convert DynamoDb "Binary" type as it is not a native Python data type
+        # SEE: https://boto3.amazonaws.com/v1/documentation/api/latest/_modules/boto3/dynamodb/types.html
+        items.extend(
+            [
+                {k: v["B"] if list(v.keys())[0] == "B" else deserializer.deserialize(v) for k, v in d.items()}
+                for d in response.get("Items", [])
+            ]
+        )
+        next_token = response.get("LastEvaluatedKey", None)
+        kwargs["ExclusiveStartKey"] = next_token
+    return _utils.list_to_arrow_table(mapping=items) if as_dataframe else items
+
+
 @_handle_reserved_keyword_error
-def _read_items(
-    table_name: str, boto3_session: Optional[boto3.Session] = None, **kwargs: Any
-) -> Sequence[Dict[str, Any]]:
-    """Read items from given DynamoDB table.
-
-    This function set the optimal reading strategy based on the received kwargs.
-
-    Parameters
-    ----------
-    table_name : str
-        DynamoDB table name.
-    boto3_session : boto3.Session, optional
-        Boto3 Session. Defaults to None (the default boto3 Session will be used).
-
-    Returns
-    -------
-    Sequence[Mapping[str, Any]]
-        Retrieved items.
-    """
-    # Get DynamoDB resource and Table instance
-    resource = _utils.resource(service_name="dynamodb", session=boto3_session)
+def _read_query(table_name: str, boto3_session: Optional[boto3.Session] = None, **kwargs: Any) -> List[Dict[str, Any]]:
     table = get_table(table_name=table_name, boto3_session=boto3_session)
+    response = table.query(**kwargs)
+    items: List[Dict[str, Any]] = response.get("Items", [])
 
+    # Handle pagination
+    while "LastEvaluatedKey" in response:
+        kwargs["ExclusiveStartKey"] = response["LastEvaluatedKey"]
+        response = table.query(**kwargs)
+        items.extend(response.get("Items", []))
+    return items
+
+
+@_handle_reserved_keyword_error
+def _read_batch_items(
+    table_name: str, boto3_session: Optional[boto3.Session] = None, **kwargs: Any
+) -> List[Dict[str, Any]]:
+    resource = _utils.resource(service_name="dynamodb", session=boto3_session)
+    response = resource.batch_get_item(RequestItems={table_name: kwargs})
+    items: List[Dict[str, Any]] = response.get("Responses", {table_name: []}).get(table_name, [])
+
+    # SEE: handle possible unprocessed keys. As suggested in Boto3 docs,
+    # this approach should involve exponential backoff, but this should be
+    # already managed by AWS SDK itself, as stated
+    # [here](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Programming.Errors.html)
+    while response["UnprocessedKeys"]:
+        kwargs["Keys"] = response["UnprocessedKeys"][table_name]["Keys"]
+        response = resource.batch_get_item(RequestItems={table_name: kwargs})
+        items.extend(response.get("Responses", {table_name: []}).get(table_name, []))
+    return items
+
+
+@_handle_reserved_keyword_error
+def _read_item(table_name: str, boto3_session: Optional[boto3.Session] = None, **kwargs: Any) -> List[Dict[str, Any]]:
+    table = get_table(table_name=table_name, boto3_session=boto3_session)
+    return [table.get_item(**kwargs).get("Item", {})]
+
+
+def _read_items(
+    table_name: str,
+    as_dataframe: bool,
+    arrow_kwargs: Dict[str, Any],
+    use_threads: Union[bool, int],
+    boto3_session: Optional[boto3.Session] = None,
+    **kwargs: Any,
+) -> Union[pd.DataFrame, List[Dict[str, Any]]]:
     # Extract 'Keys' and 'IndexName' from provided kwargs: if needed, will be reinserted later on
     keys = kwargs.pop("Keys", None)
     index = kwargs.pop("IndexName", None)
@@ -189,38 +271,36 @@ def _read_items(
     use_get_item = (keys is not None) and (len(keys) == 1)
     use_batch_get_item = (keys is not None) and (len(keys) > 1)
     use_query = (keys is None) and ("KeyConditionExpression" in kwargs)
-    use_scan = (keys is None) and ("KeyConditionExpression" not in kwargs)
 
-    # Read items
+    # Single Item
     if use_get_item:
         kwargs["Key"] = keys[0]
-        items = [table.get_item(**kwargs).get("Item", {})]
-    elif use_batch_get_item:
+        return _convert_items(_read_item(table_name, boto3_session, **kwargs), as_dataframe, arrow_kwargs)
+
+    # Batch of Items
+    if use_batch_get_item:
         kwargs["Keys"] = keys
-        response = resource.batch_get_item(RequestItems={table_name: kwargs})
-        items = response.get("Responses", {table_name: []}).get(table_name, [])
-        # SEE: handle possible unprocessed keys. As suggested in Boto3 docs,
-        # this approach should involve exponential backoff, but this should be
-        # already managed by AWS SDK itself, as stated
-        # [here](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Programming.Errors.html)
-        while response["UnprocessedKeys"]:
-            kwargs["Keys"] = response["UnprocessedKeys"][table_name]["Keys"]
-            response = resource.batch_get_item(RequestItems={table_name: kwargs})
-            items.extend(response.get("Responses", {table_name: []}).get(table_name, []))
-    elif use_query or use_scan:
-        if index:
-            kwargs["IndexName"] = index
-        _read_method = table.query if use_query else table.scan
-        response = _read_method(**kwargs)
-        items = response.get("Items", [])
+        return _convert_items(_read_batch_items(table_name, boto3_session, **kwargs), as_dataframe, arrow_kwargs)
 
-        # Handle pagination
-        while "LastEvaluatedKey" in response:
-            kwargs["ExclusiveStartKey"] = response["LastEvaluatedKey"]
-            response = _read_method(**kwargs)
-            items.extend(response.get("Items", []))
+    if index:
+        kwargs["IndexName"] = index
 
-    return items
+    # Query
+    if use_query:
+        return _convert_items(_read_query(table_name, boto3_session, **kwargs), as_dataframe, arrow_kwargs)
+
+    # Last resort use Parallel Scan
+    executor = _get_executor(use_threads=use_threads)
+    dynamodb_client = _utils.client(service_name="dynamodb", session=boto3_session)
+    total_segments = _utils.ensure_cpu_count(use_threads=use_threads)
+    kwargs = _serialize_kwargs(kwargs)
+    kwargs["TableName"] = table_name
+    kwargs["TotalSegments"] = total_segments
+
+    items = executor.map(
+        _read_scan, dynamodb_client, itertools.repeat(as_dataframe), itertools.repeat(kwargs), range(total_segments)
+    )
+    return _utils.table_refs_to_df(items, arrow_kwargs) if as_dataframe else _utils.flatten_list(ray_get(items))
 
 
 @overload
@@ -238,7 +318,9 @@ def read_items(
     allow_full_scan: bool = ...,
     max_items_evaluated: Optional[int] = ...,
     as_dataframe: Literal[True] = ...,
+    use_threads: Union[bool, int] = ...,
     boto3_session: Optional[boto3.Session] = ...,
+    pyarrow_additional_kwargs: Optional[Dict[str, Any]] = ...,
 ) -> pd.DataFrame:
     ...
 
@@ -259,7 +341,9 @@ def read_items(
     allow_full_scan: bool = ...,
     max_items_evaluated: Optional[int] = ...,
     as_dataframe: Literal[False],
+    use_threads: Union[bool, int] = ...,
     boto3_session: Optional[boto3.Session] = ...,
+    pyarrow_additional_kwargs: Optional[Dict[str, Any]] = ...,
 ) -> List[Dict[str, Any]]:
     ...
 
@@ -280,7 +364,9 @@ def read_items(
     allow_full_scan: bool = ...,
     max_items_evaluated: Optional[int] = ...,
     as_dataframe: bool,
+    use_threads: Union[bool, int] = ...,
     boto3_session: Optional[boto3.Session] = ...,
+    pyarrow_additional_kwargs: Optional[Dict[str, Any]] = ...,
 ) -> Union[pd.DataFrame, List[Dict[str, Any]]]:
     ...
 
@@ -299,7 +385,9 @@ def read_items(  # pylint: disable=too-many-branches
     allow_full_scan: bool = False,
     max_items_evaluated: Optional[int] = None,
     as_dataframe: bool = True,
+    use_threads: Union[bool, int] = True,
     boto3_session: Optional[boto3.Session] = None,
+    pyarrow_additional_kwargs: Optional[Dict[str, Any]] = None,
 ) -> Union[pd.DataFrame, List[Dict[str, Any]]]:
     """Read items from given DynamoDB table.
 
@@ -309,6 +397,13 @@ def read_items(  # pylint: disable=too-many-branches
 
     Under the hood, it wraps all the four available read actions: get_item, batch_get_item,
     query and scan.
+
+    Note
+    ----
+    Parallel Scans are used based on specified `use_threads`.
+    A parallel scan with a large number of workers could consume all the provisioned throughput
+    of the table or index.
+    See: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.ParallelScan
 
     Parameters
     ----------
@@ -340,8 +435,16 @@ def read_items(  # pylint: disable=too-many-branches
         Limit the number of items evaluated in case of query or scan operations. Defaults to None (all matching items).
     as_dataframe : bool
         If True, return items as pd.DataFrame, otherwise as list/dict. Defaults to True.
+    use_threads : Union[bool, int]
+        Used for Parallel Scan requests. True (default) to enable concurrency, False to disable multiple threads.
+        If enabled os.cpu_count() is used as the max number of threads.
+        If integer is provided, specified number is used.
     boto3_session : boto3.Session, optional
         Boto3 Session. Defaults to None (the default boto3 Session will be used).
+    pyarrow_additional_kwargs : Dict[str, Any], optional
+        Forwarded to `to_pandas` method converting from PyArrow tables to Pandas dataframe.
+        Valid values include "split_blocks", "self_destruct", "ignore_metadata".
+        e.g. pyarrow_additional_kwargs={'split_blocks': True}.
 
     Raises
     ------
@@ -439,6 +542,8 @@ def read_items(  # pylint: disable=too-many-branches
     ... )
 
     """
+    arrow_kwargs = _data_types.pyarrow2pandas_defaults(use_threads=use_threads, kwargs=pyarrow_additional_kwargs)
+
     # Extract key schema
     table_key_schema = get_table(table_name=table_name, boto3_session=boto3_session).key_schema
 
@@ -483,19 +588,20 @@ def read_items(  # pylint: disable=too-many-branches
     _logger.debug("kwargs: %s", kwargs)
     # If kwargs are sufficiently informative, proceed with actual read op
     if any((partition_values, key_condition_expression, filter_expression, allow_full_scan, max_items_evaluated)):
-        items = _read_items(table_name, boto3_session, **kwargs)
+        return _read_items(
+            table_name=table_name,
+            as_dataframe=as_dataframe,
+            arrow_kwargs=arrow_kwargs,
+            use_threads=use_threads,
+            boto3_session=boto3_session,
+            **kwargs,
+        )
     # Raise otherwise
-    else:
-        _args = (
-            "partition_values",
-            "key_condition_expression",
-            "filter_expression",
-            "allow_full_scan",
-            "max_items_evaluated",
-        )
-        raise exceptions.InvalidArgumentCombination(
-            f"Please provide at least one of these arguments: {', '.join(_args)}."
-        )
-
-    # Enforce DataFrame type if requested
-    return pd.DataFrame(items) if as_dataframe else items
+    _args = (
+        "partition_values",
+        "key_condition_expression",
+        "filter_expression",
+        "allow_full_scan",
+        "max_items_evaluated",
+    )
+    raise exceptions.InvalidArgumentCombination(f"Please provide at least one of these arguments: {', '.join(_args)}.")

--- a/awswrangler/dynamodb/_utils.py
+++ b/awswrangler/dynamodb/_utils.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any, Dict, Iterator, List, Mapping, Optional, Union
 
 import boto3
+from boto3.dynamodb.conditions import ConditionExpressionBuilder
 from botocore.exceptions import ClientError
 
 from awswrangler import _utils, exceptions
@@ -133,6 +134,47 @@ def execute_statement(
         _execute_statement(kwargs=kwargs, boto3_session=boto3_session)
         return None
     return _read_execute_statement(kwargs=kwargs, boto3_session=boto3_session)
+
+
+def _serialize_kwargs(kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    """Serialize a DynamoDB input arguments dictionary.
+
+    Parameters
+    ----------
+    kwargs : Dict[str, Any]
+        Dictionary to serialize.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Serialized dictionary.
+    """
+    names = {}
+    values = {}
+    serializer = boto3.dynamodb.types.TypeSerializer()
+
+    if "FilterExpression" in kwargs and not isinstance(kwargs["FilterExpression"], str):
+        builder = ConditionExpressionBuilder()
+        exp_string, names, values = builder.build_expression(kwargs["FilterExpression"], False)
+        kwargs["FilterExpression"] = exp_string
+
+    if "ExpressionAttributeNames" in kwargs:
+        kwargs["ExpressionAttributeNames"].update(names)
+    else:
+        if names:
+            kwargs["ExpressionAttributeNames"] = names
+
+    values = {k: serializer.serialize(v) for k, v in values.items()}
+    if "ExpressionAttributeValues" in kwargs:
+        kwargs["ExpressionAttributeValues"] = {
+            k: serializer.serialize(v) for k, v in kwargs["ExpressionAttributeValues"].items()
+        }
+        kwargs["ExpressionAttributeValues"].update(values)
+    else:
+        if values:
+            kwargs["ExpressionAttributeValues"] = values
+
+    return kwargs
 
 
 def _validate_items(

--- a/awswrangler/s3/_select.py
+++ b/awswrangler/s3/_select.py
@@ -24,10 +24,6 @@ _logger: logging.Logger = logging.getLogger(__name__)
 _RANGE_CHUNK_SIZE: int = int(1024 * 1024)
 
 
-def _flatten_list(elements: List[List[Any]]) -> List[Any]:
-    return [item for sublist in elements for item in sublist]
-
-
 def _gen_scan_range(obj_size: int, scan_range_chunk_size: Optional[int] = None) -> Iterator[Tuple[int, int]]:
     chunk_size = scan_range_chunk_size or _RANGE_CHUNK_SIZE
     for i in range(0, obj_size, chunk_size):
@@ -275,5 +271,7 @@ def select_query(
 
     arrow_kwargs = _data_types.pyarrow2pandas_defaults(use_threads=use_threads, kwargs=pyarrow_additional_kwargs)
     executor = _get_executor(use_threads=use_threads)
-    tables = _flatten_list(ray_get([_select_query(path=path, executor=executor, **select_kwargs) for path in paths]))
+    tables = _utils.flatten_list(
+        ray_get([_select_query(path=path, executor=executor, **select_kwargs) for path in paths])
+    )
     return _utils.table_refs_to_df(tables, kwargs=arrow_kwargs)

--- a/awswrangler/timestream.py
+++ b/awswrangler/timestream.py
@@ -17,10 +17,6 @@ from awswrangler.distributed.ray import ray_get
 _logger: logging.Logger = logging.getLogger(__name__)
 
 
-def _flatten_list(elements: List[List[Any]]) -> List[Any]:
-    return [item for sublist in elements for item in sublist]
-
-
 def _df2list(df: pd.DataFrame) -> List[List[Any]]:
     """Extract Parameters."""
     parameters: List[List[Any]] = df.values.tolist()
@@ -305,7 +301,7 @@ def write(
     _logger.debug("len(dfs): %s", len(dfs))
 
     executor = _get_executor(use_threads=use_threads)
-    errors = _flatten_list(
+    errors = _utils.flatten_list(
         ray_get(
             [
                 _write_df(
@@ -324,7 +320,7 @@ def write(
             ]
         )
     )
-    return _flatten_list(ray_get(errors))
+    return _utils.flatten_list(ray_get(errors))
 
 
 @overload

--- a/tests/unit/test_dynamodb.py
+++ b/tests/unit/test_dynamodb.py
@@ -247,10 +247,12 @@ def test_read_items_simple(params, dynamodb_table):
             sort_values=["a"],
         )
 
-    with pytest.raises(ClientError):
+    with pytest.raises((ClientError, AttributeError)):
         wr.dynamodb.read_items(table_name=dynamodb_table, filter_expression="nonsense")
 
-    df2 = wr.dynamodb.read_items(table_name=dynamodb_table, max_items_evaluated=5)
+    df2 = wr.dynamodb.read_items(
+        table_name=dynamodb_table, max_items_evaluated=5, pyarrow_additional_kwargs={"types_mapper": None}
+    )
     assert df2.shape == df.shape
     assert df2.dtypes.to_list() == df.dtypes.to_list()
 
@@ -391,7 +393,7 @@ def test_read_items_expression(params, dynamodb_table):
     assert df5.shape == (2, len(df.columns))
 
     # Reserved keyword
-    df = wr.dynamodb.read_items(
+    wr.dynamodb.read_items(
         table_name=dynamodb_table,
         filter_expression="#operator = :v",
         expression_attribute_names={"#operator": "operator"},


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Feature

https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.ParallelScan

### Detail
- Distribute DynamoDB Parallel Scan (both threads and Ray)
- This requires converting items to arrow tables first (because Ray dataset requires arrow table references)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
