### PR TITLE
(test) Fix SSE default

### DIFF
--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -216,7 +216,8 @@ def test_merge_additional_kwargs(path, kms_key_id, s3_additional_kwargs, use_thr
     descs = wr.s3.describe_objects(paths, use_threads=use_threads)
     for desc in descs.values():
         if s3_additional_kwargs is None:
-            assert desc.get("ServerSideEncryption") is None
+            # SSE enabled by default
+            assert desc.get("ServerSideEncryption") == "AES256"
         elif s3_additional_kwargs["ServerSideEncryption"] == "aws:kms":
             assert desc.get("ServerSideEncryption") == "aws:kms"
         elif s3_additional_kwargs["ServerSideEncryption"] == "AES256":

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -267,7 +267,7 @@ def test_copy_additional_kwargs(path, path2, kms_key_id, s3_additional_kwargs, u
     assert df.equals(wr.s3.read_csv(file_path2))
     desc = wr.s3.describe_objects([file_path2])[file_path2]
     if s3_additional_kwargs is None:
-        assert desc.get("ServerSideEncryption") is None
+        assert desc.get("ServerSideEncryption") == "AES256"
     elif s3_additional_kwargs["ServerSideEncryption"] == "aws:kms":
         assert desc.get("ServerSideEncryption") == "aws:kms"
     elif s3_additional_kwargs["ServerSideEncryption"] == "AES256":

--- a/tests/unit/test_s3_text.py
+++ b/tests/unit/test_s3_text.py
@@ -340,7 +340,8 @@ def test_csv_additional_kwargs(path, kms_key_id, s3_additional_kwargs, use_threa
     assert df.equals(wr.s3.read_csv([path]))
     desc = wr.s3.describe_objects([path])[path]
     if s3_additional_kwargs is None:
-        assert desc.get("ServerSideEncryption") is None
+        # SSE enabled by default
+        assert desc.get("ServerSideEncryption") == "AES256"
     elif s3_additional_kwargs["ServerSideEncryption"] == "aws:kms":
         assert desc.get("ServerSideEncryption") == "aws:kms"
     elif s3_additional_kwargs["ServerSideEncryption"] == "AES256":


### PR DESCRIPTION
Tests started to fail because all new objects are now SSE encrypted ([from Jan 5?](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-encryption.html)).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.