### PR TITLE
fix column names and apply map

### DIFF
--- a/awswrangler/neptune/_neptune.py
+++ b/awswrangler/neptune/_neptune.py
@@ -110,8 +110,8 @@ def execute_sparql(client: NeptuneClient, query: str) -> pd.DataFrame:
     data = client.read_sparql(query)
     df = None
     if "results" in data and "bindings" in data["results"]:
-        df = pd.DataFrame(data["results"]["bindings"])
-        df.applymap(lambda x: x["value"])
+        df = pd.DataFrame(data["results"]["bindings"], columns=data.get("head").get("vars"))
+        df = df.applymap(lambda d: d["value"] if "value" in d else None)
     else:
         df = pd.DataFrame(data)
 


### PR DESCRIPTION
### Feature or Bugfix

- Bugfix

### Detail
- if the SparQL query does not return any results then the _execute_sparql returns an empty data frame although column names were defined in the query
- the df.applymap() is not inplace and has no effect 

### Relates
- [<URL or Ticket>](https://github.com/aws/aws-sdk-pandas/issues/2491)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
