### PR TITLE
fix: readthedocs failing because of missing build.os variable

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,8 @@
 version: 2
 formats: all
 
+build:
+  os: ubuntu-22.04
+
 conda:
   environment: docs/environment.yml


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
- Our documentation is no longer building because we didn't perform [this migration](https://blog.readthedocs.com/use-build-os-config/) in time
- Added the missing `build.os` variable
- We are currently missing the documentation for release `3.4.1` because it's failing to build

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
