### PR TITLE
docs: Fix links to 'Who uses library' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Powered By [<img src="https://arrow.apache.org/img/arrow.png" width="200">](http
 - [Getting Help](#getting-help)
 - [Community Resources](#community-resources)
 - [Logging](#logging)
-- [Who uses AWS SDK for pandas?](#who-uses-aws-sdk-pandas)
+- [Who uses AWS SDK for pandas?](#who-uses-aws-sdk-for-pandas)
 
 ## Quick Start
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -72,7 +72,7 @@ Read The Docs
    api
    Community Resources <https://github.com/aws/aws-sdk-pandas#community-resources>
    Logging <https://github.com/aws/aws-sdk-pandas#logging>
-   Who uses AWS SDK for pandas? <https://github.com/aws/aws-sdk-pandas#who-uses-aws-sdk-pandas>
+   Who uses AWS SDK for pandas? <https://github.com/aws/aws-sdk-pandas#who-uses-aws-sdk-for-pandas>
    License <https://github.com/aws/aws-sdk-pandas/blob/main/LICENSE.txt>
    Contributing <https://github.com/aws/aws-sdk-pandas/blob/main/CONTRIBUTING.md>
 


### PR DESCRIPTION
### Feature or Bugfix
- Documentation

### Detail
- Fix links to 'Who uses library' section

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
