### PR TITLE
fix: Schema evolution for `to_csv` and `to_json`

### DIFF
--- a/awswrangler/catalog/_create.py
+++ b/awswrangler/catalog/_create.py
@@ -434,7 +434,7 @@ def _create_csv_table(  # pylint: disable=too-many-arguments,too-many-locals
     )
 
 
-def _create_json_table(  # pylint: disable=too-many-arguments
+def _create_json_table(  # pylint: disable=too-many-arguments,too-many-locals
     database: str,
     table: str,
     path: str,

--- a/tests/test_s3_parquet.py
+++ b/tests/test_s3_parquet.py
@@ -1,7 +1,7 @@
 import itertools
 import logging
 import math
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 
 import boto3
 import numpy as np
@@ -569,6 +569,41 @@ def test_read_parquet_versioned(path) -> None:
         df_temp = wr.s3.read_parquet(path_file, version_id=version_id)
         assert df_temp.equals(df)
         assert version_id == wr.s3.describe_objects(path=path_file, version_id=version_id)[path_file]["VersionId"]
+
+
+def test_parquet_schema_evolution(path, glue_database, glue_table):
+    df = pd.DataFrame({
+        "id": [1, 2],
+        "value": ["foo", "boo"],
+    })
+    wr.s3.to_parquet(
+        df=df,
+        path=path,
+        dataset=True,
+        mode="overwrite",
+        database=glue_database,
+        table=glue_table,
+    )
+
+    df2 = pd.DataFrame({
+        "id": [3, 4],
+        "value": ["bar", None],
+        "date": [date(2020, 1, 3), date(2020, 1, 4)],
+        "flag": [True, False]
+    })
+    wr.s3.to_parquet(
+        df=df2,
+        path=path,
+        dataset=True,
+        mode="append",
+        database=glue_database,
+        table=glue_table,
+        schema_evolution=True,
+        catalog_versioning=True,
+    )
+
+    column_types = wr.catalog.get_table_types(glue_database, glue_table)
+    assert len(column_types) == len(df2.columns)
 
 
 def test_read_parquet_schema_validation_with_index_column(path) -> None:

--- a/tests/test_s3_parquet.py
+++ b/tests/test_s3_parquet.py
@@ -572,10 +572,12 @@ def test_read_parquet_versioned(path) -> None:
 
 
 def test_parquet_schema_evolution(path, glue_database, glue_table):
-    df = pd.DataFrame({
-        "id": [1, 2],
-        "value": ["foo", "boo"],
-    })
+    df = pd.DataFrame(
+        {
+            "id": [1, 2],
+            "value": ["foo", "boo"],
+        }
+    )
     wr.s3.to_parquet(
         df=df,
         path=path,
@@ -585,12 +587,9 @@ def test_parquet_schema_evolution(path, glue_database, glue_table):
         table=glue_table,
     )
 
-    df2 = pd.DataFrame({
-        "id": [3, 4],
-        "value": ["bar", None],
-        "date": [date(2020, 1, 3), date(2020, 1, 4)],
-        "flag": [True, False]
-    })
+    df2 = pd.DataFrame(
+        {"id": [3, 4], "value": ["bar", None], "date": [date(2020, 1, 3), date(2020, 1, 4)], "flag": [True, False]}
+    )
     wr.s3.to_parquet(
         df=df2,
         path=path,

--- a/tests/test_s3_parquet.py
+++ b/tests/test_s3_parquet.py
@@ -605,7 +605,7 @@ def test_parquet_schema_evolution(path, glue_database, glue_table):
     assert len(column_types) == len(df2.columns)
 
 
-def test_to_csv_schema_evolution_out_of_order(path, glue_database, glue_table) -> None:
+def test_to_parquet_schema_evolution_out_of_order(path, glue_database, glue_table) -> None:
     df = pd.DataFrame({"c0": [0, 1, 2], "c1": ["a", "b", "c"]})
     wr.s3.to_parquet(df=df, path=path, dataset=True, database=glue_database, table=glue_table)
 

--- a/tests/test_s3_parquet.py
+++ b/tests/test_s3_parquet.py
@@ -630,7 +630,6 @@ def test_to_csv_schema_evolution_out_of_order(path, glue_database, glue_table) -
     assert list(df_out.columns) == list(df_expected.columns)
 
 
-
 def test_read_parquet_schema_validation_with_index_column(path) -> None:
     path_file = f"{path}file.parquet"
     df = pd.DataFrame({"idx": [1], "col": [2]})

--- a/tests/test_s3_parquet.py
+++ b/tests/test_s3_parquet.py
@@ -609,7 +609,7 @@ def test_to_csv_schema_evolution_out_of_order(path, glue_database, glue_table) -
     df = pd.DataFrame({"c0": [0, 1, 2], "c1": ["a", "b", "c"]})
     wr.s3.to_parquet(df=df, path=path, dataset=True, database=glue_database, table=glue_table)
 
-    df2 = pd.DataFrame({"c0": [3, 4, 5], "c1": ["a", "b", "c"]})
+    df2 = df.copy()
     df2["c2"] = ["x", "y", "z"]
 
     wr.s3.to_parquet(

--- a/tests/test_s3_text.py
+++ b/tests/test_s3_text.py
@@ -1,4 +1,3 @@
-import datetime as dt
 import logging
 
 import boto3


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Detail
- `to_csv` and `to_json` did not support schema evolution the way that `to_parquet` does

### Relates
- https://github.com/aws/aws-sdk-pandas/issues/2103

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
