### PR TITLE
fix: KeyError exception in athena wrangler

### DIFF
--- a/awswrangler/athena/_cache.py
+++ b/awswrangler/athena/_cache.py
@@ -58,7 +58,7 @@ class _LocalMetadataCacheManager:
             cache_oversize = len(self._cache) + len(items) - self._max_cache_size
             for _ in range(cache_oversize):
                 _, query_execution_id = heappop(self._pqueue)
-                del self._cache[query_execution_id]
+                self._cache.pop(query_execution_id, None)
 
             for item in items[: self._max_cache_size]:
                 heappush(self._pqueue, (item["Status"]["SubmissionDateTime"], item["QueryExecutionId"]))


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
- When updating cache in Athena `read_sql_query` code flow on a multi thread code we got an KeyError exception.  Now have updated code to only remove the item in cache if key actually exists.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
