### PR TITLE
fix: Boto3 session not being passed to `cleanrooms.wait_query`

### DIFF
--- a/awswrangler/cleanrooms/_read.py
+++ b/awswrangler/cleanrooms/_read.py
@@ -101,9 +101,9 @@ def read_sql_query(
     )["protectedQuery"]["id"]
 
     _logger.debug("query_id: %s", query_id)
-    path: str = wait_query(membership_id=membership_id, query_id=query_id)["protectedQuery"]["result"]["output"]["s3"][
-        "location"
-    ]
+    path: str = wait_query(membership_id=membership_id, query_id=query_id, boto3_session=boto3_session)[
+        "protectedQuery"
+    ]["result"]["output"]["s3"]["location"]
 
     _logger.debug("path: %s", path)
     chunked: Union[bool, int] = False if chunksize is None else chunksize


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Boto3 session not being passed to `cleanrooms.wait_query` from `cleanrooms.read_sql_query`

### Relates
- #2380

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
