### PR TITLE
fix: readthedocs migration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,6 +6,11 @@ build:
   tools:
     python: mambaforge-4.10
 
+python:
+  install:
+    - method: pip
+      path: .
+
 conda:
   environment: docs/environment.yml
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ formats: all
 build:
   os: ubuntu-22.04
   tools:
-    python: mambaforge-22.9
+    python: mambaforge-4.10
 
 conda:
   environment: docs/environment.yml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ formats: all
 build:
   os: ubuntu-22.04
   tools:
-    python: mambaforge-22.9"
+    python: mambaforge-22.9
 
 conda:
   environment: docs/environment.yml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,12 +4,7 @@ formats: all
 build:
   os: ubuntu-22.04
   tools:
-    python: mambaforge-4.10
-
-python:
-  install:
-    - method: pip
-      path: .
+    python: miniconda3-4.7
 
 conda:
   environment: docs/environment.yml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,10 @@ formats: all
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: mambaforge-22.9"
 
 conda:
   environment: docs/environment.yml
+
+sphinx:
+  configuration: docs/source/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,8 @@
 version: 2
 formats: all
 
+build:
+  os: ubuntu-22.04
+
 conda:
   environment: docs/environment.yml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,8 +1,5 @@
 version: 2
 formats: all
 
-build:
-  os: ubuntu-22.04
-
 conda:
   environment: docs/environment.yml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,6 +3,8 @@ formats: all
 
 build:
   os: ubuntu-22.04
+  tools:
+    python: "3.11"
 
 conda:
   environment: docs/environment.yml


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
- Our documentation is no longer building because we didn't perform [this migration](https://blog.readthedocs.com/use-build-os-config/) in time
- Added the missing `build.os` and `build.tools` variables
- We are currently missing the documentation for release `3.4.1` because it's failing to build

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
