### PR TITLE
feat: Add function to get the partition columns from a Table in the AWS Glue Catalog

### DIFF
--- a/awswrangler/athena/_read.py
+++ b/awswrangler/athena/_read.py
@@ -1409,3 +1409,44 @@ def unload(
         data_source=data_source,
         execution_params=execution_params,
     )
+
+@apply_configs
+@_utils.validate_distributed_kwargs(
+    unsupported_kwargs=["boto3_session"],
+)
+def get_partition_cols(
+    database: str,
+    table: str,
+    boto3_session: Optional[boto3.Session] = None,
+) -> List[str]:
+    """Get all partition columns from a Table in the AWS Glue Catalog.
+
+    Parameters
+    ----------
+    database : str
+        Database name.
+    table : str
+        Table name.
+    boto3_session : boto3.Session(), optional
+        Boto3 Session. The default boto3 session will be used if boto3_session receive None.
+
+    Returns
+    -------
+    List[str]
+        List of partition columns from a Table in the AWS Glue Catalog.
+
+    Examples
+    --------
+    >>> import awswrangler as wr
+    >>> partition_cols = wr.athena.get_partition_cols(
+            database = "my_database",
+    ...     table = "my_table"
+    ... )
+
+    """
+    df = read_sql_query(
+        sql = f'SELECT * FROM "{table}$partitions" limit 1',
+        database = database,
+        boto3_session = boto3_session,
+        )
+    return df.columns.to_list()

--- a/tests/unit/test_athena.py
+++ b/tests/unit/test_athena.py
@@ -394,6 +394,24 @@ def test_read_sql_query_parameter_formatting_respects_prefixes(path, glue_databa
     )
     assert len(df) == 2
 
+def test_get_partition_cols(path, glue_database, glue_table):
+    wr.s3.to_parquet(
+        df=get_df(),
+        path=path,
+        index=True,
+        use_threads=True,
+        dataset=True,
+        mode="overwrite",
+        database=glue_database,
+        table=glue_table,
+        partition_cols=["par0", "par1"],
+    )
+    partition_cols = wr.athena.get_partition_cols(
+        database=glue_database,
+        table=glue_table,
+    )
+    assert partition_cols == ["par0", "par1"]
+
 
 @pytest.mark.parametrize(
     "col_name,col_value",


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Feature

### Detail
- Returns a list of the `partition_cols` from a Table in the AWS Glue Catalog
- Can be useful for setting the `partition_cols` parameter for both `athena.to_iceberg` and `s3.to_parquet` functions in already existing tables

### Relates
- <URL or Ticket>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
