### PR TITLE
chore: upgrade `oracledb` to 2.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -881,13 +881,13 @@ xray = ["mypy-boto3-xray (>=1.34.0,<1.35.0)"]
 
 [[package]]
 name = "botocore"
-version = "1.34.2"
+version = "1.34.6"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">= 3.8"
 files = [
-    {file = "botocore-1.34.2-py3-none-any.whl", hash = "sha256:655b1ea2a5d7b989a0eb6006c16137f785bc7334f31378115668c4be5d4b00eb"},
-    {file = "botocore-1.34.2.tar.gz", hash = "sha256:8a9f4ad438ba814b9b7a22b24de3004f8aa232e7ae86e0087aea4d7792dc3a2a"},
+    {file = "botocore-1.34.6-py3-none-any.whl", hash = "sha256:697000cb756b8f469c10ed0a8a8590f799a90a98b814ebfccd2add4048084ff1"},
+    {file = "botocore-1.34.6.tar.gz", hash = "sha256:bfe587f48e154a3a836f85af165116b7d5dba9b3b746ce0b94e6d2ed1e06c206"},
 ]
 
 [package.dependencies]
@@ -899,7 +899,7 @@ urllib3 = [
 ]
 
 [package.extras]
-crt = ["awscrt (==0.19.17)"]
+crt = ["awscrt (==0.19.19)"]
 
 [[package]]
 name = "botocore-stubs"
@@ -3750,44 +3750,42 @@ kerberos = ["requests-kerberos"]
 
 [[package]]
 name = "oracledb"
-version = "1.4.2"
+version = "2.0.0"
 description = "Python interface to Oracle Database"
 optional = true
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "oracledb-1.4.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1fba71bbc0ec8fc806236a30d1212d2f516519c0658f0022f3d5fb593cb4e9b2"},
-    {file = "oracledb-1.4.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5f1d7c4d3d68572fa0ef3d3973dd0905c4f30e31d91de6a8da771223937fefa9"},
-    {file = "oracledb-1.4.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a5b9542d77b86c80dcc0314458cb15619831c06f232bbdbd77863f8ab5921b3"},
-    {file = "oracledb-1.4.2-cp310-cp310-win32.whl", hash = "sha256:db99de736ed7996bd428ad0a4eb154543d6dd4add2a2b67b46a51cbf761e01ec"},
-    {file = "oracledb-1.4.2-cp310-cp310-win_amd64.whl", hash = "sha256:facf47d6787a0d2ab7cf8dfa68572ea4a3f1cb022843a8ff3b9f87d75ba7c815"},
-    {file = "oracledb-1.4.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:56667754b7d4add421edebb624e772f64f3a192e9ff5a7d3ed32d79ed1d37a01"},
-    {file = "oracledb-1.4.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:abc152418518fb8e433403afe39b6d2a71faa8653316d6a8e1853bb152584e84"},
-    {file = "oracledb-1.4.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2152dffc586fd7544bd0dd883db4ab93cf17a0bfece8f4d305353f4bdebc627c"},
-    {file = "oracledb-1.4.2-cp311-cp311-win32.whl", hash = "sha256:99d08c406752c38c3f3e863db372d1f74adb4d23dd6a34437ddea9fe3f437a37"},
-    {file = "oracledb-1.4.2-cp311-cp311-win_amd64.whl", hash = "sha256:e5ab88775074b6a758951fea09e53a824343ab53cb84e5a662a52ef5c5799a2b"},
-    {file = "oracledb-1.4.2-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:e482cd62cf2c1eb9d655f95d5e87e7903ad83fd759b3c2b2b634d4480ff9d086"},
-    {file = "oracledb-1.4.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69302569a08a9bc136c1032d72222545271100460d1dcde7f9bb8fa928efb11f"},
-    {file = "oracledb-1.4.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21f74ed6de46465020b23f8fe765f246d835e121482009f7389cb693686f3151"},
-    {file = "oracledb-1.4.2-cp312-cp312-win32.whl", hash = "sha256:7e13acc1dab125506b87e536d0e3ed2e1482b61cadae7ba140471c4d2b9315e3"},
-    {file = "oracledb-1.4.2-cp312-cp312-win_amd64.whl", hash = "sha256:dea6a0c5150ebb52c0ba617b636d2f5af40fef1d0901e3df3f3f0bcc03359ac7"},
-    {file = "oracledb-1.4.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ecdebcca26e9964903dd36d01bb95bbf64cd4403a741f8ec7ad9122073fb30a8"},
-    {file = "oracledb-1.4.2-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:52a8b99e00cda8de6ca8e887e00dfb60753eab2b98cf1812c7fb7033e757b5fc"},
-    {file = "oracledb-1.4.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:d77808966802c36995ac81107ee8e3ec188030fc81f753d813edbb604c8bf584"},
-    {file = "oracledb-1.4.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:420fd1571426bd4d645849977c4660dcb953387166684d55e5032abf25aac2ed"},
-    {file = "oracledb-1.4.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a6028c8edf53fa13781cdd9324c02e41d6072f5b753e6c6a37c1e1081587e6b2"},
-    {file = "oracledb-1.4.2-cp37-cp37m-win32.whl", hash = "sha256:2154d4c71f421d2be8fbcbd51174e6fc7194346e74e903882c6be43e6ac03fed"},
-    {file = "oracledb-1.4.2-cp37-cp37m-win_amd64.whl", hash = "sha256:c99e5ade66a04e57b8ff98dd9e1a3068426835446c76d7fa6b8d2100f1d32a52"},
-    {file = "oracledb-1.4.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:34fabe0b96a4ca3369bfd3edf570455aad16d64e62563bb493cd4870c51724e3"},
-    {file = "oracledb-1.4.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf56e92ad93b3822918dec26f6c0948904a3ac5ab49a8246c1e48c65933bbcaa"},
-    {file = "oracledb-1.4.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5050aff415b9ef516b271f52e667f52dde9f236bd36ffb6c2e080b9011e6d19d"},
-    {file = "oracledb-1.4.2-cp38-cp38-win32.whl", hash = "sha256:1d21b92854b8ea7fd6b216743e7e8585b666031ca2d2b3700c23b62710648c03"},
-    {file = "oracledb-1.4.2-cp38-cp38-win_amd64.whl", hash = "sha256:87243baec69b71b3bdb2b9e3962812d66f75953ae1773251c8db510426470761"},
-    {file = "oracledb-1.4.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:a8e8b306d8032436d0619191021379f298215cc90ae1d9cc0e064529d5cfbb61"},
-    {file = "oracledb-1.4.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a31bfbbfec42e9c4f518c9fb4c0a70dda7154ae01539a697688107a75047297f"},
-    {file = "oracledb-1.4.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:29b0188a0ecf4951114c5bdd5a252725f9637fe2a7786e454036720d5f6aa9bf"},
-    {file = "oracledb-1.4.2-cp39-cp39-win32.whl", hash = "sha256:035432c89f92ad1b36cd9ce8cd70ddcbe7a2b8e281d8951e77136a977c82a135"},
-    {file = "oracledb-1.4.2-cp39-cp39-win_amd64.whl", hash = "sha256:c839cf0f3f90b953243dc65debcfc66dfbd3c885ff9fd2e68d16de986d25e01c"},
-    {file = "oracledb-1.4.2.tar.gz", hash = "sha256:e28ed9046f2735dc2dd5bbcdf3667f284e384e0ec7eed3eeb3798fa8a7d47e36"},
+    {file = "oracledb-2.0.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:129f62fb95af22367723707e5ecf9dbf7f4a7c04f8e9ae509312ab72fa049b35"},
+    {file = "oracledb-2.0.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:df356d6a076da6cb74f5ce3c13090ab0d6760ecc6babed3beadbec6403c86d5c"},
+    {file = "oracledb-2.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d31e9b59f5b471b9cf02904d437379e9efd0a69dee5bc9b9899a7fc7695df97"},
+    {file = "oracledb-2.0.0-cp310-cp310-win32.whl", hash = "sha256:acd1c88a21d712853cdd360ed911fa17b63e0f79eef8cad6dd9dbb04eb32ae0b"},
+    {file = "oracledb-2.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:8faefd3ef397e8d665e8864c01a4459fb42097f0cf7089e69a1665b545bd4984"},
+    {file = "oracledb-2.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:2ae142807e14f2f59cb138d7023e698698ad893ff90101cfc1c2f128474ae3c6"},
+    {file = "oracledb-2.0.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e315bec42a839ccd545553de693cffa32178eb54e30578c8cf568de1302aa399"},
+    {file = "oracledb-2.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33b8ee18558e5e7e79bab2d09f62095fd637781a41d3bcbc5eb3fa93d4a20285"},
+    {file = "oracledb-2.0.0-cp311-cp311-win32.whl", hash = "sha256:741766325c2738171a86e667e34f87e39c6ad1c62d361743e399e5ced6c86d88"},
+    {file = "oracledb-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:b5821533e5a881abeaa107115474baa832315ce3bca1609c535d121e3266d226"},
+    {file = "oracledb-2.0.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:8c4f5a7ceec2e2a3584bbd8853285ebfd5382c5514df3d52323ac014816bf398"},
+    {file = "oracledb-2.0.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ee5d7967ab4043678d078a42ae2920527993d177f5c9c16f69f64cc9c0e8ab71"},
+    {file = "oracledb-2.0.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0607557008bc76bba372694ffab6333ceea078ccb6bacb60aad8409e0b74b80a"},
+    {file = "oracledb-2.0.0-cp312-cp312-win32.whl", hash = "sha256:3d9706346e8074d7f5bc037609524285b472b33ef30ea93d49715d50c32a1deb"},
+    {file = "oracledb-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:fa151acf5d47cbd1129d857196fde652a5b4c95011d7b79037111b11f36e704f"},
+    {file = "oracledb-2.0.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:5d8ed11913dc83f3942e78775ebde0bd02945c81de2ad9f41d706f0b07855363"},
+    {file = "oracledb-2.0.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cbbb278a89396e8c5a63fe3c661cb4ff28a829954d3aae4f105e4e5ec160cc1e"},
+    {file = "oracledb-2.0.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc5888d0a36625e9342a6fbdccc15b5687d99fe14fab856bcdc8d6b64b4af735"},
+    {file = "oracledb-2.0.0-cp37-cp37m-win32.whl", hash = "sha256:64d4ba925ce5fae0f89a1f227703b550d18635f5ff03f243a49b32368400af12"},
+    {file = "oracledb-2.0.0-cp37-cp37m-win_amd64.whl", hash = "sha256:13a3676c13bb5a3881e8542ff8e7f8da53e85d7486f3e030a2a0342b2fd349b1"},
+    {file = "oracledb-2.0.0-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:765d9bd16bcbb72849c3ca6165d2b7c34b2493508e7378a4f1abc99e90967dbe"},
+    {file = "oracledb-2.0.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:47b55c2fc6f4e27abed142bd7181234a7ba14d5eff7ad123ef922be6220f395e"},
+    {file = "oracledb-2.0.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:860e468bcf1fd263f9d646888a8ae79102fb8288c982ab4f120e843b8ee278ca"},
+    {file = "oracledb-2.0.0-cp38-cp38-win32.whl", hash = "sha256:992a2baf14dd4dd7b7b04db2fa0b256d8203780a838de627b50e81411203b1f0"},
+    {file = "oracledb-2.0.0-cp38-cp38-win_amd64.whl", hash = "sha256:42369b5bfbfb0fa9c24840fab6d0547e16e67eff00869a4df336312dceb1d3e6"},
+    {file = "oracledb-2.0.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:52b142ae57faf96048b529d668c33740d26b183b6ca4af4dd22d4e9d9c05f8a8"},
+    {file = "oracledb-2.0.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5f13a4aa7dc8e116c55ed4a594884b73eae357d61379900a4d3934acc8425e15"},
+    {file = "oracledb-2.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4769fb134053a270210e546664a768eb7fed59e295d47d6fdf57dbe5b23f8c83"},
+    {file = "oracledb-2.0.0-cp39-cp39-win32.whl", hash = "sha256:34c26a4d19c2e12bde4afd24e3fe0289c998171cfc0b0eb6bea6ddcca1529c7f"},
+    {file = "oracledb-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:32223707c2029f74f648da1e826c3ea10e04c770a91f6078115ca6177106638d"},
+    {file = "oracledb-2.0.0.tar.gz", hash = "sha256:fb4481e7ad1a9e81214828a219a45b653301d80c5a1cc47e03857105b61ae2c9"},
 ]
 
 [package.dependencies]
@@ -6204,4 +6202,4 @@ sqlserver = ["pyodbc"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8, <4.0"
-content-hash = "e4ebbe01f2934388afbac5c38e6f0a7d24ee279233c9c91d0a24687ba5c6c4b5"
+content-hash = "7144d8d7114ebd005c1a9d76672a9d69a93293cc66cd3f322ea191945c6b85eb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ redshift-connector = { version = "^2.0.0", optional = true }
 pymysql = { version = "^1.0.0", optional = true }
 pg8000 = { version = "^1.29.0", optional = true }
 pyodbc = { version = ">=4,<6", optional = true }
-oracledb = { version = "^1.0.0", optional = true }
+oracledb = { version = ">=1,<3", optional = true }
 
 # Graph
 gremlinpython = { version = "^3.6.2", optional = true }


### PR DESCRIPTION
### Detail
- Updates `oracledb` from `1.4.2` to `2.0.0`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
