### PR TITLE
Improve decorators to leverage typing and stubs

### DIFF
--- a/awswrangler/_threading.py
+++ b/awswrangler/_threading.py
@@ -3,7 +3,7 @@
 import concurrent.futures
 import itertools
 import logging
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, TypeVar, Union
 
 from awswrangler import _utils
 from awswrangler._distributed import EngineEnum, engine
@@ -14,6 +14,9 @@ if TYPE_CHECKING:
 _logger: logging.Logger = logging.getLogger(__name__)
 
 
+MapOutputType = TypeVar("MapOutputType")
+
+
 class _ThreadPoolExecutor:
     def __init__(self, use_threads: Union[bool, int]):
         super().__init__()
@@ -22,7 +25,9 @@ class _ThreadPoolExecutor:
         if self._cpus > 1:
             self._exec = concurrent.futures.ThreadPoolExecutor(max_workers=self._cpus)  # pylint: disable=R1732
 
-    def map(self, func: Callable[..., Any], boto3_client: Optional["BaseClient"], *iterables: Any) -> List[Any]:
+    def map(
+        self, func: Callable[..., MapOutputType], boto3_client: Optional["BaseClient"], *iterables: Any
+    ) -> List[MapOutputType]:
         """Map iterables to multi-threaded function."""
         _logger.debug("Map: %s", func)
         if self._exec is not None:

--- a/awswrangler/_utils.py
+++ b/awswrangler/_utils.py
@@ -612,6 +612,7 @@ TryItOutputType = TypeVar("TryItOutputType")
 def try_it(
     f: Callable[..., TryItOutputType],
     ex: Any,
+    *args: Any,
     ex_code: Optional[str] = None,
     base: float = 1.0,
     max_num_tries: int = 3,
@@ -624,7 +625,7 @@ def try_it(
     delay: float = base
     for i in range(max_num_tries):
         try:
-            return f(**kwargs)
+            return f(*args, **kwargs)
         except ex as exception:
             if ex_code is not None and hasattr(exception, "response"):
                 if exception.response["Error"]["Code"] != ex_code:

--- a/awswrangler/_utils.py
+++ b/awswrangler/_utils.py
@@ -8,7 +8,21 @@ import random
 import time
 from concurrent.futures import FIRST_COMPLETED, Future, wait
 from functools import partial, wraps
-from typing import TYPE_CHECKING, Any, Callable, Dict, Generator, List, Optional, Sequence, Tuple, Type, Union, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Generator,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    overload,
+)
 
 import boto3
 import botocore.credentials
@@ -592,15 +606,17 @@ def retry(
     return wrapper
 
 
+TryItOutputType = TypeVar("TryItOutputType")
+
+
 def try_it(
-    f: Callable[..., Any],
+    f: Callable[..., TryItOutputType],
     ex: Any,
-    *args: Any,
     ex_code: Optional[str] = None,
     base: float = 1.0,
     max_num_tries: int = 3,
     **kwargs: Any,
-) -> Any:
+) -> TryItOutputType:
     """Run function with decorrelated Jitter.
 
     Reference: https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
@@ -608,7 +624,7 @@ def try_it(
     delay: float = base
     for i in range(max_num_tries):
         try:
-            return f(*args, **kwargs)
+            return f(**kwargs)
         except ex as exception:
             if ex_code is not None and hasattr(exception, "response"):
                 if exception.response["Error"]["Code"] != ex_code:

--- a/awswrangler/athena/_utils.py
+++ b/awswrangler/athena/_utils.py
@@ -117,14 +117,14 @@ def _start_query_execution(
 
     client_athena = _utils.client(service_name="athena", session=boto3_session)
     _logger.debug("args: \n%s", pprint.pformat(args))
-    response: Dict[str, Any] = _utils.try_it(
+    response = _utils.try_it(
         f=client_athena.start_query_execution,
         ex=botocore.exceptions.ClientError,
         ex_code="ThrottlingException",
         max_num_tries=5,
         **args,
     )
-    return cast(str, response["QueryExecutionId"])
+    return response["QueryExecutionId"]
 
 
 def _get_workgroup_config(session: Optional[boto3.Session] = None, workgroup: Optional[str] = None) -> _WorkGroupConfig:
@@ -1216,7 +1216,7 @@ def get_query_execution(query_execution_id: str, boto3_session: Optional[boto3.S
 
     """
     client_athena = _utils.client(service_name="athena", session=boto3_session)
-    response: Dict[str, Any] = _utils.try_it(
+    response = _utils.try_it(
         f=client_athena.get_query_execution,
         ex=botocore.exceptions.ClientError,
         ex_code="ThrottlingException",
@@ -1306,7 +1306,7 @@ def list_query_executions(workgroup: Optional[str] = None, boto3_session: Option
     if workgroup:
         kwargs["WorkGroup"] = workgroup
     query_list: List[str] = []
-    response: Dict[str, Any] = _utils.try_it(
+    response = _utils.try_it(
         f=client_athena.list_query_executions,
         ex=botocore.exceptions.ClientError,
         ex_code="ThrottlingException",

--- a/awswrangler/distributed/ray/_pool.py
+++ b/awswrangler/distributed/ray/_pool.py
@@ -2,19 +2,21 @@
 
 import itertools
 import logging
-from typing import TYPE_CHECKING, Any, Callable, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, TypeVar
 
 if TYPE_CHECKING:
     from botocore.client import BaseClient
 
 _logger: logging.Logger = logging.getLogger(__name__)
 
+MapOutputType = TypeVar("MapOutputType")
+
 
 class _RayPoolExecutor:
     def __init__(self) -> None:
         pass
 
-    def map(self, func: Callable[..., Any], _: Optional["BaseClient"], *args: Any) -> List[Any]:
+    def map(self, func: Callable[..., MapOutputType], _: Optional["BaseClient"], *args: Any) -> List[MapOutputType]:
         """Map func and return ray futures."""
         _logger.debug("Ray map: %s", func)
         # Discard boto3 client

--- a/awswrangler/distributed/ray/modin/_core.py
+++ b/awswrangler/distributed/ray/modin/_core.py
@@ -75,4 +75,4 @@ def modin_repartition(function: FunctionType) -> FunctionType:
                 df = from_partitions(unwrap_partitions(df, axis=axis), axis=axis, row_lengths=row_lengths)
         return function(df, *args, **kwargs)
 
-    return wrapper
+    return wrapper  # type: ignore[return-value]

--- a/awswrangler/distributed/ray/modin/_core.py
+++ b/awswrangler/distributed/ray/modin/_core.py
@@ -2,7 +2,7 @@
 # pylint: disable=import-outside-toplevel
 import logging
 from functools import wraps
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, TypeVar
 
 import numpy as np
 import pandas as pd
@@ -30,7 +30,10 @@ def _validate_partition_shape(df: pd.DataFrame) -> bool:
     return partitions_shape[1] == 1
 
 
-def modin_repartition(function: Callable[..., Any]) -> Callable[..., Any]:
+FunctionType = TypeVar("FunctionType", bound=Callable[..., Any])
+
+
+def modin_repartition(function: FunctionType) -> FunctionType:
     """
     Decorate callable to repartition Modin data frame.
 

--- a/awswrangler/lakeformation/_utils.py
+++ b/awswrangler/lakeformation/_utils.py
@@ -74,7 +74,7 @@ def _get_table_objects(
     """Get Governed Table Objects from Lake Formation Engine."""
     client_lakeformation = _utils.client(service_name="lakeformation", session=boto3_session)
 
-    scan_kwargs: Dict[str, Union[str, int]] = _catalog_id(
+    scan_kwargs: Dict[str, Union[str, int, None]] = _catalog_id(
         catalog_id=catalog_id,
         **_transaction_id(transaction_id=transaction_id, DatabaseName=database, TableName=table, MaxResults=100),
     )
@@ -83,7 +83,7 @@ def _get_table_objects(
             partition_cols=partition_cols, partitions_types=partitions_types, partitions_values=partitions_values
         )
 
-    next_token: str = "init_token"  # Dummy token
+    next_token: Optional[str] = "init_token"  # Dummy token
     table_objects: List[Dict[str, Any]] = []
     while next_token:
         response = _utils.try_it(
@@ -97,8 +97,8 @@ def _get_table_objects(
         for objects in response["Objects"]:
             for table_object in objects["Objects"]:
                 if objects["PartitionValues"]:
-                    table_object["PartitionValues"] = objects["PartitionValues"]
-                table_objects.append(table_object)
+                    table_object["PartitionValues"] = objects["PartitionValues"]  # type: ignore[typeddict-item]
+                table_objects.append(table_object)  # type: ignore[arg-type]
         next_token = response.get("NextToken", None)
         scan_kwargs["NextToken"] = next_token
     return table_objects

--- a/awswrangler/s3/_describe.py
+++ b/awswrangler/s3/_describe.py
@@ -4,7 +4,7 @@ import concurrent.futures
 import datetime
 import itertools
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, cast
 
 import boto3
 
@@ -33,13 +33,12 @@ def _describe_object(
         )
     else:
         extra_kwargs = {}
-    desc: Dict[str, Any]
     if version_id:
         extra_kwargs["VersionId"] = version_id
     desc = _utils.try_it(
         f=s3_client.head_object, ex=s3_client.exceptions.NoSuchKey, Bucket=bucket, Key=key, **extra_kwargs
     )
-    return path, desc
+    return path, cast(Dict[str, Any], desc)
 
 
 def _describe_object_concurrent(

--- a/awswrangler/s3/_list.py
+++ b/awswrangler/s3/_list.py
@@ -33,7 +33,7 @@ def _path2list(
     if isinstance(path, str):  # prefix
         paths: List[str] = [
             path
-            for paths in _list_objects(  # type: ignore
+            for paths in _list_objects(
                 path=path,
                 s3_client=s3_client,
                 suffix=_suffix,
@@ -115,7 +115,7 @@ def _list_objects(  # pylint: disable=too-many-branches
 
     for page in response_iterator:  # pylint: disable=too-many-nested-blocks
         if delimiter is None:
-            contents: Optional[List[Dict[str, Any]]] = page.get("Contents")
+            contents = page.get("Contents")
             if contents is not None:
                 for content in contents:
                     key: str = content["Key"]
@@ -131,7 +131,7 @@ def _list_objects(  # pylint: disable=too-many-branches
                                     continue
                             paths.append(f"s3://{bucket}/{key}")
         else:
-            prefixes: Optional[List[Optional[Dict[str, str]]]] = page.get("CommonPrefixes")
+            prefixes = page.get("CommonPrefixes")
             if prefixes is not None:
                 for pfx in prefixes:
                     if (pfx is not None) and ("Prefix" in pfx):

--- a/awswrangler/s3/_select.py
+++ b/awswrangler/s3/_select.py
@@ -13,7 +13,7 @@ import pyarrow as pa
 
 from awswrangler import _data_types, _utils, exceptions
 from awswrangler._distributed import engine
-from awswrangler._threading import _get_executor
+from awswrangler._threading import _get_executor, _ThreadPoolExecutor
 from awswrangler.distributed.ray import ray_get
 from awswrangler.s3._describe import size_objects
 from awswrangler.s3._list import _path2list
@@ -82,7 +82,7 @@ def _select_object_content(
 @engine.dispatch_on_engine
 def _select_query(
     path: str,
-    executor: Any,
+    executor: _ThreadPoolExecutor,
     sql: str,
     input_serialization: str,
     input_serialization_params: Dict[str, Union[bool, str]],
@@ -131,7 +131,7 @@ def _select_query(
         # and JSON objects (in LINES mode only)
         scan_ranges = [None]  # type: ignore
 
-    return executor.map(_select_object_content, s3_client, itertools.repeat(args), scan_ranges)  # type: ignore
+    return executor.map(_select_object_content, s3_client, itertools.repeat(args), scan_ranges)
 
 
 def select_query(


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Detail
- Added generics for the `try_it` and `map` functions. This will allow MyPy to take advantage of type hints even when we use those decorators

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
