### PR TITLE
fix: Change minimum boto3 version to one that supports cleanrooms

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -5978,4 +5978,4 @@ sqlserver = ["pyodbc"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8, <4.0"
-content-hash = "d3e1410850086b9f5eca34edcbf49efb33fa31a5a1a81e7d10f31d2f63aea912"
+content-hash = "3d241343d24cde077ee7242e4b8505dc64d8d0c18e5a562161564efb97cb1e55"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 python = ">=3.8, <4.0"
 
 # Required
-boto3 = "^1.20.32"
+boto3 = "^1.26.96"
 botocore = "^1.23.32"
 pandas = ">=1.2.0,!=1.5.0,<3.0.0" # Exclusion per: https://github.com/aws/aws-sdk-pandas/issues/1678
 numpy = "^1.18"


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- The current minimum version of `boto3` does not support CleanRooms. This could lead to customers installing `awswrangler`, and then getting `UnknownServiceError` when trying to import it

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
