### PR TITLE
(enhancement) Use fast file metadata provider

### DIFF
--- a/awswrangler/distributed/ray/modin/s3/_read_parquet.py
+++ b/awswrangler/distributed/ray/modin/s3/_read_parquet.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Union
 import modin.pandas as pd
 import pyarrow as pa
 from ray.data import read_datasource
+from ray.data.datasource import FastFileMetadataProvider
 
 from awswrangler.distributed.ray.datasources import ArrowParquetDatasource
 from awswrangler.distributed.ray.modin._utils import _to_modin
@@ -37,5 +38,6 @@ def _read_parquet_distributed(  # pylint: disable=unused-argument
         columns=columns,
         dataset_kwargs=dataset_kwargs,
         path_root=path_root,
+        meta_provider=FastFileMetadataProvider(),
     )
     return _to_modin(dataset=dataset, to_pandas_kwargs=arrow_kwargs, ignore_index=bool(path_root))

--- a/awswrangler/distributed/ray/modin/s3/_read_parquet.py
+++ b/awswrangler/distributed/ray/modin/s3/_read_parquet.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Union
 import modin.pandas as pd
 import pyarrow as pa
 from ray.data import read_datasource
-from ray.data.datasource import FastFileMetadataProvider
 
 from awswrangler.distributed.ray.datasources import ArrowParquetDatasource
 from awswrangler.distributed.ray.modin._utils import _to_modin
@@ -38,6 +37,5 @@ def _read_parquet_distributed(  # pylint: disable=unused-argument
         columns=columns,
         dataset_kwargs=dataset_kwargs,
         path_root=path_root,
-        meta_provider=FastFileMetadataProvider(),
     )
     return _to_modin(dataset=dataset, to_pandas_kwargs=arrow_kwargs, ignore_index=bool(path_root))

--- a/awswrangler/distributed/ray/modin/s3/_read_text.py
+++ b/awswrangler/distributed/ray/modin/s3/_read_text.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 import modin.pandas as pd
 from pyarrow import csv
 from ray.data import read_datasource
+from ray.data.datasource import FastFileMetadataProvider
 
 from awswrangler import exceptions
 from awswrangler.distributed.ray.datasources import (
@@ -116,5 +117,6 @@ def _read_text_distributed(  # pylint: disable=unused-argument
         read_options=read_options,
         parse_options=parse_options,
         convert_options=convert_options,
+        meta_provider=FastFileMetadataProvider(),
     )
     return _to_modin(dataset=ray_dataset, ignore_index=ignore_index)


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
- Use [FastFileMetadataProvider](https://docs.ray.io/en/latest/_modules/ray/data/datasource/file_meta_provider.html#FastFileMetadataProvider) to skip directory paths expansion

### Relates
- #1982 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
