### PR TITLE
fix: Tox environment dependency issues

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
        s3fs==0.4.2
 allowlist_externals = poetry
 commands_pre =
-       poetry install --no-root --sync
+       poetry install --no-root --sync --extras "deltalake gremlin mysql opencypher opensearch oracle postgres redshift sparql sqlserver"
 commands =
        pytest -n {posargs} -s -v --timeout=300 --reruns=2 --reruns-delay=15 \
               --cov=awswrangler --cov-report=xml --cov-report term-missing --cov-branch \
@@ -39,10 +39,8 @@ setenv =
        COV_FAIL_UNDER = 74.00
 deps =
        {[testenv]deps}
-       .[ray]
-       .[modin]
 allowlist_externals = poetry
 commands_pre =
-       {[testenv]commands_pre}
+       poetry install --no-root --sync --all-extras
 commands =
        {[testenv]commands}

--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,7 @@ passenv =
        AWS_SESSION_TOKEN
 setenv =
        COV_FAIL_UNDER = 87.00
-deps =
-       poetry
+allowlist_externals = poetry
 commands_pre =
        poetry install --no-root --sync --extras "deltalake gremlin mysql opencypher opensearch oracle postgres redshift sparql sqlserver"
 commands =
@@ -30,8 +29,7 @@ passenv =
        AWS_SESSION_TOKEN
 setenv =
        COV_FAIL_UNDER = 74.00
-deps =
-       {[testenv]deps}
+allowlist_externals = poetry
 commands_pre =
        poetry install --no-root --sync --all-extras
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -11,18 +11,10 @@ passenv =
        AWS_SESSION_TOKEN
 setenv =
        COV_FAIL_UNDER = 87.00
+allowlist_externals = poetry
+commands_pre =
+       poetry install --no-root --sync
 deps =
-       .[deltalake]
-       .[gremlin]
-       .[mysql]
-       .[opencypher]
-       .[openpyxl]
-       .[opensearch]
-       .[oracle]
-       .[postgres]
-       .[redshift]
-       .[sparql]
-       .[sqlserver]
        pytest==7.1.2
        pytest-cov==4.0.0
        pytest-rerunfailures==10.2

--- a/tox.ini
+++ b/tox.ini
@@ -12,14 +12,7 @@ passenv =
 setenv =
        COV_FAIL_UNDER = 87.00
 deps =
-       pytest==7.1.2
-       pytest-cov==4.0.0
-       pytest-rerunfailures==10.2
-       pytest-xdist==3.0.2
-       pytest-timeout==2.1.0
-       moto==4.0.3
-       s3fs==0.4.2
-allowlist_externals = poetry
+       poetry
 commands_pre =
        poetry install --no-root --sync --extras "deltalake gremlin mysql opencypher opensearch oracle postgres redshift sparql sqlserver"
 commands =
@@ -39,7 +32,6 @@ setenv =
        COV_FAIL_UNDER = 74.00
 deps =
        {[testenv]deps}
-allowlist_externals = poetry
 commands_pre =
        poetry install --no-root --sync --all-extras
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -11,9 +11,6 @@ passenv =
        AWS_SESSION_TOKEN
 setenv =
        COV_FAIL_UNDER = 87.00
-allowlist_externals = poetry
-commands_pre =
-       poetry install --no-root --sync
 deps =
        pytest==7.1.2
        pytest-cov==4.0.0
@@ -22,6 +19,9 @@ deps =
        pytest-timeout==2.1.0
        moto==4.0.3
        s3fs==0.4.2
+allowlist_externals = poetry
+commands_pre =
+       poetry install --no-root --sync
 commands =
        pytest -n {posargs} -s -v --timeout=300 --reruns=2 --reruns-delay=15 \
               --cov=awswrangler --cov-report=xml --cov-report term-missing --cov-branch \
@@ -41,5 +41,8 @@ deps =
        {[testenv]deps}
        .[ray]
        .[modin]
+allowlist_externals = poetry
+commands_pre =
+       {[testenv]commands_pre}
 commands =
        {[testenv]commands}


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Tox wasn't installing versions of dependencies from `poetry.lock`. The script therefore updated from PyArrow 11 to PyArrow 12 behind the scenes, causing issues with index recovery.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
