### PR TITLE
fix: Python 3.8 unit tests

### DIFF
--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import random
 import re
+import sys
 import time
 import uuid
 from datetime import date, datetime
@@ -28,6 +29,7 @@ from awswrangler._utils import try_it
 
 is_ray_modin = wr.engine.get() == EngineEnum.RAY and wr.memory_format.get() == MemoryFormatEnum.MODIN
 is_pandas_2_x = False
+is_python_3_8_x = sys.version_info.major == 3 and sys.version_info.minor == 8
 
 if is_ray_modin:
     from modin.pandas import DataFrame as ModinDataFrame

--- a/tests/unit/test_s3_select.py
+++ b/tests/unit/test_s3_select.py
@@ -6,13 +6,18 @@ import pytest
 import awswrangler as wr
 import awswrangler.pandas as pd
 
-from .._utils import is_ray_modin
+from .._utils import is_python_3_8_x, is_ray_modin
 
 logging.getLogger("awswrangler").setLevel(logging.DEBUG)
 
 pytestmark = pytest.mark.distributed
 
 
+@pytest.mark.xfail(
+    condition=is_python_3_8_x,
+    reason="Python 3.8 uses older version of Pandas, which doesn't support the usage of index=False with orient='records'",
+    raises=ValueError,
+)
 @pytest.mark.parametrize("use_threads", [True, False, 2])
 def test_full_table(path, use_threads):
     df = pd.DataFrame(

--- a/tests/unit/test_s3_text_compressed.py
+++ b/tests/unit/test_s3_text_compressed.py
@@ -13,7 +13,7 @@ import pytest
 import awswrangler as wr
 import awswrangler.pandas as pd
 
-from .._utils import get_df_csv, is_ray_modin
+from .._utils import get_df_csv, is_python_3_8_x, is_ray_modin
 
 EXT = {"gzip": ".gz", "bz2": ".bz2", "xz": ".xz", "zip": ".zip"}
 
@@ -127,6 +127,11 @@ def test_json(path: str, compression: str | None) -> None:
     assert df.shape == df2.shape == df3.shape
 
 
+@pytest.mark.xfail(
+    condition=is_python_3_8_x,
+    reason="Python 3.8 uses older version of Pandas, which doesn't support the usage of index=False with orient='records'",
+    raises=ValueError,
+)
 @pytest.mark.parametrize("chunksize", [None, 1])
 @pytest.mark.parametrize("compression", ["gzip", "bz2", "xz", "zip", None])
 def test_partitioned_json(path: str, compression: str | None, chunksize: int | None) -> None:


### PR DESCRIPTION
### Detail
- Add `xfail` to unit tests failing because `index=False` and `orient="records"` have been set on a version of Pandas that doesn't support this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
