### PR TITLE
docs: add show_create_table to athena api ref

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -140,6 +140,7 @@ Amazon Athena
     read_sql_table
     repair_table
     run_spark_calculation
+    show_create_table
     start_query_execution
     stop_query_execution
     to_iceberg


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Feature

### Detail
- adds `show_create_table` to  docs for Athena

### Relates
- <URL or Ticket>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
