### PR TITLE
Add distributed variant of the `_read_parquet_metadata_file` function based on the PyArrow file system

### DIFF
--- a/awswrangler/distributed/ray/_register.py
+++ b/awswrangler/distributed/ray/_register.py
@@ -22,7 +22,6 @@ def register_ray() -> None:
     for func in [
         _get_work_unit_results,
         _delete_objects,
-        _read_parquet_metadata_file,
         _read_scan,
         _select_query,
         _select_object_content,
@@ -45,7 +44,10 @@ def register_ray() -> None:
             _is_pandas_or_modin_frame,
             _split_modin_frame,
         )
-        from awswrangler.distributed.ray.modin.s3._read_parquet import _read_parquet_distributed
+        from awswrangler.distributed.ray.modin.s3._read_parquet import (
+            _read_parquet_distributed,
+            _read_parquet_metadata_file_distributed,
+        )
         from awswrangler.distributed.ray.modin.s3._read_text import _read_text_distributed
         from awswrangler.distributed.ray.modin.s3._write_dataset import (
             _to_buckets_distributed,
@@ -59,6 +61,7 @@ def register_ray() -> None:
             _read_parquet: _read_parquet_distributed,
             _read_text: _read_text_distributed,
             _to_buckets: _to_buckets_distributed,
+            _read_parquet_metadata_file: _read_parquet_metadata_file_distributed,
             _to_parquet: _to_parquet_distributed,
             _to_partitions: _to_partitions_distributed,
             _to_text: _to_text_distributed,

--- a/awswrangler/distributed/ray/_register.py
+++ b/awswrangler/distributed/ray/_register.py
@@ -46,7 +46,6 @@ def register_ray() -> None:
         )
         from awswrangler.distributed.ray.modin.s3._read_parquet import (
             _read_parquet_distributed,
-            _read_parquet_metadata_file_distributed,
         )
         from awswrangler.distributed.ray.modin.s3._read_text import _read_text_distributed
         from awswrangler.distributed.ray.modin.s3._write_dataset import (
@@ -55,13 +54,15 @@ def register_ray() -> None:
         )
         from awswrangler.distributed.ray.modin.s3._write_parquet import _to_parquet_distributed
         from awswrangler.distributed.ray.modin.s3._write_text import _to_text_distributed
+        from awswrangler.distributed.ray.s3._read_parquet import (
+            _read_parquet_metadata_file_distributed,
+        )
 
         for o_f, d_f in {
             pyarrow_types_from_pandas: pyarrow_types_from_pandas_distributed,
             _read_parquet: _read_parquet_distributed,
             _read_text: _read_text_distributed,
             _to_buckets: _to_buckets_distributed,
-            _read_parquet_metadata_file: _read_parquet_metadata_file_distributed,
             _to_parquet: _to_parquet_distributed,
             _to_partitions: _to_partitions_distributed,
             _to_text: _to_text_distributed,
@@ -71,3 +72,8 @@ def register_ray() -> None:
             table_refs_to_df: _arrow_refs_to_df,
         }.items():
             engine.register_func(o_f, d_f)  # type: ignore[arg-type]
+
+        for o_f, d_f in {
+            _read_parquet_metadata_file: _read_parquet_metadata_file_distributed,
+        }.items():
+            engine.register_func(o_f, ray_remote()(d_f))

--- a/awswrangler/distributed/ray/modin/s3/_read_parquet.py
+++ b/awswrangler/distributed/ray/modin/s3/_read_parquet.py
@@ -7,6 +7,7 @@ import pyarrow as pa
 import pyarrow.parquet
 from ray.data import read_datasource
 
+from awswrangler.distributed.ray import ray_remote
 from awswrangler.distributed.ray.datasources import ArrowParquetDatasource
 from awswrangler.distributed.ray.modin._utils import _to_modin
 
@@ -17,6 +18,7 @@ if TYPE_CHECKING:
 _logger: logging.Logger = logging.getLogger(__name__)
 
 
+@ray_remote()
 def _read_parquet_metadata_file_distributed(
     s3_client: Optional["S3Client"],
     path: str,

--- a/awswrangler/distributed/ray/modin/s3/_read_parquet.py
+++ b/awswrangler/distributed/ray/modin/s3/_read_parquet.py
@@ -1,46 +1,15 @@
 """Modin on Ray S3 read parquet module (PRIVATE)."""
-import logging
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Union
 
 import modin.pandas as pd
 import pyarrow as pa
-import pyarrow.parquet
 from ray.data import read_datasource
 
-from awswrangler.distributed.ray import ray_remote
 from awswrangler.distributed.ray.datasources import ArrowParquetDatasource
 from awswrangler.distributed.ray.modin._utils import _to_modin
-from awswrangler.s3._read_parquet import _pyarrow_parquet_file_wrapper
 
 if TYPE_CHECKING:
     from mypy_boto3_s3 import S3Client
-
-
-_logger: logging.Logger = logging.getLogger(__name__)
-
-
-@ray_remote()
-def _read_parquet_metadata_file_distributed(
-    s3_client: Optional["S3Client"],
-    path: str,
-    s3_additional_kwargs: Optional[Dict[str, str]],
-    use_threads: Union[bool, int],
-    version_id: Optional[str] = None,
-    coerce_int96_timestamp_unit: Optional[str] = None,
-) -> Optional[pa.schema]:
-    fs = pyarrow.fs.S3FileSystem()
-    path_without_s3_prefix = path[len("s3://") :]
-
-    with fs.open_input_file(path_without_s3_prefix) as f:
-        pq_file = _pyarrow_parquet_file_wrapper(
-            source=f,
-            coerce_int96_timestamp_unit=coerce_int96_timestamp_unit,
-        )
-
-        if pq_file:
-            return pq_file.schema.to_arrow_schema()
-
-    return None
 
 
 def _read_parquet_distributed(  # pylint: disable=unused-argument

--- a/awswrangler/distributed/ray/s3/__init__.py
+++ b/awswrangler/distributed/ray/s3/__init__.py
@@ -1,0 +1,1 @@
+"""Ray S3 Module."""

--- a/awswrangler/distributed/ray/s3/_read_parquet.py
+++ b/awswrangler/distributed/ray/s3/_read_parquet.py
@@ -1,0 +1,31 @@
+from typing import TYPE_CHECKING, Dict, Optional, Union
+
+import pyarrow as pa
+from pyarrow.fs import _resolve_filesystem_and_path
+
+from awswrangler.s3._read_parquet import _pyarrow_parquet_file_wrapper
+
+if TYPE_CHECKING:
+    from mypy_boto3_s3 import S3Client
+
+
+def _read_parquet_metadata_file_distributed(
+    s3_client: Optional["S3Client"],
+    path: str,
+    s3_additional_kwargs: Optional[Dict[str, str]],
+    use_threads: Union[bool, int],
+    version_id: Optional[str] = None,
+    coerce_int96_timestamp_unit: Optional[str] = None,
+) -> Optional[pa.schema]:
+    resolved_filesystem, resolved_path = _resolve_filesystem_and_path(path)
+
+    with resolved_filesystem.open_input_file(resolved_path) as f:
+        pq_file = _pyarrow_parquet_file_wrapper(
+            source=f,
+            coerce_int96_timestamp_unit=coerce_int96_timestamp_unit,
+        )
+
+        if pq_file:
+            return pq_file.schema.to_arrow_schema()
+
+    return None

--- a/tests/unit/test_fs.py
+++ b/tests/unit/test_fs.py
@@ -218,7 +218,8 @@ def test_additional_kwargs(path, kms_key_id, s3_additional_kwargs, use_threads):
         assert s3obj.read() == "foo"
     desc = wr.s3.describe_objects([path])[path]
     if s3_additional_kwargs is None:
-        assert desc.get("ServerSideEncryption") is None
+        # S3 default encryption
+        assert desc.get("ServerSideEncryption") == "AES256"
     elif s3_additional_kwargs["ServerSideEncryption"] == "aws:kms":
         assert desc.get("ServerSideEncryption") == "aws:kms"
     elif s3_additional_kwargs["ServerSideEncryption"] == "AES256":


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
- Add distributed variant of the `_read_parquet_metadata_file` function based on the PyArrow file system
- This version of the schema read will be slightly faster than the previous version. For 2222 objects, the mean execution time of reading the file metadata was reduced from 135 seconds to 123 seconds

![2222-objects](https://user-images.githubusercontent.com/15194249/220948218-c190f946-52c2-4730-a116-5e84cf70bc36.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
