### PR TITLE
fix: remove constrain on pandas 1.5+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ python = ">=3.7.1, <4.0"
 
 boto3 = "^1.24.11"
 botocore = "^1.27.11"
-pandas = "^1.2.0, <=1.5.1, !=1.5.0" # Exclusion per: https://github.com/aws/aws-sdk-pandas/issues/1678
+pandas = "^1.2.0, !=1.5.0" # Exclusion per: https://github.com/aws/aws-sdk-pandas/issues/1678
 numpy = [
     { version = ">=1.21.0 <=1.23.4", markers = "python_full_version >= '3.7.1' and python_full_version < '3.11.0'" },
     { version = "^1.23.5", markers = "python_full_version >= '3.11.0'" },


### PR DESCRIPTION
Pandas 1.5.0 had a memory leak with awswrangler,
but according to https://github.com/aws/aws-sdk-pandas/issues/1678 it is no longer the case.

The current dependency expressed in pyproject.toml locks dependents to use only 1.5.1. Since the bug has been fixed in pandas we can now remove the lock.

### Feature or Bugfix
- Bugfix

### Detail
- awswranger does not let people use pandas 1.5.2+

### Relates
- https://github.com/aws/aws-sdk-pandas/issues/1678

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
