### PR TITLE
fix: prevent lambda build from deleting libarrow files

### DIFF
--- a/building/lambda/build-lambda-layer.sh
+++ b/building/lambda/build-lambda-layer.sh
@@ -12,6 +12,7 @@ rm -rf dist arrow
 
 export ARROW_HOME=$(pwd)/dist
 export LD_LIBRARY_PATH=$(pwd)/dist/lib:$LD_LIBRARY_PATH
+export CMAKE_PREFIX_PATH=$ARROW_HOME:$CMAKE_PREFIX_PATH
 
 git clone \
   --depth 1 \
@@ -84,10 +85,6 @@ pip3 install . -t ./python ".[redshift,mysql,postgres,gremlin,opensearch,openpyx
 
 rm -rf python/pyarrow*
 rm -rf python/boto*
-
-rm -f /aws-sdk-pandas/dist/pyarrow_files/pyarrow/libarrow.so
-rm -f /aws-sdk-pandas/dist/pyarrow_files/pyarrow/libparquet.so
-rm -f /aws-sdk-pandas/dist/pyarrow_files/pyarrow/libarrow_python.so
 
 cp -r /aws-sdk-pandas/dist/pyarrow_files/pyarrow* python/
 


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
- Deleting libarrow.so files is causing lambda layer to fail. The deletion was initially put in place to save space but is not longer needed

### Relates
- https://github.com/apache/arrow/pull/7334

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
