### PR TITLE
fix: Deserialization error when reading from DynamoDB using `KeyConditionExpression`

### DIFF
--- a/awswrangler/dynamodb/_read.py
+++ b/awswrangler/dynamodb/_read.py
@@ -252,7 +252,7 @@ def _read_query_chunked(table_name: str, dynamodb_client: "DynamoDBClient", **kw
         response = dynamodb_client.query(TableName=table_name, **kwargs)
         items = response.get("Items", [])
         total_items += len(items)
-        yield items
+        yield [_deserialize_item(item) for item in items]
 
         if ("Limit" in kwargs) and (total_items >= kwargs["Limit"]):
             break

--- a/awswrangler/dynamodb/_read.py
+++ b/awswrangler/dynamodb/_read.py
@@ -35,14 +35,15 @@ from awswrangler.dynamodb._utils import _deserialize_item, _serialize_item, exec
 
 if TYPE_CHECKING:
     from mypy_boto3_dynamodb.client import DynamoDBClient
+    from mypy_boto3_dynamodb.type_defs import TableAttributeValueTypeDef
 
 _logger: logging.Logger = logging.getLogger(__name__)
 
 
-_ItemsListType = List[Dict[str, Any]]
+_ItemsListType = List[Dict[str, "TableAttributeValueTypeDef"]]
 
 
-def _read_chunked(iterator: Iterator[dict[str, Any]]) -> Iterator[pd.DataFrame]:
+def _read_chunked(iterator: Iterator[dict[str, "TableAttributeValueTypeDef"]]) -> Iterator[pd.DataFrame]:
     for item in iterator:
         yield pd.DataFrame(item)
 

--- a/awswrangler/dynamodb/_utils.py
+++ b/awswrangler/dynamodb/_utils.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
         AttributeValueTypeDef,
         ExecuteStatementOutputTypeDef,
         KeySchemaElementTypeDef,
+        TableAttributeValueTypeDef,
         WriteRequestTypeDef,
     )
 
@@ -57,7 +58,7 @@ def get_table(
 
 
 def _serialize_item(
-    item: Mapping[str, Any], serializer: TypeSerializer | None = None
+    item: Mapping[str, "TableAttributeValueTypeDef"], serializer: TypeSerializer | None = None
 ) -> dict[str, "AttributeValueTypeDef"]:
     serializer = serializer if serializer else TypeSerializer()
     return {k: serializer.serialize(v) for k, v in item.items()}
@@ -65,7 +66,7 @@ def _serialize_item(
 
 def _deserialize_item(
     item: Mapping[str, "AttributeValueTypeDef"], deserializer: TypeDeserializer | None = None
-) -> dict[str, Any]:
+) -> dict[str, "TableAttributeValueTypeDef"]:
     deserializer = deserializer if deserializer else TypeDeserializer()
     return {k: deserializer.deserialize(v) for k, v in item.items()}
 

--- a/tests/unit/test_dynamodb.py
+++ b/tests/unit/test_dynamodb.py
@@ -549,3 +549,153 @@ def test_read_items_schema(params, dynamodb_table: str, chunked: bool):
     }
     wr.dynamodb.read_items(allow_full_scan=True, **kwargs)
     wr.dynamodb.read_items(filter_expression=Attr("id").eq(1), **kwargs)
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {
+            "KeySchema": [{"AttributeName": "par0", "KeyType": "HASH"}, {"AttributeName": "par1", "KeyType": "RANGE"}],
+            "AttributeDefinitions": [
+                {"AttributeName": "par0", "AttributeType": "N"},
+                {"AttributeName": "par1", "AttributeType": "S"},
+            ],
+        }
+    ],
+)
+def test_deserialization_read_single_item(params: dict[str, Any], dynamodb_table: str) -> None:
+    wr.dynamodb.put_items(
+        items=[
+            {
+                "par0": 0,
+                "par1": "foo",
+            },
+            {
+                "par0": 1,
+                "par1": "bar",
+            },
+        ],
+        table_name=dynamodb_table,
+    )
+
+    items_df = wr.dynamodb.read_items(
+        table_name=dynamodb_table,
+        partition_values=[0],
+        sort_values=["foo"],
+        consistent=True,
+    )
+
+    assert not isinstance(items_df.iloc[0]["par0"], dict)
+    assert not isinstance(items_df.iloc[0]["par1"], dict)
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {
+            "KeySchema": [{"AttributeName": "par0", "KeyType": "HASH"}, {"AttributeName": "par1", "KeyType": "RANGE"}],
+            "AttributeDefinitions": [
+                {"AttributeName": "par0", "AttributeType": "N"},
+                {"AttributeName": "par1", "AttributeType": "S"},
+            ],
+        }
+    ],
+)
+def test_deserialization_read_batch_items(params: dict[str, Any], dynamodb_table: str) -> None:
+    wr.dynamodb.put_items(
+        items=[
+            {
+                "par0": 0,
+                "par1": "foo",
+            },
+            {
+                "par0": 1,
+                "par1": "bar",
+            },
+        ],
+        table_name=dynamodb_table,
+    )
+
+    items_df = wr.dynamodb.read_items(
+        table_name=dynamodb_table,
+        partition_values=[0, 1],
+        sort_values=["foo", "bar"],
+        consistent=True,
+    )
+
+    assert not isinstance(items_df.iloc[0]["par0"], dict)
+    assert not isinstance(items_df.iloc[0]["par1"], dict)
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {
+            "KeySchema": [{"AttributeName": "par0", "KeyType": "HASH"}, {"AttributeName": "par1", "KeyType": "RANGE"}],
+            "AttributeDefinitions": [
+                {"AttributeName": "par0", "AttributeType": "N"},
+                {"AttributeName": "par1", "AttributeType": "S"},
+            ],
+        }
+    ],
+)
+def test_deserialization_read_query(params: dict[str, Any], dynamodb_table: str) -> None:
+    wr.dynamodb.put_items(
+        items=[
+            {
+                "par0": 0,
+                "par1": "foo",
+            },
+            {
+                "par0": 1,
+                "par1": "bar",
+            },
+        ],
+        table_name=dynamodb_table,
+    )
+
+    items_df = wr.dynamodb.read_items(
+        table_name=dynamodb_table,
+        key_condition_expression=Key("par0").eq(0),
+        consistent=True,
+    )
+
+    assert not isinstance(items_df.iloc[0]["par0"], dict)
+    assert not isinstance(items_df.iloc[0]["par1"], dict)
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {
+            "KeySchema": [{"AttributeName": "par0", "KeyType": "HASH"}, {"AttributeName": "par1", "KeyType": "RANGE"}],
+            "AttributeDefinitions": [
+                {"AttributeName": "par0", "AttributeType": "N"},
+                {"AttributeName": "par1", "AttributeType": "S"},
+            ],
+        }
+    ],
+)
+def test_deserialization_full_scan(params: dict[str, Any], dynamodb_table: str) -> None:
+    wr.dynamodb.put_items(
+        items=[
+            {
+                "par0": 0,
+                "par1": "foo",
+            },
+            {
+                "par0": 1,
+                "par1": "bar",
+            },
+        ],
+        table_name=dynamodb_table,
+    )
+
+    items_df = wr.dynamodb.read_items(
+        table_name=dynamodb_table,
+        allow_full_scan=True,
+        consistent=True,
+    )
+
+    assert not isinstance(items_df.iloc[0]["par0"], dict)
+    assert not isinstance(items_df.iloc[0]["par1"], dict)

--- a/tests/unit/test_dynamodb.py
+++ b/tests/unit/test_dynamodb.py
@@ -33,12 +33,16 @@ pytestmark = pytest.mark.distributed
 )
 @pytest.mark.parametrize("use_threads", [False, True])
 def test_write(params: dict[str, Any], use_threads: bool, dynamodb_table: str) -> None:
-    df = pd.DataFrame(
-        {
-            "title": ["Titanic", "Snatch", "The Godfather"],
-            "year": [1997, 2000, 1972],
-            "genre": ["drama", "caper story", "crime"],
-        }
+    df = (
+        pd.DataFrame(
+            {
+                "title": ["Titanic", "Snatch", "The Godfather"],
+                "year": [1997, 2000, 1972],
+                "genre": ["drama", "caper story", "crime"],
+            }
+        )
+        .sort_values(by="year")
+        .reset_index(drop=True)
     )
     path = tempfile.gettempdir()
     query = f'SELECT * FROM "{dynamodb_table}"'
@@ -62,7 +66,7 @@ def test_write(params: dict[str, Any], use_threads: bool, dynamodb_table: str) -
     df3 = wr.dynamodb.read_partiql_query(query)
     df3 = df3[df.columns].sort_values(by="year").reset_index(drop=True)
     df3["year"] = df3["year"].astype("int64")
-    assert_pandas_equals(df.sort_values(by="year").reset_index(drop=True), df3)
+    assert_pandas_equals(df, df3)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_dynamodb.py
+++ b/tests/unit/test_dynamodb.py
@@ -49,7 +49,7 @@ def test_write(params: dict[str, Any], use_threads: bool, dynamodb_table: str) -
     wr.dynamodb.put_json(file_path, dynamodb_table, use_threads=use_threads)
 
     df2 = wr.dynamodb.read_partiql_query(query)
-    df2 = df2[df.columns].sort_values(by="year", ascending=True).reset_index(drop=True)
+    df2 = df2[df.columns].sort_values(by="year").reset_index(drop=True)
     df2["year"] = df["year"].astype("int64")
     assert_pandas_equals(df, df2)
 
@@ -60,9 +60,9 @@ def test_write(params: dict[str, Any], use_threads: bool, dynamodb_table: str) -
     wr.dynamodb.put_csv(file_path, dynamodb_table, use_threads=use_threads)
 
     df3 = wr.dynamodb.read_partiql_query(query)
-    df3 = df3[df.columns].sort_values(by="year", ascending=True).reset_index(drop=True)
+    df3 = df3[df.columns].sort_values(by="year").reset_index(drop=True)
     df3["year"] = df3["year"].astype("int64")
-    assert_pandas_equals(df.sort_values(by="year", ascending=True).reset_index(drop=True), df3)
+    assert_pandas_equals(df.sort_values(by="year").reset_index(drop=True), df3)
 
 
 @pytest.mark.parametrize(
@@ -165,10 +165,10 @@ def test_execute_statement(params: dict[str, Any], use_threads: bool, dynamodb_t
         parameters=[title, year],
     )
     df3 = wr.dynamodb.read_partiql_query(f'SELECT * FROM "{dynamodb_table}"')
-    df3 = df3[df.columns].sort_values(by="year", ascending=True).reset_index(drop=True)
+    df3 = df3[df.columns].sort_values(by="year").reset_index(drop=True)
     df3["year"] = df3["year"].astype("int64")
     assert_pandas_equals(
-        df.sort_values(by="year", ascending=True).reset_index(drop=True),
+        df.sort_values(by="year").reset_index(drop=True),
         df3,
     )
 
@@ -210,7 +210,7 @@ def test_dynamodb_put_from_file(
         raise RuntimeError(f"Unknown format {format}")
 
     df2 = wr.dynamodb.read_partiql_query(query=f"SELECT * FROM {dynamodb_table}")
-    df2 = df2.sort_values(by="par0", ascending=True).reset_index(drop=True)
+    df2 = df2.sort_values(by="par0").reset_index(drop=True)
     df2["par0"] = df["par0"].astype("int64")
     assert_pandas_equals(df, df2)
 
@@ -606,8 +606,8 @@ def test_deserialization_read_single_item(params: dict[str, Any], dynamodb_table
         consistent=True,
     )
 
-    assert not isinstance(items_df.iloc[0]["par0"], dict)
-    assert not isinstance(items_df.iloc[0]["par1"], dict)
+    assert items_df.iloc[0]["par0"] == 0
+    assert items_df.iloc[0]["par1"] == "foo"
 
 
 @pytest.mark.parametrize(
@@ -642,10 +642,12 @@ def test_deserialization_read_batch_items(params: dict[str, Any], dynamodb_table
         partition_values=[0, 1],
         sort_values=["foo", "bar"],
         consistent=True,
-    )
+    ).sort_values(by=["par0"])
 
-    assert not isinstance(items_df.iloc[0]["par0"], dict)
-    assert not isinstance(items_df.iloc[0]["par1"], dict)
+    assert items_df.iloc[0]["par0"] == 0
+    assert items_df.iloc[0]["par1"] == "foo"
+    assert items_df.iloc[1]["par0"] == 1
+    assert items_df.iloc[1]["par1"] == "bar"
 
 
 @pytest.mark.parametrize(
@@ -682,8 +684,8 @@ def test_deserialization_read_query(params: dict[str, Any], dynamodb_table: str)
         consistent=True,
     )
 
-    assert not isinstance(items_df.iloc[0]["par0"], dict)
-    assert not isinstance(items_df.iloc[0]["par1"], dict)
+    assert items_df.iloc[0]["par0"] == 0
+    assert items_df.iloc[0]["par1"] == "foo"
 
 
 @pytest.mark.parametrize(
@@ -717,7 +719,9 @@ def test_deserialization_full_scan(params: dict[str, Any], dynamodb_table: str) 
         table_name=dynamodb_table,
         allow_full_scan=True,
         consistent=True,
-    )
+    ).sort_values(by=["par0"])
 
-    assert not isinstance(items_df.iloc[0]["par0"], dict)
-    assert not isinstance(items_df.iloc[0]["par1"], dict)
+    assert items_df.iloc[0]["par0"] == 0
+    assert items_df.iloc[0]["par1"] == "foo"
+    assert items_df.iloc[1]["par0"] == 1
+    assert items_df.iloc[1]["par1"] == "bar"

--- a/tests/unit/test_dynamodb.py
+++ b/tests/unit/test_dynamodb.py
@@ -656,7 +656,8 @@ def test_deserialization_read_query(params: dict[str, Any], dynamodb_table: str)
 
     items_df = wr.dynamodb.read_items(
         table_name=dynamodb_table,
-        key_condition_expression=Key("par0").eq(0),
+        key_condition_expression="par0 = :v1",
+        expression_attribute_values={":v1": 0},
         consistent=True,
     )
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Fix deserialization error when reading from DynamoDB using `KeyConditionExpression`
- Added unit tests to make sure the output has been deserialized for all the different read options in the DynamoDB module
- Upgraded unit tests to check for DataFrame equality

### Relates
- #2605

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
