### PR TITLE
feat: Apache Spark on Amazon Athena - `wr.athena.create_spark_session` & `wr.athena.run_spark_calculation`

### DIFF
--- a/awswrangler/athena/__init__.py
+++ b/awswrangler/athena/__init__.py
@@ -6,7 +6,7 @@ from awswrangler.athena._executions import (  # noqa
     start_query_execution,
     wait_query,
 )
-from awswrangler.athena._spark import run_spark_calculation
+from awswrangler.athena._spark import create_spark_session, run_spark_calculation
 from awswrangler.athena._read import (  # noqa
     get_query_results,
     read_sql_query,
@@ -43,6 +43,7 @@ __all__ = [
     "generate_create_query",
     "list_query_executions",
     "repair_table",
+    "create_spark_session",
     "run_spark_calculation",
     "create_ctas_table",
     "show_create_table",

--- a/awswrangler/athena/__init__.py
+++ b/awswrangler/athena/__init__.py
@@ -6,6 +6,7 @@ from awswrangler.athena._executions import (  # noqa
     start_query_execution,
     wait_query,
 )
+from awswrangler.athena._spark import run_spark_calculation
 from awswrangler.athena._read import (  # noqa
     get_query_results,
     read_sql_query,
@@ -42,6 +43,7 @@ __all__ = [
     "generate_create_query",
     "list_query_executions",
     "repair_table",
+    "run_spark_calculation",
     "create_ctas_table",
     "show_create_table",
     "start_query_execution",

--- a/awswrangler/athena/_spark.py
+++ b/awswrangler/athena/_spark.py
@@ -45,7 +45,6 @@ def _wait_session(
     return response
 
 
-# TODO: refactor copy-pasted waiters
 def _wait_calculation_execution(
     calculation_execution_id: str,
     boto3_session: Optional[boto3.Session] = None,
@@ -83,11 +82,6 @@ def _get_calculation_execution_results(
     response: "GetCalculationExecutionResponseTypeDef" = client_athena.get_calculation_execution(
         CalculationExecutionId=calculation_execution_id,
     )
-    # TODO: process results by content-types
-    # result_type = response["Result"]["ResultType"]
-    # result_s3_uri = response["Result"]["ResultS3Uri"]
-    # if result_type == "application/vnd.aws.athena.v1+json":
-    #    return s3.read_json(path=result_s3_uri)
     return cast(Dict[str, Any], response)
 
 

--- a/awswrangler/athena/_spark.py
+++ b/awswrangler/athena/_spark.py
@@ -100,12 +100,20 @@ def create_spark_session(
     Parameters
     ----------
     workgroup : str
+        Athena workgroup name. Must be Spark-enabled.
     coordinator_dpu_size : int, optional
+        The number of DPUs to use for the coordinator. A coordinator is a special executor that orchestrates
+        processing work and manages other executors in a notebook session. The default is 1.
     max_concurrent_dpus : int, optional
+        The maximum number of DPUs that can run concurrently. The default is 5.
     default_executor_dpu_size: int, optional
+        The default number of DPUs to use for executors. The default is 1.
     additional_configs : Dict[str, Any], optional
+        Contains additional engine parameter mappings in the form of key-value pairs.
     idle_timeout : int, optional
+         The idle timeout in minutes for the session. The default is 15.
     boto3_session : boto3.Session(), optional
+        Boto3 Session. The default boto3 session will be used if boto3_session receive None.
 
     Returns
     -------
@@ -151,14 +159,24 @@ def run_spark_calculation(
     Parameters
     ----------
     code : str
+        A string that contains the code for the calculation.
     workgroup : str
+        Athena workgroup name. Must be Spark-enabled.
     session_id : str, optional
+        The session id. If not passed, a session will be started.
     coordinator_dpu_size : int, optional
+        The number of DPUs to use for the coordinator. A coordinator is a special executor that orchestrates
+        processing work and manages other executors in a notebook session. The default is 1.
     max_concurrent_dpus : int, optional
+        The maximum number of DPUs that can run concurrently. The default is 5.
     default_executor_dpu_size: int, optional
+        The default number of DPUs to use for executors. The default is 1.
     additional_configs : Dict[str, Any], optional
+        Contains additional engine parameter mappings in the form of key-value pairs.
     idle_timeout : int, optional
+        The idle timeout in minutes for the session. The default is 15.
     boto3_session : boto3.Session(), optional
+        Boto3 Session. The default boto3 session will be used if boto3_session receive None.
 
     Returns
     -------

--- a/awswrangler/athena/_spark.py
+++ b/awswrangler/athena/_spark.py
@@ -1,0 +1,166 @@
+"""Amazon Spark on Athena Calculations Module."""
+# pylint: disable=too-many-lines
+import logging
+import time
+from typing import Any, Dict, List, Optional, Union
+
+import boto3
+import pandas as pd
+
+from awswrangler import _utils, exceptions, s3
+
+_logger: logging.Logger = logging.getLogger(__name__)
+
+
+_SESSION_FINAL_STATES: List[str] = ["IDLE", "TERMINATED", "DEGRADED", "FAILED"]
+_CALCULATION_EXECUTION_FINAL_STATES: List[str] = ["COMPLETED", "FAILED", "CANCELED"]
+_SESSION_WAIT_POLLING_DELAY: float = 5.0  # SECONDS
+_CALCULATION_EXECUTION_WAIT_POLLING_DELAY: float = 5.0  # SECONDS
+
+
+def _wait_session(
+    session_id: str,
+    boto3_session: Optional[boto3.Session] = None,
+    athena_session_wait_polling_delay: float = _SESSION_WAIT_POLLING_DELAY,
+) -> Dict[str, Any]:
+    client_athena = _utils.client(service_name="athena", session=boto3_session)
+
+    response: Dict[str, Any] = client_athena.get_session_status(SessionId=session_id)
+    state: str = response["Status"]["State"]
+
+    while state not in _SESSION_FINAL_STATES:
+        time.sleep(athena_session_wait_polling_delay)
+        response = client_athena.get_session_status(SessionId=session_id)
+        state = response["Status"]["State"]
+    _logger.debug("Session state: %s", state)
+    _logger.debug("Session state change reason: %s", response["Status"].get("StateChangeReason"))
+    if state in ["FAILED", "DEGRADED", "TERMINATED"]:
+        raise exceptions.SessionFailed(response["Status"].get("StateChangeReason"))
+    return response
+
+
+# TODO: refactor copy-paste
+def _wait_calculation_execution(
+    calculation_execution_id: str,
+    boto3_session: Optional[boto3.Session] = None,
+    athena_calculation_execution_wait_polling_delay: float = _CALCULATION_EXECUTION_WAIT_POLLING_DELAY,
+) -> Dict[str, Any]:
+    client_athena = _utils.client(service_name="athena", session=boto3_session)
+
+    response: Dict[str, Any] = client_athena.get_calculation_execution_status(
+        CalculationExecutionId=calculation_execution_id
+    )
+    state: str = response["Status"]["State"]
+
+    while state not in _CALCULATION_EXECUTION_FINAL_STATES:
+        time.sleep(athena_calculation_execution_wait_polling_delay)
+        response = client_athena.get_calculation_execution_status(CalculationExecutionId=calculation_execution_id)
+        state = response["Status"]["State"]
+    _logger.debug("Calculation execution state: %s", state)
+    _logger.debug("Calculation execution state change reason: %s", response["Status"].get("StateChangeReason"))
+    if state in ["CANCELED", "FAILED"]:
+        raise exceptions.CalculationFailed(response["Status"].get("StateChangeReason"))
+    return response
+
+
+def _get_calculation_execution_results(
+    calculation_execution_id: str,
+    boto3_session: Optional[boto3.Session] = None,
+) -> Union[str, pd.DataFrame, Dict[str, Any]]:
+    client_athena = _utils.client(service_name="athena", session=boto3_session)
+
+    _wait_calculation_execution(
+        calculation_execution_id=calculation_execution_id,
+        boto3_session=boto3_session,
+    )
+
+    response = client_athena.get_calculation_execution(
+        CalculationExecutionId=calculation_execution_id,
+    )
+    result_type = response["Result"]["ResultType"]
+    result_s3_uri = response["Result"]["ResultS3Uri"]
+
+    # TODO: process other content-types
+    if result_type == "application/vnd.aws.athena.v1+json":
+        return s3.read_json(path=result_s3_uri)
+
+    return response
+
+
+def create_session(
+    workgroup: str,
+    notebook_id: Optional[str] = None,
+    notebook_version: str = "Athena notebook version 1",
+    coordinator_dpu_size: int = 1,
+    max_concurrent_dpus: int = 5,
+    default_executor_dpu_size: int = 1,
+    additional_configs: Optional[Dict[str, Any]] = None,
+    idle_timeout: int = 15,
+    boto3_session: Optional[boto3.Session] = None,
+):
+    client_athena = _utils.client(service_name="athena", session=boto3_session)
+    engine_configuration: Dict[str, Any] = {
+        "CoordinatorDpuSize": coordinator_dpu_size,
+        "MaxConcurrentDpus": max_concurrent_dpus,
+        "DefaultExecutorDpuSize": default_executor_dpu_size,
+    }
+    if additional_configs:
+        engine_configuration["AdditionalConfigs"] = additional_configs
+    response = client_athena.start_session(
+        WorkGroup=workgroup,
+        EngineConfiguration=engine_configuration,
+        # NotebookId=notebook_id,
+        # NotebookVersion=notebook_version if notebook_id else None,
+        SessionIdleTimeoutInMinutes=idle_timeout,
+    )
+    _logger.info("Session info:\n%s", response)
+    session_id: str = response["SessionId"]
+    # Wait for the session to reach IDLE state to be able to accept calculations
+    _wait_session(
+        session_id=session_id,
+        boto3_session=boto3_session,
+    )
+    return session_id
+
+
+def run_spark_calculation(
+    code: str,
+    workgroup: str,
+    session_id: Optional[str] = None,
+    notebook_id: Optional[str] = None,
+    notebook_version: str = "Athena notebook version 1",
+    coordinator_dpu_size: int = 1,
+    max_concurrent_dpus: int = 5,
+    default_executor_dpu_size: int = 1,
+    additional_configs: Optional[Dict[str, Any]] = None,
+    idle_timeout: int = 15,
+    boto3_session: Optional[boto3.Session] = None,
+) -> Union[str, pd.DataFrame, Dict[str, Any]]:
+    client_athena = _utils.client(service_name="athena", session=boto3_session)
+
+    session_id = (
+        create_session(
+            workgroup=workgroup,
+            notebook_id=notebook_id,
+            notebook_version=notebook_version,
+            coordinator_dpu_size=coordinator_dpu_size,
+            max_concurrent_dpus=max_concurrent_dpus,
+            default_executor_dpu_size=default_executor_dpu_size,
+            additional_configs=additional_configs,
+            idle_timeout=idle_timeout,
+            boto3_session=boto3_session,
+        )
+        if not session_id
+        else session_id
+    )
+
+    response = client_athena.start_calculation_execution(
+        SessionId=session_id,
+        CodeBlock=code,
+    )
+    _logger.info("Calculation execution info:\n%s", response)
+
+    return _get_calculation_execution_results(
+        calculation_execution_id=response["CalculationExecutionId"],
+        boto3_session=boto3_session,
+    )

--- a/awswrangler/athena/_spark.py
+++ b/awswrangler/athena/_spark.py
@@ -1,4 +1,4 @@
-"""Amazon Spark on Athena Calculations Module."""
+"""Apache Spark on Amazon Athena Module."""
 # pylint: disable=too-many-lines
 import logging
 import time
@@ -102,6 +102,25 @@ def create_spark_session(
     idle_timeout: int = 15,
     boto3_session: Optional[boto3.Session] = None,
 ) -> str:
+    """
+    Create session and wait until ready to accept calculations.
+
+    Parameters
+    ----------
+    workgroup : str
+    notebook_id : str, optional
+    notebook_version : str, optional
+    coordinator_dpu_size : int, optional
+    max_concurrent_dpus : int, optional
+    default_executor_dpu_size: int, optional
+    additional_configs : Dict[str, Any], optional
+    idle_timeout : int, optional
+    boto3_session : boto3.Session(), optional
+
+    Returns
+    -------
+        Session id
+    """
     client_athena = _utils.client(service_name="athena", session=boto3_session)
     engine_configuration: "EngineConfigurationTypeDef" = {
         "CoordinatorDpuSize": coordinator_dpu_size,
@@ -140,6 +159,27 @@ def run_spark_calculation(
     idle_timeout: int = 15,
     boto3_session: Optional[boto3.Session] = None,
 ) -> "GetCalculationExecutionResponseTypeDef":
+    """
+    Execute Spark Calculation and wait for completion.
+
+    Parameters
+    ----------
+    code : str
+    workgroup : str
+    session_id : str, optional
+    notebook_id : str, optional
+    notebook_version : str, optional
+    coordinator_dpu_size : int, optional
+    max_concurrent_dpus : int, optional
+    default_executor_dpu_size: int, optional
+    additional_configs : Dict[str, Any], optional
+    idle_timeout : int, optional
+    boto3_session : boto3.Session(), optional
+
+    Returns
+    -------
+        Calculation response
+    """
     client_athena = _utils.client(service_name="athena", session=boto3_session)
 
     session_id = (

--- a/awswrangler/athena/_spark.py
+++ b/awswrangler/athena/_spark.py
@@ -117,7 +117,14 @@ def create_spark_session(
 
     Returns
     -------
+    str
         Session id
+
+    Examples
+    --------
+    >>> import awswrangler as wr
+    >>> df = wr.athena.create_spark_session(workgroup="...", max_concurrent_dpus=10)
+
     """
     client_athena = _utils.client(service_name="athena", session=boto3_session)
     engine_configuration: "EngineConfigurationTypeDef" = {
@@ -180,7 +187,17 @@ def run_spark_calculation(
 
     Returns
     -------
+    Dict[str, Any]
         Calculation response
+
+    Examples
+    --------
+    >>> import awswrangler as wr
+    >>> df = wr.athena.run_spark_calculation(
+    ...     code="print(spark)",
+    ...     workgroup="...",
+    ... )
+
     """
     client_athena = _utils.client(service_name="athena", session=boto3_session)
 

--- a/awswrangler/exceptions.py
+++ b/awswrangler/exceptions.py
@@ -49,6 +49,14 @@ class QueryCancelled(Exception):
     """QueryCancelled exception."""
 
 
+class SessionFailed(Exception):
+    """SessionFailed exception."""
+
+
+class CalculationFailed(Exception):
+    """CalculationFailed exception."""
+
+
 class EmptyDataFrame(Exception):
     """EmptyDataFrame exception."""
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -121,6 +121,7 @@ Amazon Athena
     :toctree: stubs
 
     create_athena_bucket
+    create_spark_session
     create_ctas_table
     generate_create_query
     get_query_columns_types
@@ -133,6 +134,7 @@ Amazon Athena
     read_sql_query
     read_sql_table
     repair_table
+    run_spark_calculation
     start_query_execution
     stop_query_execution
     to_iceberg

--- a/test_infra/stacks/base_stack.py
+++ b/test_infra/stacks/base_stack.py
@@ -127,6 +127,27 @@ class BaseStack(Stack):  # type: ignore
                 ),
             },
         )
+        athena_spark_exec_role = iam.Role(
+            self,
+            "aws-sdk-pandas-athena-spark-exec-role",
+            role_name="AthenaSparkExecutionRole",
+            assumed_by=iam.ServicePrincipal("athena.amazonaws.com"),
+            managed_policies=[
+                iam.ManagedPolicy.from_aws_managed_policy_name("AmazonS3FullAccess"),
+                iam.ManagedPolicy.from_aws_managed_policy_name("AWSGlueConsoleFullAccess"),
+                iam.ManagedPolicy.from_aws_managed_policy_name("AmazonAthenaFullAccess"),
+            ],
+            inline_policies={
+                "GetDataAccess": iam.PolicyDocument(
+                    statements=[
+                        iam.PolicyStatement(
+                            actions=["lakeformation:GetDataAccess"],
+                            resources=["*"],
+                        ),
+                    ]
+                ),
+            },
+        )
         glue_db = glue.Database(
             self,
             id="aws_sdk_pandas_glue_database",
@@ -199,6 +220,7 @@ class BaseStack(Stack):  # type: ignore
         CfnOutput(self, "GlueDatabaseName", value=glue_db.database_name)
         CfnOutput(self, "GlueDataQualityRole", value=glue_data_quality_role.role_arn)
         CfnOutput(self, "EMRServerlessExecutionRoleArn", value=emr_serverless_exec_role.role_arn)
+        CfnOutput(self, "AthenaSparkExecutionRoleArn", value=athena_spark_exec_role.role_arn)
         CfnOutput(self, "LogGroupName", value=log_group.log_group_name)
         CfnOutput(self, "LogStream", value=log_stream.log_stream_name)
 

--- a/test_infra/stacks/base_stack.py
+++ b/test_infra/stacks/base_stack.py
@@ -87,6 +87,16 @@ class BaseStack(Stack):  # type: ignore
             resource_arn=self.bucket.bucket_arn,
             use_service_linked_role=True,
         )
+        inline_lf_policies = {
+            "GetDataAccess": iam.PolicyDocument(
+                statements=[
+                    iam.PolicyStatement(
+                        actions=["lakeformation:GetDataAccess"],
+                        resources=["*"],
+                    ),
+                ]
+            ),
+        }
         glue_data_quality_role = iam.Role(
             self,
             "aws-sdk-pandas-glue-data-quality-role",
@@ -96,16 +106,7 @@ class BaseStack(Stack):  # type: ignore
                 iam.ManagedPolicy.from_aws_managed_policy_name("AmazonS3FullAccess"),
                 iam.ManagedPolicy.from_aws_managed_policy_name("AWSGlueConsoleFullAccess"),
             ],
-            inline_policies={
-                "GetDataAccess": iam.PolicyDocument(
-                    statements=[
-                        iam.PolicyStatement(
-                            actions=["lakeformation:GetDataAccess"],
-                            resources=["*"],
-                        ),
-                    ]
-                ),
-            },
+            inline_policies=inline_lf_policies,
         )
         emr_serverless_exec_role = iam.Role(
             self,
@@ -116,16 +117,7 @@ class BaseStack(Stack):  # type: ignore
                 iam.ManagedPolicy.from_aws_managed_policy_name("AmazonS3FullAccess"),
                 iam.ManagedPolicy.from_aws_managed_policy_name("AWSGlueConsoleFullAccess"),
             ],
-            inline_policies={
-                "GetDataAccess": iam.PolicyDocument(
-                    statements=[
-                        iam.PolicyStatement(
-                            actions=["lakeformation:GetDataAccess"],
-                            resources=["*"],
-                        ),
-                    ]
-                ),
-            },
+            inline_policies=inline_lf_policies,
         )
         athena_spark_exec_role = iam.Role(
             self,
@@ -137,16 +129,7 @@ class BaseStack(Stack):  # type: ignore
                 iam.ManagedPolicy.from_aws_managed_policy_name("AWSGlueConsoleFullAccess"),
                 iam.ManagedPolicy.from_aws_managed_policy_name("AmazonAthenaFullAccess"),
             ],
-            inline_policies={
-                "GetDataAccess": iam.PolicyDocument(
-                    statements=[
-                        iam.PolicyStatement(
-                            actions=["lakeformation:GetDataAccess"],
-                            resources=["*"],
-                        ),
-                    ]
-                ),
-            },
+            inline_policies=inline_lf_policies,
         )
         glue_db = glue.Database(
             self,

--- a/tests/unit/test_athena_spark.py
+++ b/tests/unit/test_athena_spark.py
@@ -1,44 +1,36 @@
-import pandas as pd
 import pytest
 
 import awswrangler as wr
-
 from tests._utils import create_workgroup
 
 
 @pytest.fixture(scope="session")
-def workgroup_spark(bucket, kms_key):
-    """
+def athena_spark_execution_role_arn(cloudformation_outputs):
+    return cloudformation_outputs["AthenaSparkExecutionRole"]
+
+
+@pytest.fixture(scope="session")
+def workgroup_spark(bucket, kms_key, athena_spark_execution_role_arn):
     return create_workgroup(
         wkg_name="aws_sdk_pandas_spark",
         config={
             "EngineVersion": {
                 "SelectedEngineVersion": "PySpark engine version 3",
             },
+            "ExecutionRole": athena_spark_execution_role_arn,
+            "ResultConfiguration": {"OutputLocation": f"s3://{bucket}/athena_workgroup_spark/"},
         },
     )
-    """
-    return "dummy-spark"
 
 
 @pytest.mark.parametrize(
     "code",
-    [
-        "print(spark)",
-        (
-            "taxi_df = spark.read.format('parquet')"
-            ".option('header', 'true')"
-            ".option('inferSchema', 'true')"
-            ".load('s3://athena-examples-us-east-1/notebooks/yellow_tripdata_2016-01.parquet')\n"
-            "taxi_df.coalesce(1)"
-            ".write.mode('overwrite')"
-            ".csv('s3://<REDACTED>/select_taxi')"
-        ),
-    ],
+    ["print(spark)"],
 )
 def test_athena_spark_calculation(code, path, workgroup_spark):
     result = wr.athena.run_spark_calculation(
         code=code,
         workgroup=workgroup_spark,
     )
-    assert type(result) in [str, dict, pd.DataFrame]
+
+    assert result["Status"]["State"] == "COMPLETED"

--- a/tests/unit/test_athena_spark.py
+++ b/tests/unit/test_athena_spark.py
@@ -1,0 +1,44 @@
+import pandas as pd
+import pytest
+
+import awswrangler as wr
+
+from tests._utils import create_workgroup
+
+
+@pytest.fixture(scope="session")
+def workgroup_spark(bucket, kms_key):
+    """
+    return create_workgroup(
+        wkg_name="aws_sdk_pandas_spark",
+        config={
+            "EngineVersion": {
+                "SelectedEngineVersion": "PySpark engine version 3",
+            },
+        },
+    )
+    """
+    return "dummy-spark"
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        "print(spark)",
+        (
+            "taxi_df = spark.read.format('parquet')"
+            ".option('header', 'true')"
+            ".option('inferSchema', 'true')"
+            ".load('s3://athena-examples-us-east-1/notebooks/yellow_tripdata_2016-01.parquet')\n"
+            "taxi_df.coalesce(1)"
+            ".write.mode('overwrite')"
+            ".csv('s3://<REDACTED>/select_taxi')"
+        ),
+    ],
+)
+def test_athena_spark_calculation(code, path, workgroup_spark):
+    result = wr.athena.run_spark_calculation(
+        code=code,
+        workgroup=workgroup_spark,
+    )
+    assert type(result) in [str, dict, pd.DataFrame]

--- a/tests/unit/test_athena_spark.py
+++ b/tests/unit/test_athena_spark.py
@@ -6,7 +6,7 @@ from tests._utils import create_workgroup
 
 @pytest.fixture(scope="session")
 def athena_spark_execution_role_arn(cloudformation_outputs):
-    return cloudformation_outputs["AthenaSparkExecutionRole"]
+    return cloudformation_outputs["AthenaSparkExecutionRoleArn"]
 
 
 @pytest.fixture(scope="session")

--- a/tutorials/041 - Apache Spark on Amazon Athena.ipynb
+++ b/tutorials/041 - Apache Spark on Amazon Athena.ipynb
@@ -1,0 +1,178 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "[![AWS SDK for pandas](_static/logo.png \"AWS SDK for pandas\")](https://github.com/aws/aws-sdk-pandas)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "# 41 - Apache Spark on Amazon Athena"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "Amazon Athena makes it easy to interactively run data analytics and exploration using Apache Spark without the need to plan for, configure, or manage resources. Running Apache Spark applications on Athena means submitting Spark code for processing and receiving the results directly without the need for additional configuration.\n",
+    "\n",
+    "More in [User Guide](https://docs.aws.amazon.com/athena/latest/ug/notebooks-spark.html)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Run a Spark calculation"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "For this tutorial, you will need Spark-enabled Athena Workgroup. For the steps to create one, visit [Getting started with Apache Spark on Amazon Athena.\n",
+    "](https://docs.aws.amazon.com/athena/latest/ug/notebooks-spark-getting-started.html#notebooks-spark-getting-started-creating-a-spark-enabled-workgroup)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import awswrangler as wr\n",
+    "\n",
+    "workgroup: str = \"my-spark-workgroup\"\n",
+    "\n",
+    "result = wr.athena.run_spark_calculation(\n",
+    "    code=\"print(spark)\",\n",
+    "    workgroup=workgroup,\n",
+    ")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Create and re-use a session"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "It is possible to create a session and re-use it launching multiple calculations with the same resources. To create a session, use:"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "session_id: str = wr.athena.create_spark_session(\n",
+    "    workgroup=workgroup,\n",
+    ")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Now, to use the session, pass `session_id`:"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "result = wr.athena.run_spark_calculation(\n",
+    "    code=\"print(spark)\",\n",
+    "    workgroup=workgroup,\n",
+    "    session_id=session_id,\n",
+    ")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.9.14",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Scope
- This PR adds basic capabilities to start a session and kick off a calculation. Any potential data integration (i.e. ability to pass data frames, read results) will be addressed in next PRs.

### Detail
- Add `create_spark_session` and `run_spark_calculation` with corresponding waiters
- Add simple test case
- Expand test case
- Add tutorial / docstrings
- Add test infra IAM role

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
