### PR TITLE
fix: remove .lower in dtype sanitize for to_parquet

### DIFF
--- a/awswrangler/s3/_write.py
+++ b/awswrangler/s3/_write.py
@@ -125,7 +125,7 @@ def _sanitize(
         bucketing_info = [
             catalog.sanitize_column_name(bucketing_col) for bucketing_col in bucketing_info[0]
         ], bucketing_info[1]
-    dtype = {catalog.sanitize_column_name(k): v.lower() for k, v in dtype.items()}
+    dtype = {catalog.sanitize_column_name(k): v for k, v in dtype.items()}
     _utils.check_duplicated_columns(df=df)
     return _SanitizeResult(df, dtype, partition_cols, bucketing_info)
 


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

AWS Glue enforces sanitisation of table and column names. For instance, a table with name `Metadata` would be automatically sanitised to `metadata` (i.e. lowercase) at creation.

However, this behaviour does not seem to apply to nested fields in data type values. The `CreateTime` value in the `struct<CreateTime:timestamp, LastUpdatedTime:timestamp>` data type is not sanitised by the service.

See #2357  for more details.

My worry is whether we wouldn't be breaking something else with this change?

### Detail
- Avoid lowercasing `dtype` data type values in `to_parquet` sanitisation process

### Relates
- #2357

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
