### PR TITLE
fix: Update RDS cert bundle

### DIFF
--- a/test_infra/stacks/databases_stack.py
+++ b/test_infra/stacks/databases_stack.py
@@ -493,7 +493,7 @@ class DatabasesStack(Stack):  # type: ignore
                 "USERNAME": self.db_username,
                 "PASSWORD": self.db_password,
                 "JDBC_ENFORCE_SSL": "true",
-                "CUSTOM_JDBC_CERT": "s3://rds-downloads/rds-combined-ca-bundle.pem",
+                "CUSTOM_JDBC_CERT": "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem",
             },
             subnet=self.glue_connection_subnet,
             security_groups=[self.db_security_group],


### PR DESCRIPTION
### Relates
- RDS SSL tests started failing due to cert CA rotation. Cert bundle must be updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
