### PR TITLE
fix: Hyphenated Iceberg table names

### DIFF
--- a/awswrangler/athena/_write_iceberg.py
+++ b/awswrangler/athena/_write_iceberg.py
@@ -48,7 +48,7 @@ def _create_iceberg_table(
     )
 
     create_sql: str = (
-        f"CREATE TABLE IF NOT EXISTS {table} ({cols_str}) "
+        f"CREATE TABLE IF NOT EXISTS `{table}` ({cols_str}) "
         f"{partition_cols_str} "
         f"LOCATION '{path}' "
         f"TBLPROPERTIES ('table_type' ='ICEBERG', 'format'='parquet'{table_properties_str})"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -246,6 +246,16 @@ def glue_table(glue_database: str) -> str:
 
 
 @pytest.fixture(scope="function")
+def glue_table_with_hyphenated_name(glue_database: str) -> str:
+    name = f"tbl-{get_time_str_with_random_suffix()}"
+    print(f"Table name: {name}")
+    wr.catalog.delete_table_if_exists(database=glue_database, table=name)
+    yield name
+    wr.catalog.delete_table_if_exists(database=glue_database, table=name)
+    print(f"Table {glue_database}.{name} deleted.")
+
+
+@pytest.fixture(scope="function")
 def glue_table2(glue_database) -> str:
     name = f"tbl_{get_time_str_with_random_suffix()}"
     print(f"Table name: {name}")

--- a/tests/unit/test_athena.py
+++ b/tests/unit/test_athena.py
@@ -1587,7 +1587,7 @@ def test_athena_to_iceberg_with_hyphenated_table_name(
     )
 
     df_out = wr.athena.read_sql_query(
-        sql=f"SELECT * FROM \"{glue_table_with_hyphenated_name}\"",
+        sql=f'SELECT * FROM "{glue_table_with_hyphenated_name}"',
         database=glue_database,
         ctas_approach=False,
         unload_approach=False,

--- a/tests/unit/test_athena.py
+++ b/tests/unit/test_athena.py
@@ -1568,3 +1568,30 @@ def test_to_iceberg_cast(path, path2, glue_table, glue_database):
     )
     df2 = wr.athena.read_sql_table(database=glue_database, table=glue_table, ctas_approach=False)
     assert pandas_equals(df_expected, df2.sort_values("c0").reset_index(drop=True))
+
+
+def test_athena_to_iceberg_with_hyphenated_table_name(
+    path: str, path2: str, glue_database: str, glue_table_with_hyphenated_name: str
+):
+    df = pd.DataFrame({"c0": [1, 2, 3, 4], "c1": ["foo", "bar", "baz", "boo"]})
+    df["c0"] = df["c0"].astype("int")
+    df["c1"] = df["c1"].astype("string")
+
+    wr.athena.to_iceberg(
+        df=df,
+        database=glue_database,
+        table=glue_table_with_hyphenated_name,
+        table_location=path,
+        temp_path=path2,
+        keep_files=False,
+    )
+
+    df_out = wr.athena.read_sql_query(
+        sql=f"SELECT * FROM \"{glue_table_with_hyphenated_name}\"",
+        database=glue_database,
+        ctas_approach=False,
+        unload_approach=False,
+    )
+
+    assert len(df) == len(df_out)
+    assert len(df.columns) == len(df_out.columns)


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
- The `athena.to_iceberg` function does not work for a hyphenated table name

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
