### PR TITLE
fix: Engine initialization did not respect OS env

### DIFF
--- a/awswrangler/_distributed.py
+++ b/awswrangler/_distributed.py
@@ -112,7 +112,7 @@ class Engine:
     def register(cls, name: Optional[EngineLiteral] = None) -> None:
         """Register the distribution engine dispatch methods."""
         with cls._lock:
-            engine_name = cast(EngineLiteral, name or WR_ENGINE or cls.get_installed().value)
+            engine_name = cast(EngineLiteral, name or cls.get().value)
             cls.set(engine_name)
             cls._registry.clear()
 

--- a/awswrangler/_distributed.py
+++ b/awswrangler/_distributed.py
@@ -11,8 +11,14 @@ from functools import wraps
 from importlib import reload
 from typing import Any, Callable, Dict, Literal, Optional, TypeVar, cast
 
-WR_ENGINE = os.getenv("WR_ENGINE")
-WR_MEMORY_FORMAT = os.getenv("WR_MEMORY_FORMAT")
+EngineLiteral = Literal["python", "ray"]
+MemoryFormatLiteral = Literal["pandas", "modin"]
+
+FunctionType = TypeVar("FunctionType", bound=Callable[..., Any])
+
+
+WR_ENGINE: Optional[EngineLiteral] = os.getenv("WR_ENGINE")  # type: ignore[assignment]
+WR_MEMORY_FORMAT: Optional[MemoryFormatLiteral] = os.getenv("WR_MEMORY_FORMAT")  # type: ignore[assignment]
 
 
 @unique
@@ -29,11 +35,6 @@ class MemoryFormatEnum(Enum):
 
     MODIN = "modin"
     PANDAS = "pandas"
-
-
-EngineLiteral = Literal["python", "ray"]
-MemoryFormatLiteral = Literal["pandas", "modin"]
-FunctionType = TypeVar("FunctionType", bound=Callable[..., Any])
 
 
 class Engine:
@@ -111,7 +112,7 @@ class Engine:
     def register(cls, name: Optional[EngineLiteral] = None) -> None:
         """Register the distribution engine dispatch methods."""
         with cls._lock:
-            engine_name = cast(EngineLiteral, name or cls.get_installed().value)
+            engine_name = cast(EngineLiteral, name or WR_ENGINE or cls.get_installed().value)
             cls.set(engine_name)
             cls._registry.clear()
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
Engine initialization did not respect OS env. When importing `awswrangler`, `engine.register` gets called. This function looks at only the value of the `name` parameter (`None` in this case) or the output of `engine.get_installed()`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
