### PR TITLE
fix: Add missing TIME type to pyarrow2redshift conversion method

### DIFF
--- a/awswrangler/_data_types.py
+++ b/awswrangler/_data_types.py
@@ -88,6 +88,8 @@ def pyarrow2redshift(  # pylint: disable=too-many-branches,too-many-return-state
         return "TIMESTAMP"
     if pa.types.is_date(dtype):
         return "DATE"
+    if pa.types.is_time(dtype):
+        return "TIME"
     if pa.types.is_decimal(dtype):
         return f"DECIMAL({dtype.precision},{dtype.scale})"
     if pa.types.is_dictionary(dtype):


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
- Add missing TIME type to pyarrow2redshift conversion method

### Relates
- #2024

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
