### PR TITLE
chore: Add typeddicts to docs

### DIFF
--- a/docs/source/_templates/typed-dict-template.rst
+++ b/docs/source/_templates/typed-dict-template.rst
@@ -1,0 +1,32 @@
+{{ objname }}
+{{ underline }}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+    :show-inheritance:
+
+    {% block attributes_summary %}
+    {% if attributes %}
+
+    .. rubric:: Attributes
+
+    .. autosummary::
+    {% for item in attributes %}
+        ~{{ name }}.{{ item }}
+    {%- endfor %}
+
+    {% endif %}
+    {% endblock %}
+
+    {% block methods_documentation %}
+    {% if methods %}
+
+    .. rubric:: Attributes Documentation
+
+    {% for item in attributes %}
+    .. autoattribute:: {{ item }}
+    {%- endfor %}
+
+    {% endif %}
+    {% endblock %}

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -23,6 +23,7 @@ API Reference
 * `AWS STS`_
 * `AWS Secrets Manager`_
 * `Amazon Chime`_
+* `Typing`_
 * `Global Configurations`_
 * `Distributed - Ray`_
 
@@ -440,6 +441,24 @@ Amazon Chime
     :toctree: stubs
 
     post_message
+
+Typing
+---------------------
+
+.. currentmodule:: awswrangler.typing
+
+.. autosummary::
+    :toctree: stubs
+    :template: typed-dict-template.rst
+
+    GlueTableSettings
+    AthenaCTASSettings
+    AthenaUNLOADSettings
+    AthenaCacheSettings
+    AthenaPartitionProjectionSettings
+    RaySettings
+    RayReadParquetSettings
+    _S3WriteDataReturnValue
 
 Global Configurations
 ---------------------


### PR DESCRIPTION
### Feature or Bugfix
- Documentation

### Detail
- Add the TypedDict classes from `awswrangler.typing` into the docs
- I had to create a new template in order to properly display the `TypedDict`.

<img width="879" alt="typed-dict-docs" src="https://user-images.githubusercontent.com/15194249/229206808-8a93363d-319e-41b5-bf47-7e8e9ae226e4.png">

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
