### PR TITLE
feat: test dependabot groups feature

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,8 @@ updates:
       interval: "weekly"
       time: "09:00"
       timezone: "Europe/London"
-    commit-message:
-      prefix: "[skip ci] pip"
-      prefix-development: "[skip ci] pip"
-      include: "scope"
+    groups:
+        production-dependencies:
+          dependency-type: "production"
+        development-dependencies:
+          dependency-type: "development"


### PR DESCRIPTION
Signed-off-by: Abdel Jaidi <jaidisido@gmail.com>

### Feature or Bugfix
<!-- please choose -->
- Feature

### Detail
Dependabot now supports grouped pull requests:
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups

A single pull request per group is opened, updating multiple packages at once. As a result, there is no need to skip the CI anymore

Note that the feature is in beta

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
