### PR TITLE
fix: Add missing call to `sanitize_column_name` in `create_*_table`

### DIFF
--- a/awswrangler/catalog/_create.py
+++ b/awswrangler/catalog/_create.py
@@ -299,6 +299,7 @@ def _create_parquet_table(
     catalog_table_input: Optional[Dict[str, Any]],
 ) -> None:
     table = sanitize_table_name(table=table)
+    columns_types = {sanitize_column_name(k): v for k, v in columns_types.items()}
     partitions_types = {} if partitions_types is None else partitions_types
     _logger.debug("catalog_table_input: %s", catalog_table_input)
 
@@ -361,6 +362,7 @@ def _create_orc_table(
     catalog_table_input: Optional[Dict[str, Any]],
 ) -> None:
     table = sanitize_table_name(table=table)
+    columns_types = {sanitize_column_name(k): v for k, v in columns_types.items()}
     partitions_types = {} if partitions_types is None else partitions_types
     _logger.debug("catalog_table_input: %s", catalog_table_input)
 
@@ -428,6 +430,7 @@ def _create_csv_table(  # pylint: disable=too-many-arguments,too-many-locals
     catalog_id: Optional[str],
 ) -> None:
     table = sanitize_table_name(table=table)
+    columns_types = {sanitize_column_name(k): v for k, v in columns_types.items()}
     partitions_types = {} if partitions_types is None else partitions_types
     _logger.debug("catalog_table_input: %s", catalog_table_input)
 
@@ -501,8 +504,10 @@ def _create_json_table(  # pylint: disable=too-many-arguments,too-many-locals
     catalog_id: Optional[str],
 ) -> None:
     table = sanitize_table_name(table=table)
+    columns_types = {sanitize_column_name(k): v for k, v in columns_types.items()}
     partitions_types = {} if partitions_types is None else partitions_types
     _logger.debug("catalog_table_input: %s", catalog_table_input)
+
     table_input: Dict[str, Any]
     if schema_evolution is False:
         _utils.check_schema_changes(columns_types=columns_types, table_input=catalog_table_input, mode=mode)

--- a/tests/unit/test_catalog.py
+++ b/tests/unit/test_catalog.py
@@ -201,13 +201,25 @@ def test_catalog(
         )
 
 
-def test_catalog_table_comments(glue_database: str, glue_table: str, path: str) -> None:
-    wr.catalog.create_parquet_table(
+@pytest.mark.parametrize("format", ["parquet", "orc", "csv", "json"])
+def test_catalog_table_comments(glue_database: str, glue_table: str, path: str, format: str) -> None:
+    format2func = {
+        "parquet": wr.catalog.create_parquet_table,
+        "orc": wr.catalog.create_orc_table,
+        "csv": wr.catalog.create_csv_table,
+        "json": wr.catalog.create_json_table,
+    }
+
+    format2func[format](
         database=glue_database,
         table=glue_table,
         path=path,
         columns_types={"col0": "bigint", "col1": "double", "col with spaces": "double"},
-        columns_comments={"col0": "first description", "col1": "second description", "col with spaces": "third description"},
+        columns_comments={
+            "col0": "first description",
+            "col1": "second description",
+            "col with spaces": "third description",
+        },
         description="My own table!",
     )
     desc = wr.catalog.table(database=glue_database, table=glue_table)

--- a/tests/unit/test_catalog.py
+++ b/tests/unit/test_catalog.py
@@ -201,6 +201,20 @@ def test_catalog(
         )
 
 
+def test_catalog_table_comments(glue_database: str, glue_table: str, path: str) -> None:
+    wr.catalog.create_parquet_table(
+        database=glue_database,
+        table=glue_table,
+        path=path,
+        columns_types={"col0": "bigint", "col1": "double", "col with spaces": "double"},
+        columns_comments={"col0": "first description", "col1": "second description", "col with spaces": "third description"},
+        description="My own table!",
+    )
+    desc = wr.catalog.table(database=glue_database, table=glue_table)
+
+    assert desc["Comment"].all()
+
+
 def test_catalog_partitions(glue_database: str, glue_table: str, path: str, account_id: str) -> None:
     assert wr.catalog.does_table_exist(database=glue_database, table=glue_table) is False
     wr.catalog.create_parquet_table(


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Add missing call to `sanitize_column_name` in `create_*_table`
- This fixes an issue where column comments are not applied if the column name is not sanitized

### Relates
- #2463

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
