### PR TITLE
chore: Typing improvements

### DIFF
--- a/awswrangler/distributed/ray/modin/s3/_write_dataset.py
+++ b/awswrangler/distributed/ray/modin/s3/_write_dataset.py
@@ -4,7 +4,6 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
 import boto3
 import modin.pandas as pd
 import numpy as np
-from pandas import DataFrame as PandasDataFrame
 
 from awswrangler import _utils, typing
 from awswrangler._distributed import engine
@@ -139,8 +138,8 @@ def _to_partitions_distributed(  # pylint: disable=unused-argument
     if not bucketing_info:
         # If only partitioning (without bucketing), avoid expensive modin groupby
         # by partitioning and writing each block as an ordinary Pandas DataFrame
-        _to_partitions_func = engine.dispatch_func(_to_partitions, PandasDataFrame)
-        func = engine.dispatch_func(func, PandasDataFrame)
+        _to_partitions_func = engine.dispatch_func(_to_partitions, "python")
+        func = engine.dispatch_func(func, "python")
 
         @ray_remote()
         def write_partitions(df: pd.DataFrame, block_index: int) -> Tuple[List[str], Dict[str, List[str]]]:

--- a/awswrangler/s3/_write.py
+++ b/awswrangler/s3/_write.py
@@ -2,7 +2,7 @@
 
 import logging
 from enum import Enum
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, NamedTuple, Optional
 
 import pandas as pd
 
@@ -95,12 +95,19 @@ def _validate_args(
         )
 
 
+class _SanitizeResult(NamedTuple):
+    frame: pd.DataFrame
+    dtype: Dict[str, str]
+    partition_cols: List[str]
+    bucketing_info: Optional[typing.BucketingInfoTuple]
+
+
 def _sanitize(
     df: pd.DataFrame,
     dtype: Dict[str, str],
     partition_cols: List[str],
-    bucketing_info: Optional[Tuple[List[str], int]] = None,
-) -> Tuple[pd.DataFrame, Dict[str, str], List[str], Optional[Tuple[List[str], int]]]:
+    bucketing_info: Optional[typing.BucketingInfoTuple] = None,
+) -> _SanitizeResult:
     df = catalog.sanitize_dataframe_columns_names(df=df)
     partition_cols = [catalog.sanitize_column_name(p) for p in partition_cols]
     if bucketing_info:
@@ -109,4 +116,4 @@ def _sanitize(
         ], bucketing_info[1]
     dtype = {catalog.sanitize_column_name(k): v.lower() for k, v in dtype.items()}
     _utils.check_duplicated_columns(df=df)
-    return df, dtype, partition_cols, bucketing_info
+    return _SanitizeResult(df, dtype, partition_cols, bucketing_info)

--- a/docs/source/scale.rst
+++ b/docs/source/scale.rst
@@ -16,7 +16,9 @@ Once installed, you can use the library in your code as usual:
 
     >>> import awswrangler as wr
 
-At import, SDK for pandas looks for an environmental variable called ``WR_ADDRESS``. If found, it is used to send commands to a remote cluster. If not found, a local Ray runtime is initialized on your machine instead.
+At import, SDK for pandas looks for an environmental variable called ``WR_ADDRESS``.
+If found, it is used to send commands to a remote cluster.
+If not found, a local Ray runtime is initialized on your machine instead.
 
 To confirm that you are in distributed mode, run:
 
@@ -124,14 +126,18 @@ S3FS Filesystem
 ^^^^^^^^^^^^^^^^
 
 When Ray is chosen as an engine, `S3Fs <https://s3fs.readthedocs.io/en/latest/>`_ is used instead of boto3 for certain API calls.
-These include listing a large number of S3 objects for example. This choice was made for performance reasons as a boto3 implementation can be much slower in some cases.
-As a side effect, users won't be able to use the ``s3_additional_kwargs`` input parameter as it's currently not supported by S3Fs.
+These include listing a large number of S3 objects for example.
+This choice was made for performance reasons as a boto3 implementation can be much slower in some cases.
+As a side effect,
+users won't be able to use the ``s3_additional_kwargs`` input parameter as it's currently not supported by S3Fs.
 
 Unsupported kwargs
 ^^^^^^^^^^^^^^^^^^^
 
-Most AWS SDK for pandas calls support passing the ``boto3_session`` argument. While this is acceptable for an application running in a single process,
-distributed applications require the session to be serialized and passed to the worker nodes in the cluster. This constitutes a security risk.
+Most AWS SDK for pandas calls support passing the ``boto3_session`` argument.
+While this is acceptable for an application running in a single process,
+distributed applications require the session to be serialized and passed to the worker nodes in the cluster.
+This constitutes a security risk.
 As a result, passing ``boto3_session`` when using the Ray runtime is not supported.
 
 To learn more

--- a/validate.sh
+++ b/validate.sh
@@ -6,4 +6,4 @@ ruff . --ignore "PL" --ignore "D"
 ruff awswrangler
 mypy --install-types --non-interactive awswrangler
 pylint -j 0 --disable=all --enable=R0913,R0915 awswrangler
-doc8 --ignore D005,D002 --max-line-length 120 docs/source
+doc8 --ignore D005,D002 --ignore-path docs/source/stubs --max-line-length 120 docs/source


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Detail
- Fix line-too-long errors in `about.rst` which have been causing static check errors
- Clarify return type of `_sanitize` function. A named tuple will make it clearer what each of the 4 values in the tuple represents
- Add string literals for engine and memory format specification.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
