### PR TITLE
Unit tests: Wrap redshift connectors in `with` block

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -183,11 +183,10 @@ def redshift_external_schema(cloudformation_outputs, databases_parameters, glue_
     IAM_ROLE '{databases_parameters["redshift"]["role"]}'
     REGION '{region}';
     """
-    con = wr.redshift.connect(connection="aws-sdk-pandas-redshift")
-    with con.cursor() as cursor:
-        cursor.execute(sql)
-        con.commit()
-    con.close()
+    with wr.redshift.connect(connection="aws-sdk-pandas-redshift") as con:
+        with con.cursor() as cursor:
+            cursor.execute(sql)
+            con.commit()
     return "aws_sdk_pandas_external"
 
 
@@ -284,11 +283,10 @@ def redshift_table():
     name = f"tbl_{get_time_str_with_random_suffix()}"
     print(f"Table name: {name}")
     yield name
-    con = wr.redshift.connect("aws-sdk-pandas-redshift")
-    with con.cursor() as cursor:
-        cursor.execute(f"DROP TABLE IF EXISTS public.{name}")
-    con.commit()
-    con.close()
+    with wr.redshift.connect("aws-sdk-pandas-redshift") as con:
+        with con.cursor() as cursor:
+            cursor.execute(f"DROP TABLE IF EXISTS public.{name}")
+        con.commit()
 
 
 @pytest.fixture(scope="function")
@@ -296,11 +294,10 @@ def redshift_table_with_hyphenated_name():
     name = f"tbl-{get_time_str_with_random_suffix()}"
     print(f"Table name: {name}")
     yield name
-    con = wr.redshift.connect("aws-sdk-pandas-redshift")
-    with con.cursor() as cursor:
-        cursor.execute(f'DROP TABLE IF EXISTS public."{name}"')
-    con.commit()
-    con.close()
+    with wr.redshift.connect("aws-sdk-pandas-redshift") as con:
+        with con.cursor() as cursor:
+            cursor.execute(f'DROP TABLE IF EXISTS public."{name}"')
+        con.commit()
 
 
 @pytest.fixture(scope="function")
@@ -405,9 +402,8 @@ def random_glue_database():
 
 @pytest.fixture(scope="function")
 def redshift_con():
-    con = wr.redshift.connect("aws-sdk-pandas-redshift")
-    yield con
-    con.close()
+    with wr.redshift.connect("aws-sdk-pandas-redshift") as con:
+        yield con
 
 
 @pytest.fixture(scope="function")

--- a/tests/unit/test_redshift.py
+++ b/tests/unit/test_redshift.py
@@ -3,7 +3,7 @@ import logging
 import random
 import string
 from decimal import Decimal
-from typing import Any, Dict
+from typing import Any, Dict, Iterator, List, Optional, Type
 
 import boto3
 import numpy as np
@@ -38,17 +38,17 @@ pytestmark = pytest.mark.distributed
 
 
 @pytest.fixture(scope="function")
-def redshift_con():
-    con = wr.redshift.connect("aws-sdk-pandas-redshift")
-    yield con
-    con.close()
+def redshift_con() -> Iterator[redshift_connector.Connection]:
+    with wr.redshift.connect("aws-sdk-pandas-redshift") as con:
+        yield con
 
 
-def test_connection():
-    wr.redshift.connect("aws-sdk-pandas-redshift", timeout=10, force_lowercase=False).close()
+def test_connection() -> None:
+    with wr.redshift.connect("aws-sdk-pandas-redshift", timeout=10, force_lowercase=False):
+        pass
 
 
-def test_read_sql_query_simple(databases_parameters):
+def test_read_sql_query_simple(databases_parameters: Dict[str, Any]) -> None:
     con = redshift_connector.connect(
         host=databases_parameters["redshift"]["host"],
         port=int(databases_parameters["redshift"]["port"]),
@@ -56,25 +56,25 @@ def test_read_sql_query_simple(databases_parameters):
         user=databases_parameters["user"],
         password=databases_parameters["password"],
     )
-    df = wr.redshift.read_sql_query("SELECT 1", con=con)
-    con.close()
+    with con:
+        df = wr.redshift.read_sql_query("SELECT 1", con=con)
     assert df.shape == (1, 1)
 
 
 @pytest.mark.parametrize("overwrite_method", [None, "drop", "cascade", "truncate", "delete"])
-def test_to_sql_simple(redshift_table, redshift_con, overwrite_method):
+def test_to_sql_simple(redshift_table: str, redshift_con: redshift_connector.Connection, overwrite_method: str) -> None:
     df = pd.DataFrame({"c0": [1, 2, 3], "c1": ["foo", "boo", "bar"]})
     wr.redshift.to_sql(df, redshift_con, redshift_table, "public", "overwrite", overwrite_method, True)
 
 
-def test_empty_table(redshift_table, redshift_con):
+def test_empty_table(redshift_table: str, redshift_con: redshift_connector.Connection) -> None:
     with redshift_con.cursor() as cursor:
         cursor.execute(f"CREATE TABLE public.{redshift_table}(c0 integer not null, c1 integer, primary key(c0));")
     df = wr.redshift.read_sql_table(table=redshift_table, con=redshift_con, schema="public")
     assert df.columns.values.tolist() == ["c0", "c1"]
 
 
-def test_sql_types(redshift_table, redshift_con):
+def test_sql_types(redshift_table: str, redshift_con: redshift_connector.Connection) -> None:
     table = redshift_table
     df = get_df()
     df.drop(["binary"], axis=1, inplace=True)
@@ -113,25 +113,29 @@ def test_sql_types(redshift_table, redshift_con):
         ensure_data_types(df, has_list=False)
 
 
-def test_connection_temp(databases_parameters):
-    con = wr.redshift.connect_temp(cluster_identifier=databases_parameters["redshift"]["identifier"], user="test")
-    with con.cursor() as cursor:
-        cursor.execute("SELECT 1")
-        assert cursor.fetchall()[0][0] == 1
-    con.close()
+def test_connection_temp(databases_parameters: Dict[str, Any]) -> None:
+    con: redshift_connector.Connection = wr.redshift.connect_temp(
+        cluster_identifier=databases_parameters["redshift"]["identifier"], user="test"
+    )
+    with con:
+        with con.cursor() as cursor:
+            cursor.execute("SELECT 1")
+            assert cursor.fetchall()[0][0] == 1
 
 
-def test_connection_temp2(databases_parameters):
-    con = wr.redshift.connect_temp(
+def test_connection_temp2(databases_parameters: Dict[str, Any]) -> None:
+    con: redshift_connector.Connection = wr.redshift.connect_temp(
         cluster_identifier=databases_parameters["redshift"]["identifier"], user="john_doe", duration=900, db_groups=[]
     )
-    with con.cursor() as cursor:
-        cursor.execute("SELECT 1")
-        assert cursor.fetchall()[0][0] == 1
-    con.close()
+    with con:
+        with con.cursor() as cursor:
+            cursor.execute("SELECT 1")
+            assert cursor.fetchall()[0][0] == 1
 
 
-def test_copy_unload(path, redshift_table, redshift_con, databases_parameters):
+def test_copy_unload(
+    path: str, redshift_table: str, redshift_con: redshift_connector.Connection, databases_parameters: Dict[str, Any]
+) -> None:
     df = get_df().drop(["binary"], axis=1, inplace=False)
     wr.redshift.copy(
         df=df,
@@ -264,11 +268,18 @@ def generic_test_copy_upsert(
     assert len(df.columns) == len(df4.columns)
 
 
-def test_copy_upsert(path, redshift_table, redshift_con, databases_parameters):
+def test_copy_upsert(
+    path: str, redshift_table: str, redshift_con: redshift_connector.Connection, databases_parameters: Dict[str, Any]
+) -> None:
     generic_test_copy_upsert(path, redshift_table, redshift_con, databases_parameters)
 
 
-def test_copy_upsert_hyphenated_name(path, redshift_table_with_hyphenated_name, redshift_con, databases_parameters):
+def test_copy_upsert_hyphenated_name(
+    path: str,
+    redshift_table_with_hyphenated_name: str,
+    redshift_con: redshift_connector.Connection,
+    databases_parameters: Dict[str, Any],
+) -> None:
     generic_test_copy_upsert(path, redshift_table_with_hyphenated_name, redshift_con, databases_parameters)
 
 
@@ -284,8 +295,16 @@ def test_copy_upsert_hyphenated_name(path, redshift_table_with_hyphenated_name, 
     ],
 )
 def test_exceptions(
-    path, redshift_table, redshift_con, databases_parameters, diststyle, distkey, sortstyle, sortkey, exc
-):
+    path: str,
+    redshift_table: str,
+    redshift_con: redshift_connector.Connection,
+    databases_parameters: Dict[str, Any],
+    diststyle: Optional[str],
+    distkey: Optional[str],
+    sortstyle: Optional[str],
+    sortkey: Optional[List[str]],
+    exc: Type[BaseException],
+) -> None:
     df = pd.DataFrame({"id": [1], "name": "joe"})
     with pytest.raises(exc):
         wr.redshift.copy(
@@ -304,7 +323,13 @@ def test_exceptions(
         )
 
 
-def test_spectrum(path, redshift_table, redshift_con, glue_database, redshift_external_schema):
+def test_spectrum(
+    path: str,
+    redshift_table: str,
+    redshift_con: redshift_connector.Connection,
+    glue_database: str,
+    redshift_external_schema: str,
+) -> None:
     df = pd.DataFrame({"id": [1, 2, 3, 4, 5], "col_str": ["foo", None, "bar", None, "xoo"], "par_int": [0, 1, 0, 1, 1]})
     wr.s3.to_parquet(
         df=df,
@@ -325,7 +350,9 @@ def test_spectrum(path, redshift_table, redshift_con, glue_database, redshift_ex
 
 
 @pytest.mark.xfail(raises=NotImplementedError, reason="Unable to create pandas categorical from pyarrow table")
-def test_category(path, redshift_table, redshift_con, databases_parameters):
+def test_category(
+    path: str, redshift_table: str, redshift_con: redshift_connector.Connection, databases_parameters: Dict[str, Any]
+) -> None:
     df = get_df_category().drop(["binary"], axis=1, inplace=False)
     wr.redshift.copy(
         df=df,
@@ -358,7 +385,14 @@ def test_category(path, redshift_table, redshift_con, databases_parameters):
         ensure_data_types_category(df2)
 
 
-def test_unload_extras(bucket, path, redshift_table, redshift_con, databases_parameters, kms_key_id):
+def test_unload_extras(
+    bucket: str,
+    path: str,
+    redshift_table: str,
+    redshift_con: redshift_connector.Connection,
+    databases_parameters: Dict[str, Any],
+    kms_key_id: str,
+) -> None:
     table = redshift_table
     schema = databases_parameters["redshift"]["schema"]
     df = pd.DataFrame({"id": [1, 2], "name": ["foo", "boo"]})
@@ -393,8 +427,14 @@ def test_unload_extras(bucket, path, redshift_table, redshift_con, databases_par
 
 @pytest.mark.parametrize("unload_format", [None, "CSV", "PARQUET"])
 def test_unload_with_prefix(
-    bucket, path, redshift_table, redshift_con, databases_parameters, kms_key_id, unload_format
-):
+    bucket: str,
+    path: str,
+    redshift_table: str,
+    redshift_con: redshift_connector.Connection,
+    databases_parameters: Dict[str, Any],
+    kms_key_id: str,
+    unload_format: Optional[str],
+) -> None:
     test_prefix = "my_prefix"
     table = redshift_table
     schema = databases_parameters["redshift"]["schema"]
@@ -425,7 +465,7 @@ def test_unload_with_prefix(
     assert object_prefix == test_prefix
 
 
-def test_to_sql_cast(redshift_table, redshift_con):
+def test_to_sql_cast(redshift_table: str, redshift_con: redshift_connector.Connection) -> None:
     table = redshift_table
     df = pd.DataFrame(
         {
@@ -450,7 +490,7 @@ def test_to_sql_cast(redshift_table, redshift_con):
     assert df.equals(df2)
 
 
-def test_null(redshift_table, redshift_con):
+def test_null(redshift_table: str, redshift_con: redshift_connector.Connection) -> None:
     table = redshift_table
     df = pd.DataFrame({"id": [1, 2, 3], "nothing": [None, None, None]})
     wr.redshift.to_sql(
@@ -475,7 +515,13 @@ def test_null(redshift_table, redshift_con):
     assert pandas_equals(pd.concat(objs=[df, df], ignore_index=True), df2)
 
 
-def test_spectrum_long_string(path, redshift_con, glue_table, glue_database, redshift_external_schema):
+def test_spectrum_long_string(
+    path: str,
+    redshift_con: redshift_connector.Connection,
+    glue_table: str,
+    glue_database: str,
+    redshift_external_schema: str,
+) -> None:
     df = pd.DataFrame(
         {
             "id": [1, 2],
@@ -496,7 +542,9 @@ def test_spectrum_long_string(path, redshift_con, glue_table, glue_database, red
             assert len(row) == len(df.columns)
 
 
-def test_copy_unload_long_string(path, redshift_table, redshift_con, databases_parameters):
+def test_copy_unload_long_string(
+    path: str, redshift_table: str, redshift_con: redshift_connector.Connection, databases_parameters: Dict[str, Any]
+) -> None:
     df = pd.DataFrame(
         {
             "id": [1, 2],
@@ -526,7 +574,14 @@ def test_copy_unload_long_string(path, redshift_table, redshift_con, databases_p
     assert df2.shape == (2, 2)
 
 
-def test_spectrum_decimal_cast(path, path2, glue_table, glue_database, redshift_external_schema, databases_parameters):
+def test_spectrum_decimal_cast(
+    path: str,
+    path2: str,
+    glue_table: str,
+    glue_database: str,
+    redshift_external_schema: str,
+    databases_parameters: Dict[str, Any],
+) -> None:
     df = pd.DataFrame(
         {"c0": [1, 2], "c1": [1, None], "c2": [2.22222, None], "c3": ["3.33333", None], "c4": [None, None]}
     )
@@ -549,31 +604,29 @@ def test_spectrum_decimal_cast(path, path2, glue_table, glue_database, redshift_
     assert df2.c4[0] is None
 
     # Redshift Spectrum
-    con = wr.redshift.connect(connection="aws-sdk-pandas-redshift")
-    df2 = wr.redshift.read_sql_table(table=glue_table, schema=redshift_external_schema, con=con)
+    with wr.redshift.connect(connection="aws-sdk-pandas-redshift") as con:
+        df2 = wr.redshift.read_sql_table(table=glue_table, schema=redshift_external_schema, con=con)
     assert df2.shape == (2, 5)
     df2 = df2.drop(df2[df2.c0 == 2].index)
     assert df2.c1[0] == Decimal((0, (1, 0, 0, 0, 0, 0), -5))
     assert df2.c2[0] == Decimal((0, (2, 2, 2, 2, 2, 2), -5))
     assert df2.c3[0] == Decimal((0, (3, 3, 3, 3, 3, 3), -5))
     assert df2.c4[0] is None
-    con.close()
 
     # Redshift Spectrum Unload
-    con = wr.redshift.connect(connection="aws-sdk-pandas-redshift")
-    df2 = wr.redshift.unload(
-        sql=f"SELECT * FROM {redshift_external_schema}.{glue_table}",
-        con=con,
-        iam_role=databases_parameters["redshift"]["role"],
-        path=path2,
-    )
+    with wr.redshift.connect(connection="aws-sdk-pandas-redshift") as con:
+        df2 = wr.redshift.unload(
+            sql=f"SELECT * FROM {redshift_external_schema}.{glue_table}",
+            con=con,
+            iam_role=databases_parameters["redshift"]["role"],
+            path=path2,
+        )
     assert df2.shape == (2, 5)
     df2 = df2.drop(df2[df2.c0 == 2].index)
     assert df2.c1[0] == Decimal((0, (1, 0, 0, 0, 0, 0), -5))
     assert df2.c2[0] == Decimal((0, (2, 2, 2, 2, 2, 2), -5))
     assert df2.c3[0] == Decimal((0, (3, 3, 3, 3, 3, 3), -5))
     assert df2.c4[0] is None
-    con.close()
 
 
 @pytest.mark.xfail(
@@ -585,8 +638,14 @@ def test_spectrum_decimal_cast(path, path2, glue_table, glue_database, redshift_
 )
 @pytest.mark.parametrize("use_threads", [True, False])
 def test_copy_unload_kms(
-    path, redshift_table, redshift_con, databases_parameters, kms_key_id, use_threads, s3_additional_kwargs
-):
+    path: str,
+    redshift_table: str,
+    redshift_con: redshift_connector.Connection,
+    databases_parameters: Dict[str, Any],
+    kms_key_id: str,
+    use_threads: bool,
+    s3_additional_kwargs: Optional[Dict[str, Any]],
+) -> None:
     df = pd.DataFrame({"id": [1, 2, 3]})
     if s3_additional_kwargs is not None and "SSEKMSKeyId" in s3_additional_kwargs:
         s3_additional_kwargs["SSEKMSKeyId"] = kms_key_id
@@ -615,7 +674,14 @@ def test_copy_unload_kms(
 
 @pytest.mark.parametrize("parquet_infer_sampling", [1.0, 0.00000000000001])
 @pytest.mark.parametrize("use_threads", [True, False])
-def test_copy_extras(path, redshift_table, redshift_con, databases_parameters, use_threads, parquet_infer_sampling):
+def test_copy_extras(
+    path: str,
+    redshift_table: str,
+    redshift_con: redshift_connector.Connection,
+    databases_parameters: Dict[str, Any],
+    use_threads: bool,
+    parquet_infer_sampling: float,
+) -> None:
     df = pd.DataFrame(
         {
             "int8": [-1, None, 2],
@@ -660,7 +726,7 @@ def test_copy_extras(path, redshift_table, redshift_con, databases_parameters, u
     assert df.int64.sum() * num == df2.int64.sum()
 
 
-def test_decimal_cast(redshift_table, redshift_con):
+def test_decimal_cast(redshift_table: str, redshift_con: redshift_connector.Connection) -> None:
     df = pd.DataFrame(
         {
             "col0": [Decimal((0, (1, 9, 9), -2)), None, Decimal((0, (1, 9, 0), -2))],
@@ -681,7 +747,7 @@ def test_decimal_cast(redshift_table, redshift_con):
     assert df2.col2.sum() == 2
 
 
-def test_upsert(redshift_table, redshift_con):
+def test_upsert(redshift_table: str, redshift_con: redshift_connector.Connection) -> None:
     df = pd.DataFrame({"id": list((range(10))), "val": list(["foo" if i % 2 == 0 else "boo" for i in range(10)])})
     df3 = pd.DataFrame({"id": list((range(10, 15))), "val": list(["foo" if i % 2 == 0 else "boo" for i in range(5)])})
 
@@ -729,7 +795,7 @@ def test_upsert(redshift_table, redshift_con):
     assert len(df.columns) == len(df4.columns)
 
 
-def test_upsert_precombine(redshift_table, redshift_con):
+def test_upsert_precombine(redshift_table: str, redshift_con: redshift_connector.Connection) -> None:
     df = pd.DataFrame({"id": list((range(10))), "val": list([1.0 if i % 2 == 0 else 10.0 for i in range(10)])})
     df3 = pd.DataFrame({"id": list((range(6, 14))), "val": list([10.0 if i % 2 == 0 else 1.0 for i in range(8)])})
 
@@ -783,7 +849,7 @@ def test_upsert_precombine(redshift_table, redshift_con):
     assert np.array_equal(df_m.to_numpy(), df4.to_numpy())
 
 
-def test_read_retry(redshift_con):
+def test_read_retry(redshift_con: redshift_connector.Connection) -> None:
     try:
         wr.redshift.read_sql_query("ERROR", redshift_con)
     except:  # noqa
@@ -792,7 +858,7 @@ def test_read_retry(redshift_con):
     assert df.shape == (1, 1)
 
 
-def test_table_name(redshift_con):
+def test_table_name(redshift_con: redshift_connector.Connection) -> None:
     df = pd.DataFrame({"col0": [1]})
     wr.redshift.to_sql(df, redshift_con, "Test Name", "public", mode="overwrite")
     df = wr.redshift.read_sql_table(schema="public", con=redshift_con, table="Test Name")
@@ -802,14 +868,16 @@ def test_table_name(redshift_con):
     redshift_con.commit()
 
 
-def test_copy_from_files(path, redshift_table, redshift_con, databases_parameters):
+def test_copy_from_files(
+    path: str, redshift_table: str, redshift_con: redshift_connector.Connection, databases_parameters: Dict[str, Any]
+) -> None:
     df = get_df_category().drop(["binary"], axis=1, inplace=False)
     wr.s3.to_parquet(df, f"{path}test.parquet")
     bucket, key = wr._utils.parse_path(f"{path}test.csv")
     boto3.client("s3").put_object(Body=b"", Bucket=bucket, Key=key)
     wr.redshift.copy_from_files(
         path=path,
-        path_suffix=[".parquet"],
+        path_suffix=".parquet",
         con=redshift_con,
         table=redshift_table,
         schema="public",
@@ -819,14 +887,16 @@ def test_copy_from_files(path, redshift_table, redshift_con, databases_parameter
     assert df2["counter"].iloc[0] == 3
 
 
-def test_copy_from_files_extra_params(path, redshift_table, redshift_con, databases_parameters):
+def test_copy_from_files_extra_params(
+    path: str, redshift_table: str, redshift_con: redshift_connector.Connection, databases_parameters: Dict[str, Any]
+) -> None:
     df = get_df_category().drop(["binary"], axis=1, inplace=False)
     wr.s3.to_parquet(df, f"{path}test.parquet")
     bucket, key = wr._utils.parse_path(f"{path}test.csv")
     boto3.client("s3").put_object(Body=b"", Bucket=bucket, Key=key)
     wr.redshift.copy_from_files(
         path=path,
-        path_suffix=[".parquet"],
+        path_suffix=".parquet",
         con=redshift_con,
         table=redshift_table,
         schema="public",
@@ -837,7 +907,7 @@ def test_copy_from_files_extra_params(path, redshift_table, redshift_con, databa
     assert df2["counter"].iloc[0] == 3
 
 
-def test_get_paths_from_manifest(path):
+def test_get_paths_from_manifest(path: str) -> None:
     manifest_content = {
         "entries": [
             {"url": f"{path}test0.parquet", "mandatory": False},
@@ -856,7 +926,9 @@ def test_get_paths_from_manifest(path):
     assert len(paths) == 3
 
 
-def test_copy_from_files_manifest(path, redshift_table, redshift_con, databases_parameters):
+def test_copy_from_files_manifest(
+    path: str, redshift_table: str, redshift_con: redshift_connector.Connection, databases_parameters: Dict[str, Any]
+) -> None:
     df = get_df_category().drop(["binary"], axis=1, inplace=False)
     wr.s3.to_parquet(df, f"{path}test.parquet")
     bucket, key = wr._utils.parse_path(f"{path}test.parquet")
@@ -880,14 +952,16 @@ def test_copy_from_files_manifest(path, redshift_table, redshift_con, databases_
     assert df2["counter"].iloc[0] == 3
 
 
-def test_copy_from_files_ignore(path, redshift_table, redshift_con, databases_parameters):
+def test_copy_from_files_ignore(
+    path: str, redshift_table: str, redshift_con: redshift_connector.Connection, databases_parameters: Dict[str, Any]
+) -> None:
     df = get_df_category().drop(["binary"], axis=1, inplace=False)
     wr.s3.to_parquet(df, f"{path}test.parquet")
     bucket, key = wr._utils.parse_path(f"{path}test.csv")
     boto3.client("s3").put_object(Body=b"", Bucket=bucket, Key=key)
     wr.redshift.copy_from_files(
         path=path,
-        path_ignore_suffix=[".csv"],
+        path_ignore_suffix=".csv",
         con=redshift_con,
         table=redshift_table,
         schema="public",
@@ -897,7 +971,9 @@ def test_copy_from_files_ignore(path, redshift_table, redshift_con, databases_pa
     assert df2["counter"].iloc[0] == 3
 
 
-def test_copy_from_files_empty(path, redshift_table, redshift_con, databases_parameters):
+def test_copy_from_files_empty(
+    path: str, redshift_table: str, redshift_con: redshift_connector.Connection, databases_parameters: Dict[str, Any]
+) -> None:
     df = get_df_category().drop(["binary"], axis=1, inplace=False)
     wr.s3.to_parquet(df, f"{path}test.parquet")
     bucket, key = wr._utils.parse_path(f"{path}test.csv")
@@ -913,7 +989,9 @@ def test_copy_from_files_empty(path, redshift_table, redshift_con, databases_par
     assert df2["counter"].iloc[0] == 3
 
 
-def test_copy_dirty_path(path, redshift_table, redshift_con, databases_parameters):
+def test_copy_dirty_path(
+    path: str, redshift_table: str, redshift_con: redshift_connector.Connection, databases_parameters: Dict[str, Any]
+) -> None:
     df = pd.DataFrame({"col0": [0, 1, 2]})
 
     # previous file at same path
@@ -931,14 +1009,13 @@ def test_copy_dirty_path(path, redshift_table, redshift_con, databases_parameter
 
 
 @pytest.mark.parametrize("dbname", [None, "test"])
-def test_connect_secret_manager(dbname):
-    con = wr.redshift.connect(secret_id="aws-sdk-pandas/redshift", dbname=dbname)
-    df = wr.redshift.read_sql_query("SELECT 1", con=con)
-    con.close()
+def test_connect_secret_manager(dbname: Optional[str]) -> None:
+    with wr.redshift.connect(secret_id="aws-sdk-pandas/redshift", dbname=dbname) as con:
+        df = wr.redshift.read_sql_query("SELECT 1", con=con)
     assert df.shape == (1, 1)
 
 
-def test_copy_unload_session(path, redshift_table, redshift_con):
+def test_copy_unload_session(path: str, redshift_table: str, redshift_con: redshift_connector.Connection) -> None:
     df = pd.DataFrame({"col0": [1, 2, 3]})
     wr.redshift.copy(df=df, path=path, con=redshift_con, schema="public", table=redshift_table, mode="overwrite")
     df2 = wr.redshift.unload(
@@ -974,7 +1051,7 @@ def test_copy_unload_session(path, redshift_table, redshift_con):
         assert len(chunk.columns) == 1
 
 
-def test_copy_unload_creds(path, redshift_table, redshift_con):
+def test_copy_unload_creds(path: str, redshift_table: str, redshift_con: redshift_connector.Connection) -> None:
     credentials = _utils.get_credentials_from_session()
     df = pd.DataFrame({"col0": [1, 2, 3]})
     wr.redshift.copy(
@@ -1033,7 +1110,9 @@ def test_copy_unload_creds(path, redshift_table, redshift_con):
         assert len(chunk.columns) == 1
 
 
-def test_column_length(path, redshift_table, redshift_con, databases_parameters):
+def test_column_length(
+    path: str, redshift_table: str, redshift_con: redshift_connector.Connection, databases_parameters: Dict[str, Any]
+) -> None:
     df = pd.DataFrame({"a": ["foo"], "b": ["a" * 5000]}, dtype="string")
     wr.s3.to_parquet(df, f"{path}test.parquet")
     wr.redshift.copy_from_files(
@@ -1049,7 +1128,9 @@ def test_column_length(path, redshift_table, redshift_con, databases_parameters)
     assert pandas_equals(df, df2)
 
 
-def test_failed_keep_files(path, redshift_table, redshift_con, databases_parameters):
+def test_failed_keep_files(
+    path: str, redshift_table: str, redshift_con: redshift_connector.Connection, databases_parameters: Dict[str, Any]
+) -> None:
     df = pd.DataFrame({"c0": [1], "c1": ["foo"]}, dtype="string")
     with pytest.raises(ProgrammingError):
         wr.redshift.copy(
@@ -1064,7 +1145,7 @@ def test_failed_keep_files(path, redshift_table, redshift_con, databases_paramet
     assert len(wr.s3.list_objects(path)) == 0
 
 
-def test_insert_with_column_names(redshift_table, redshift_con):
+def test_insert_with_column_names(redshift_table: str, redshift_con: redshift_connector.Connection) -> None:
     create_table_sql = (
         f"CREATE TABLE public.{redshift_table} " "(c0 varchar(100), " "c1 integer default 42, " "c2 integer not null);"
     )
@@ -1094,7 +1175,9 @@ def test_insert_with_column_names(redshift_table, redshift_con):
 
 
 @pytest.mark.parametrize("chunksize", [1, 10, 500])
-def test_dfs_are_equal_for_different_chunksizes(redshift_table, redshift_con, chunksize):
+def test_dfs_are_equal_for_different_chunksizes(
+    redshift_table: str, redshift_con: redshift_connector.Connection, chunksize: int
+) -> None:
     df = pd.DataFrame({"c0": [i for i in range(64)], "c1": ["foo" for _ in range(64)]})
     wr.redshift.to_sql(df=df, con=redshift_con, schema="public", table=redshift_table, chunksize=chunksize)
 
@@ -1106,7 +1189,7 @@ def test_dfs_are_equal_for_different_chunksizes(redshift_table, redshift_con, ch
     assert df.equals(df2)
 
 
-def test_to_sql_multi_transaction(redshift_table, redshift_con):
+def test_to_sql_multi_transaction(redshift_table: str, redshift_con: redshift_connector.Connection) -> None:
     df = pd.DataFrame({"id": list((range(10))), "val": list(["foo" if i % 2 == 0 else "boo" for i in range(10)])})
     df2 = pd.DataFrame({"id": list((range(10, 15))), "val": list(["foo" if i % 2 == 0 else "boo" for i in range(5)])})
 
@@ -1137,7 +1220,9 @@ def test_to_sql_multi_transaction(redshift_table, redshift_con):
     assert len(df.columns) == len(df3.columns)
 
 
-def test_copy_upsert_with_column_names(path, redshift_table, redshift_con, databases_parameters):
+def test_copy_upsert_with_column_names(
+    path: str, redshift_table: str, redshift_con: redshift_connector.Connection, databases_parameters: Dict[str, Any]
+) -> None:
     df = pd.DataFrame({"id": list((range(1_000))), "val": list(["foo" if i % 2 == 0 else "boo" for i in range(1_000)])})
     df3 = pd.DataFrame(
         {"id": list((range(1_000, 1_500))), "val": list(["foo" if i % 2 == 0 else "boo" for i in range(500)])}


### PR DESCRIPTION
### Feature or Bugfix
- Chore

### Detail
- Wrap redshift connectors in `with` block
- Also added type annotations for the Redshift unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
