### PR TITLE
tests: Replace load tests bucket with SSM parameter

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 from importlib import reload
 from types import ModuleType
-from typing import Iterator
+from typing import Iterator, Optional
 
 import boto3
 import botocore.exceptions
@@ -459,3 +459,12 @@ def awswrangler_import() -> Iterator[ModuleType]:
 
     # Reset for future tests
     awswrangler.config.reset()
+
+
+@pytest.fixture(scope="function")
+def data_gen_bucket() -> Optional[str]:
+    try:
+        ssm_parameter = boto3.client("ssm").get_parameter(Name="/SDKPandas/GlueRay/DataGenBucketName")
+    except botocore.exceptions.ClientError:
+        return None
+    return ssm_parameter["Parameter"]["Value"]  # type: ignore

--- a/tests/load/test_s3.py
+++ b/tests/load/test_s3.py
@@ -72,12 +72,13 @@ def test_s3_read_parquet_simple(
     ],
 )
 def test_s3_read_parquet_many_files(
+    data_gen_bucket: str,
     benchmark_time: float,
     bulk_read: bool,
     validate_schema: bool,
     request: pytest.FixtureRequest,
 ) -> None:
-    path_prefix = "s3://aws-sdk-pandas-list-par-us-east-1-658066294590/small-files-parquet/10000/"
+    path_prefix = f"s3://{data_gen_bucket}/parquet/small/partitioned/10000/"
     file_prefix = "input_1"
 
     paths = [path for path in wr.s3.list_objects(path_prefix) if path[len(path_prefix) :].startswith(file_prefix)]

--- a/tests/load/test_s3_modin.py
+++ b/tests/load/test_s3_modin.py
@@ -28,11 +28,12 @@ def test_modin_s3_read_parquet_simple(benchmark_time: float, request: pytest.Fix
     ],
 )
 def test_modin_s3_read_parquet_many_files(
+    data_gen_bucket: str,
     benchmark_time: float,
     bulk_read: bool,
     request: pytest.FixtureRequest,
 ) -> None:
-    path_prefix = "s3://aws-sdk-pandas-list-par-us-east-1-658066294590/small-files-parquet/10000/"
+    path_prefix = f"s3://{data_gen_bucket}/parquet/small/partitioned/10000/"
     file_prefix = "input_1"
 
     paths = [path for path in wr.s3.list_objects(path_prefix) if path[len(path_prefix) :].startswith(file_prefix)]


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Enhancement

### Detail
- Replace load tests bucket with SSM parameter

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
