### PR TITLE
chore: Remove `parallelism` parameter from S3 wait methods

### DIFF
--- a/awswrangler/s3/_wait.py
+++ b/awswrangler/s3/_wait.py
@@ -39,19 +39,19 @@ def _wait_objects(
     delay: Optional[float],
     max_attempts: Optional[int],
     use_threads: Union[bool, int],
-    parallelism: Optional[int],
     s3_client: "S3Client",
 ) -> None:
     delay = 5 if delay is None else delay
     max_attempts = 20 if max_attempts is None else max_attempts
-    parallelism = 100 if parallelism is None else parallelism
+
+    concurrency = _utils.ensure_worker_or_thread_count(use_threads)
 
     if len(paths) < 1:
         return None
 
     path_batches = (
-        _utils.chunkify(paths, num_chunks=parallelism)
-        if len(paths) > parallelism
+        _utils.chunkify(paths, num_chunks=concurrency)
+        if len(paths) > concurrency
         else _utils.chunkify(paths, max_length=1)
     )
 
@@ -79,7 +79,6 @@ def wait_objects_exist(
     max_attempts: Optional[int] = None,
     use_threads: Union[bool, int] = True,
     boto3_session: Optional[boto3.Session] = None,
-    parallelism: Optional[int] = None,
 ) -> None:
     """Wait Amazon S3 objects exist.
 
@@ -104,9 +103,6 @@ def wait_objects_exist(
         True to enable concurrent requests, False to disable multiple threads.
         If enabled os.cpu_count() will be used as the max number of threads.
         If integer is provided, specified number is used.
-    parallelism: int, optional
-        The requested parallelism of the wait. Only used when `distributed` add-on is installed.
-        Parallelism may be limited by the number of files of the dataset. 100 by default.
     boto3_session : boto3.Session(), optional
         Boto3 Session. The default boto3 session will be used if boto3_session receive None.
 
@@ -128,7 +124,6 @@ def wait_objects_exist(
         delay=delay,
         max_attempts=max_attempts,
         use_threads=use_threads,
-        parallelism=parallelism,
         s3_client=s3_client,
     )
 
@@ -142,7 +137,6 @@ def wait_objects_not_exist(
     max_attempts: Optional[int] = None,
     use_threads: Union[bool, int] = True,
     boto3_session: Optional[boto3.Session] = None,
-    parallelism: Optional[int] = None,
 ) -> None:
     """Wait Amazon S3 objects not exist.
 
@@ -167,9 +161,6 @@ def wait_objects_not_exist(
         True to enable concurrent requests, False to disable multiple threads.
         If enabled os.cpu_count() will be used as the max number of threads.
         If integer is provided, specified number is used.
-    parallelism: int, optional
-        The requested parallelism of the wait. Only used when `distributed` add-on is installed.
-        Parallelism may be limited by the number of files of the dataset. 100 by default.
     boto3_session : boto3.Session(), optional
         Boto3 Session. The default boto3 session will be used if boto3_session receive None.
 
@@ -191,6 +182,5 @@ def wait_objects_not_exist(
         delay=delay,
         max_attempts=max_attempts,
         use_threads=use_threads,
-        parallelism=parallelism,
         s3_client=s3_client,
     )

--- a/tests/load/test_s3.py
+++ b/tests/load/test_s3.py
@@ -228,7 +228,7 @@ def test_wait_object_exists(path: str, benchmark_time: int, request: pytest.Fixt
     paths = wr.s3.to_parquet(df=df, path=path, max_rows_by_file=1)["paths"]
 
     with ExecutionTimer(request) as timer:
-        wr.s3.wait_objects_exist(paths, parallelism=16)
+        wr.s3.wait_objects_exist(paths, use_threads=16)
 
     assert timer.elapsed_time < benchmark_time
 
@@ -240,7 +240,7 @@ def test_wait_object_not_exists(path: str, benchmark_time: int, request: pytest.
     file_paths = [f"{path}{i}.txt" for i in range(num_objects)]
 
     with ExecutionTimer(request) as timer:
-        wr.s3.wait_objects_not_exist(file_paths, parallelism=16)
+        wr.s3.wait_objects_not_exist(file_paths, use_threads=16)
 
     assert timer.elapsed_time < benchmark_time
 


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Detail
- Replace usage of the `parallelism` argument with `use_threads`, as we do elsewhere in the codebase (e.g. `wr.dynamodb.read_items`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
