### PR TITLE
fix: Recurring issue with `test_spectrum_decimal_cast`

### DIFF
--- a/tests/unit/test_redshift.py
+++ b/tests/unit/test_redshift.py
@@ -593,7 +593,7 @@ def test_spectrum_decimal_cast(
     # Athena
     df2 = wr.athena.read_sql_table(table=glue_table, database=glue_database)
     assert df2.shape == (2, 5)
-    df2 = df2[df2.c0 != 2]
+    df2 = df2[df2.c0 != 2].reset_index(drop=True)
     assert df2.c1[0] == Decimal("1.00000")
     assert df2.c2[0] == Decimal("2.22222")
     assert df2.c3[0] == Decimal("3.33333")
@@ -603,7 +603,7 @@ def test_spectrum_decimal_cast(
     with wr.redshift.connect(connection="aws-sdk-pandas-redshift") as con:
         df2 = wr.redshift.read_sql_table(table=glue_table, schema=redshift_external_schema, con=con)
     assert df2.shape == (2, 5)
-    df2 = df2[df2.c0 != 2]
+    df2 = df2[df2.c0 != 2].reset_index(drop=True)
     assert df2.c1[0] == Decimal("1.00000")
     assert df2.c2[0] == Decimal("2.22222")
     assert df2.c3[0] == Decimal("3.33333")
@@ -618,7 +618,7 @@ def test_spectrum_decimal_cast(
             path=path2,
         )
     assert df2.shape == (2, 5)
-    df2 = df2[df2.c0 != 2]
+    df2 = df2[df2.c0 != 2].reset_index(drop=True)
     assert df2.c1[0] == Decimal("1.00000")
     assert df2.c2[0] == Decimal("2.22222")
     assert df2.c3[0] == Decimal("3.33333")


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail

Fix recurring issue with `test_spectrum_decimal_cast`. The problem was that after filtering out the frame:

```python
df2 = df2[df2.c0 != 2]
```

we were trying to access the element with the index value `0`

```python
assert df2.c1[0] == Decimal("1.00000")
```

The filtering does not remove the index of each row. Since the data gets shuffled by the Athena query, there's a 50% chance that the value we want to access still has an index of `1`.

I resolved the issue by simply resetting the index of the filtered data frame, so that the only element in it will always have an index of `0`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
