### PR TITLE
chore: Upgrade dependabot to upgrade GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,4 +15,11 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
+    schedule:
       interval: "weekly"
+      time: "09:00"
+      timezone: "Europe/London"
+    groups:
+      devops:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,8 @@ updates:
           dependency-type: "production"
         development-dependencies:
           dependency-type: "development"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,6 @@ updates:
       time: "09:00"
       timezone: "Europe/London"
     groups:
-      devops:
+      github-actions:
         patterns:
           - "*"


### PR DESCRIPTION
### Detail
- Adding dependabot configuration to update the versions of the GitHub actions that we use
- I tested this out in a fork repo, and this is what the update PR would look like: https://github.com/LeonLuttenberger/aws-sdk-pandas/pull/7

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
