### PR TITLE
fix: Adjust timestamp precision for compatibility with Deltalake #2437

### DIFF
--- a/awswrangler/_data_types.py
+++ b/awswrangler/_data_types.py
@@ -322,7 +322,7 @@ def athena2pyarrow(dtype: str) -> pa.DataType:  # pylint: disable=too-many-retur
     if (dtype in ("string", "uuid")) or dtype.startswith("char") or dtype.startswith("varchar"):
         return pa.string()
     if dtype == "timestamp":
-        return pa.timestamp(unit="ns")
+        return pa.timestamp(unit="us")
     if dtype == "date":
         return pa.date32()
     if dtype in ("binary" or "varbinary"):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Adjust timestamp precision for compatibility with Deltalake

### Relates
- [Link to the issue #2437](https://github.com/aws/aws-sdk-pandas/issues/2437)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
