### PR TITLE
feat: Opensearch parallel bulk

### DIFF
--- a/awswrangler/opensearch/_write.py
+++ b/awswrangler/opensearch/_write.py
@@ -491,6 +491,11 @@ def index_documents(
 
     Note
     ----
+    `max_retries`, `initial_backoff`, and `max_backoff` are not supported with parallel bulk
+     (when `use_threads`is set to True).
+
+    Note
+    ----
     Some of the args are referenced from opensearch-py client library (bulk helpers)
     https://opensearch-py.readthedocs.io/en/latest/helpers.html#opensearchpy.helpers.bulk
     https://opensearch-py.readthedocs.io/en/latest/helpers.html#opensearchpy.helpers.streaming_bulk


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
- Implement parallel bulk
- Off (no threads) by default to avoid introducing breaking changes for the users
- Note parallel bulk does not support a few minority parameters: max_retries, initial_backoff & max_backoff. Whether to require user to explicitly set those to None (as they have defaults in regular bulk) in order to be able to use parallel bulk is open for discussion.

### Relates
- #1968 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
