### PR TITLE
fix: cleanrooms - pass boto session to wait_query

### DIFF
--- a/awswrangler/cleanrooms/_read.py
+++ b/awswrangler/cleanrooms/_read.py
@@ -101,7 +101,7 @@ def read_sql_query(
     )["protectedQuery"]["id"]
 
     _logger.debug("query_id: %s", query_id)
-    path: str = wait_query(membership_id=membership_id, query_id=query_id)["protectedQuery"]["result"]["output"]["s3"][
+    path: str = wait_query(membership_id=membership_id, query_id=query_id,  boto3_session=boto3_session)["protectedQuery"]["result"]["output"]["s3"][
         "location"
     ]
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix


### Detail
- When querying AWS Clean Rooms (`cleanrooms.read_sql_query`) with a boto session the library tries to call `boto3.cleanrooms.get_protected_query` with the default credentials instead of the session.

This PR passes the boto3_session to wait_query.

### Relates
- [<URL or Ticket>](https://github.com/aws/aws-sdk-pandas/issues/2380)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
