### PR TITLE
Reduce unnecessary log output for load tests

### DIFF
--- a/awswrangler/distributed/ray/modin/s3/_write_text.py
+++ b/awswrangler/distributed/ray/modin/s3/_write_text.py
@@ -31,6 +31,7 @@ _CSV_SUPPORTED_PARAMS: Dict[str, ParamConfig] = {
     "quoting": ParamConfig(default=None, supported_values={None}),
     "escapechar": ParamConfig(default=None, supported_values={None}),
     "date_format": ParamConfig(default=None, supported_values={None}),
+    "columns": ParamConfig(default=None, supported_values={None}),
 }
 
 

--- a/tests/load/test_s3.py
+++ b/tests/load/test_s3.py
@@ -173,7 +173,7 @@ def test_s3_delete_objects(path: str, path2: str, benchmark_time: float, request
     paths2 = [f"{path2}delete-test{i}.json" for i in range(objects_per_bucket)]
     paths = paths1 + paths2
     for path in paths:
-        wr.s3.to_json(df, path)
+        wr.s3.to_csv(df, path)
     with ExecutionTimer(request) as timer:
         wr.s3.delete_objects(path=paths)
     assert timer.elapsed_time < benchmark_time
@@ -232,7 +232,7 @@ def test_wait_object_exists(path: str, benchmark_time: int, request: pytest.Fixt
     file_paths = [f"{path}{i}.txt" for i in range(num_objects)]
 
     for file_path in file_paths:
-        wr.s3.to_csv(df, file_path, index=False)
+        wr.s3.to_csv(df, file_path, index=True)
 
     with ExecutionTimer(request) as timer:
         wr.s3.wait_objects_exist(file_paths, parallelism=16)


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Detail
When `test_s3_delete_objects` and `test_wait_object_exists` are preparing a large list of objects for the load test, they are using versions of the `to_text` methods which output a warning like:
```
WARNING  awswrangler.distributed.ray.modin.s3._write_text:_write_text.py:121 PyArrow method unavailable, defaulting to Pandas I/O functions: File is in the json format. This will result in slower performance of the write operations.
```

Since this step is only about preparing a list of ~500 objects on S3, there is no reason to use these version of `to_csv` and `to_json`, as it results in the same warning message being outputted ~500 times. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
