### PR TITLE
Return None for missing column and partition key comment

### DIFF
--- a/awswrangler/catalog/_get.py
+++ b/awswrangler/catalog/_get.py
@@ -1007,10 +1007,10 @@ def get_columns_comments(
     )
     comments: Dict[str, str] = {}
     for c in response["Table"]["StorageDescriptor"]["Columns"]:
-        comments[c["Name"]] = c["Comment"]
+        comments[c["Name"]] = c.get("Comment")
     if "PartitionKeys" in response["Table"]:
         for p in response["Table"]["PartitionKeys"]:
-            comments[p["Name"]] = p["Comment"]
+            comments[p["Name"]] = p.get("Comment")
     return comments
 
 


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
Missing column comments raise a `KeyError`.
Go back to returning `None` in these cases.

### Relates
https://github.com/aws/aws-sdk-pandas/issues/767

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
