### PR TITLE
fix: Fix reading of chunked parquet when columns parameter is spec…

### DIFF
--- a/awswrangler/s3/_read_parquet.py
+++ b/awswrangler/s3/_read_parquet.py
@@ -237,8 +237,15 @@ def _read_parquet_chunked(
             chunks = pq_file.iter_batches(
                 batch_size=batch_size, columns=columns, use_threads=use_threads_flag, use_pandas_metadata=False
             )
+
+            if columns is not None:
+                field_dict = {field.name: field for field in pq_file.schema.to_arrow_schema()}
+                schema = pa.schema([field_dict[column] for column in columns])
+            else:
+                schema = pq_file.schema.to_arrow_schema()
+
             table = _add_table_partitions(
-                table=pa.Table.from_batches(chunks, schema=pq_file.schema.to_arrow_schema()),
+                table=pa.Table.from_batches(chunks, schema=schema),
                 path=path,
                 path_root=path_root,
             )


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Fix for _read_parquet_chunked function if columns are specified as parameter.
- By submitting this PR,  only fields will be passed to the schema when reading data from chunks

### Relates
- https://github.com/aws/aws-sdk-pandas/issues/2433

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
