### PR TITLE
fix: Duplicate schema argument in `wr.s3.to_parquet()`

### DIFF
--- a/awswrangler/s3/_write_parquet.py
+++ b/awswrangler/s3/_write_parquet.py
@@ -64,7 +64,7 @@ def _new_writer(
         pyarrow_additional_kwargs["use_dictionary"] = True
     if not pyarrow_additional_kwargs.get("write_statistics"):
         pyarrow_additional_kwargs["write_statistics"] = True
-    if schema:
+    if not pyarrow_additional_kwargs.get("schema"):
         pyarrow_additional_kwargs["schema"] = schema
 
     with open_s3_object(

--- a/awswrangler/s3/_write_parquet.py
+++ b/awswrangler/s3/_write_parquet.py
@@ -78,7 +78,6 @@ def _new_writer(
             writer = pyarrow.parquet.ParquetWriter(
                 where=f,
                 compression="NONE" if compression is None else compression,
-                schema=schema,
                 **pyarrow_additional_kwargs,
             )
             yield writer

--- a/awswrangler/s3/_write_parquet.py
+++ b/awswrangler/s3/_write_parquet.py
@@ -64,6 +64,8 @@ def _new_writer(
         pyarrow_additional_kwargs["use_dictionary"] = True
     if not pyarrow_additional_kwargs.get("write_statistics"):
         pyarrow_additional_kwargs["write_statistics"] = True
+    if schema:
+        pyarrow_additional_kwargs["schema"] = schema
 
     with open_s3_object(
         path=file_path,


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- <feature1 or bug1>

### Relates
- https://github.com/aws/aws-sdk-pandas/issues/2454

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
