### PR TITLE
Distributed: Add support for JSON PyArrow data source

### DIFF
--- a/awswrangler/distributed/ray/datasources/__init__.py
+++ b/awswrangler/distributed/ray/datasources/__init__.py
@@ -1,6 +1,7 @@
 """Ray Datasources Module."""
 
 from awswrangler.distributed.ray.datasources.arrow_csv_datasource import ArrowCSVDatasource
+from awswrangler.distributed.ray.datasources.arrow_json_datasource import ArrowJSONDatasource
 from awswrangler.distributed.ray.datasources.arrow_parquet_datasource import ArrowParquetDatasource
 from awswrangler.distributed.ray.datasources.pandas_file_based_datasource import UserProvidedKeyBlockWritePathProvider
 from awswrangler.distributed.ray.datasources.pandas_text_datasource import (
@@ -12,6 +13,7 @@ from awswrangler.distributed.ray.datasources.pandas_text_datasource import (
 
 __all__ = [
     "ArrowCSVDatasource",
+    "ArrowJSONDatasource",
     "ArrowParquetDatasource",
     "PandasCSVDataSource",
     "PandasFWFDataSource",

--- a/awswrangler/distributed/ray/datasources/arrow_json_datasource.py
+++ b/awswrangler/distributed/ray/datasources/arrow_json_datasource.py
@@ -1,0 +1,39 @@
+"""Ray ArrowCSVDatasource Module."""
+from typing import Any
+
+import pyarrow as pa
+from pyarrow import json
+
+from awswrangler._arrow import _add_table_partitions
+from awswrangler.distributed.ray.datasources.pandas_file_based_datasource import PandasFileBasedDatasource
+
+
+class ArrowJSONDatasource(PandasFileBasedDatasource):  # pylint: disable=abstract-method
+    """JSON datasource, for reading and writing JSON files using PyArrow."""
+
+    _FILE_EXTENSION = "json"
+
+    def _read_file(  # type: ignore[override]  # pylint: disable=arguments-differ
+        self,
+        f: pa.NativeFile,
+        path: str,
+        path_root: str,
+        dataset: bool,
+        **reader_args: Any,
+    ) -> pa.Table:
+        read_options = reader_args.get("read_options", json.ReadOptions(use_threads=False))
+        parse_options = reader_args.get(
+            "parse_options",
+            json.ParseOptions(),
+        )
+
+        table = json.read_json(f, read_options=read_options, parse_options=parse_options)
+
+        if dataset:
+            table = _add_table_partitions(
+                table=table,
+                path=f"s3://{path}",
+                path_root=path_root,
+            )
+
+        return table

--- a/awswrangler/distributed/ray/datasources/arrow_json_datasource.py
+++ b/awswrangler/distributed/ray/datasources/arrow_json_datasource.py
@@ -21,11 +21,11 @@ class ArrowJSONDatasource(PandasFileBasedDatasource):  # pylint: disable=abstrac
         dataset: bool,
         **reader_args: Any,
     ) -> pa.Table:
-        read_options = reader_args.get("read_options", json.ReadOptions(use_threads=False))
-        parse_options = reader_args.get(
-            "parse_options",
-            json.ParseOptions(),
-        )
+        read_options_dict = reader_args.get("read_options", dict(use_threads=False))
+        parse_options_dict = reader_args.get("parse_options", {})
+
+        read_options = json.ReadOptions(**read_options_dict)
+        parse_options = json.ParseOptions(**parse_options_dict)
 
         table = json.read_json(f, read_options=read_options, parse_options=parse_options)
 

--- a/awswrangler/distributed/ray/modin/s3/_read_text.py
+++ b/awswrangler/distributed/ray/modin/s3/_read_text.py
@@ -3,7 +3,7 @@ import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypedDict, Union
 
 import modin.pandas as pd
-from pyarrow import csv, json
+from pyarrow import csv
 from ray.data import read_datasource
 from ray.data.datasource import FastFileMetadataProvider
 
@@ -43,8 +43,8 @@ class CSVReadConfiguration(TypedDict):
 
 
 class JSONReadConfiguration(TypedDict):
-    read_options: json.ReadOptions
-    parse_options: json.ParseOptions
+    read_options: Dict[str, Any]
+    parse_options: Dict[str, Any]
 
 
 def _parse_csv_configuration(
@@ -75,9 +75,10 @@ def _parse_json_configuration(
 ) -> JSONReadConfiguration:
     _check_parameters(pandas_kwargs, _JSON_SUPPORTED_PARAMS)
 
+    # json.ReadOptions and json.ParseOptions cannot be pickled for some reason so we're building a Python dict
     return JSONReadConfiguration(
-        read_options=json.ReadOptions(use_threads=False),
-        parse_options=json.ParseOptions(),
+        read_options=dict(use_threads=False),
+        parse_options={},
     )
 
 


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
- Add support for JSON PyArrow data source, which will only be available with the parameters `orient="records"` and `lines=True`. It will result in faster reading operations.
  - The `test_s3_read_json_simple` load test execution time has decreased from 8 seconds to 5.5 seconds
- Writing JSON with Arrow is not supported, so this feature will only work for reading. In the Ray [json_datasource](https://docs.ray.io/en/latest/_modules/ray/data/datasource/json_datasource.html), the `write_block` function uses the Pandas writing function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
