### PR TITLE
fix: PostgreSQL reserved keywords as column names

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -332,11 +332,10 @@ def postgresql_table():
     name = f"tbl_{get_time_str_with_random_suffix()}"
     print(f"Table name: {name}")
     yield name
-    con = wr.postgresql.connect("aws-sdk-pandas-postgresql")
-    with con.cursor() as cursor:
-        cursor.execute(f"DROP TABLE IF EXISTS public.{name}")
-    con.commit()
-    con.close()
+    with wr.postgresql.connect("aws-sdk-pandas-postgresql") as con:
+        with con.cursor() as cursor:
+            cursor.execute(f"DROP TABLE IF EXISTS public.{name}")
+        con.commit()
 
 
 @pytest.fixture(scope="function")

--- a/tests/unit/test_postgresql.py
+++ b/tests/unit/test_postgresql.py
@@ -21,29 +21,29 @@ pytestmark = pytest.mark.distributed
 
 @pytest.fixture(scope="function")
 def postgresql_con() -> Iterator[pg8000.Connection]:
-    con = wr.postgresql.connect("aws-sdk-pandas-postgresql")
-    yield con
-    con.close()
+    with wr.postgresql.connect("aws-sdk-pandas-postgresql") as con:
+        yield con
 
 
-def test_glue_connection():
-    wr.postgresql.connect("aws-sdk-pandas-postgresql", timeout=10).close()
+def test_glue_connection() -> None:
+    with wr.postgresql.connect("aws-sdk-pandas-postgresql", timeout=10):
+        pass
 
 
-def test_glue_connection_ssm_credential_type():
-    wr.postgresql.connect("aws-sdk-pandas-postgresql-ssm", timeout=10).close()
+def test_glue_connection_ssm_credential_type() -> None:
+    with wr.postgresql.connect("aws-sdk-pandas-postgresql-ssm", timeout=10):
+        pass
 
 
 def test_read_sql_query_simple(databases_parameters):
-    con = pg8000.connect(
+    with pg8000.connect(
         host=databases_parameters["postgresql"]["host"],
         port=int(databases_parameters["postgresql"]["port"]),
         database=databases_parameters["postgresql"]["database"],
         user=databases_parameters["user"],
         password=databases_parameters["password"],
-    )
-    df = wr.postgresql.read_sql_query("SELECT 1", con=con)
-    con.close()
+    ) as con:
+        df = wr.postgresql.read_sql_query("SELECT 1", con=con)
     assert df.shape == (1, 1)
 
 
@@ -540,7 +540,7 @@ def test_timestamp_overflow(postgresql_table, postgresql_con):
     assert df.c0.values[0] == df2.c0.values[0]
 
 
-def test_column_with_reserved_keyword(postgresql_con: pg8000.Connection, postgresql_table: str) -> None:
+def test_column_with_reserved_keyword(postgresql_table: str, postgresql_con: pg8000.Connection) -> None:
     df = pd.DataFrame({"col0": [1], "end": ["foo"]})
     wr.postgresql.to_sql(
         df=df, con=postgresql_con, table=postgresql_table, schema="public", mode="append", use_column_names=True


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Fix postgres reserved keywords not getting escaped when used as column names
- The `pg8000.native.identifier` method we've used to escape literals doesn't take reserved keywords into account when deciding when a literal needs to be wrapped in quotation marks. Instead, we'll be using our own method, which will wrap the literal into quotation marks no matter what.

### Relates
- #2617

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
