### PR TITLE
feat: add time unit to timestream write API

### DIFF
--- a/tests/unit/test_timestream.py
+++ b/tests/unit/test_timestream.py
@@ -693,4 +693,4 @@ def test_time_unit_precision(timestream_database_and_table, time_unit):
         FROM "{timestream_database_and_table}"."{timestream_database_and_table}"
         """,
     )
-    assert len(str(df_query["time"][0].timestamp()).split('.')[1]) == time_unit[1]
+    assert len(str(df_query["time"][0].timestamp()).split(".")[1]) == time_unit[1]

--- a/tests/unit/test_timestream.py
+++ b/tests/unit/test_timestream.py
@@ -354,6 +354,17 @@ def test_exceptions():
             report_s3_configuration={"BucketName": "test", "ObjectKeyPrefix": "test"},
         )
 
+    # NANOSECONDS not supported with time_col
+    with pytest.raises(wr.exceptions.InvalidArgumentValue):
+        wr.timestream.write(
+            df=df,
+            database=database,
+            table=table,
+            time_col=time_col,
+            time_unit="NANOSECONDS",
+            common_attributes={"MeasureName": "test", "MeasureValue": "13.1", "MeasureValueType": "Double"},
+        )
+
 
 def test_multimeasure_scenario(timestream_database_and_table):
     df = pd.DataFrame(
@@ -666,7 +677,7 @@ def test_batch_load(timestream_database_and_table, path, path2, time_unit, keep_
 def test_time_unit_precision(timestream_database_and_table, time_unit):
     df_write = pd.DataFrame(
         {
-            "time": [time.time() * pow(10, 9)] * 3,
+            "time": [datetime.now()] * 3,
             "dim0": ["foo", "boo", "bar"],
             "dim1": [1, 2, 3],
             "measure0": ["a", "b", "c"],


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Feature

Current timestream write API is limited to MILLISECONDS precision only. This PR attempts to enable other time units (SECONDS, MICROSECONDS and NANOSECONDS).

One remaining issue is how to handle NANOSECONDS precision. `datetime` python objects are limited to microseconds precision so we would not be able to handle that.

### Detail
- Allow `time_unit` parameter to write method

### Relates
- #2261

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
