### PR TITLE
feat: Redshift data api - allow all auth combinations

### DIFF
--- a/awswrangler/data_api/redshift.py
+++ b/awswrangler/data_api/redshift.py
@@ -98,9 +98,7 @@ class RedshiftDataApi(_connector.DataApiConnector):
                 "Either `secret_arn`, `workgroup_name`, `db_user`, or `cluster_id` must be set for authentication."
             )
         if self.db_user and self.secret_arn:
-            raise exceptions.InvalidArgumentCombination(
-                "Only one of `secret_arn` or `db_user` is allowed."
-            )
+            raise exceptions.InvalidArgumentCombination("Only one of `secret_arn` or `db_user` is allowed.")
 
     def _execute_statement(
         self,

--- a/awswrangler/data_api/redshift.py
+++ b/awswrangler/data_api/redshift.py
@@ -94,8 +94,12 @@ class RedshiftDataApi(_connector.DataApiConnector):
 
     def _validate_auth_method(self) -> None:
         if not self.workgroup_name and not self.secret_arn and not self.db_user and not self.cluster_id:
-            raise ValueError(
+            raise exceptions.InvalidArgumentCombination(
                 "Either `secret_arn`, `workgroup_name`, `db_user`, or `cluster_id` must be set for authentication."
+            )
+        if self.db_user and self.secret_arn:
+            raise exceptions.InvalidArgumentCombination(
+                "Only one of `secret_arn` or `db_user` is allowed."
             )
 
     def _execute_statement(

--- a/tests/unit/test_data_api.py
+++ b/tests/unit/test_data_api.py
@@ -54,6 +54,23 @@ def test_connect_redshift_serverless_iam_role(databases_parameters: Dict[str, An
     assert df.shape == (1, 1)
 
 
+def test_connect_redshift_cluster_iam_role(databases_parameters: Dict[str, Any]) -> None:
+    cluster_id = databases_parameters["redshift"]["identifier"]
+    database = databases_parameters["redshift"]["database"]
+    con = wr.data_api.redshift.connect(cluster_id=cluster_id, database=database, boto3_session=None)
+    df = wr.data_api.redshift.read_sql_query("SELECT 1", con=con)
+    assert df.shape == (1, 1)
+
+
+def test_connect_redshift_cluster_db_user(databases_parameters: Dict[str, Any]) -> None:
+    cluster_id = databases_parameters["redshift"]["identifier"]
+    database = databases_parameters["redshift"]["database"]
+    db_user = databases_parameters["user"]
+    con = wr.data_api.redshift.connect(cluster_id=cluster_id, database=database, db_user=db_user, boto3_session=None)
+    df = wr.data_api.redshift.read_sql_query("SELECT 1", con=con)
+    assert df.shape == (1, 1)
+
+
 def test_connect_redshift_serverless_secrets_manager(databases_parameters: Dict[str, Any]) -> None:
     workgroup_name = databases_parameters["redshift_serverless"]["workgroup"]
     database = databases_parameters["redshift_serverless"]["database"]


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Feature

### Detail
- Allow all combinations of auth as per https://docs.aws.amazon.com/redshift/latest/mgmt/data-api-access.html

### Relates
- https://github.com/aws/aws-sdk-pandas/issues/2435

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
