### PR TITLE
fix: indent categories in pyarrow_additional_kwargs correctly

### DIFF
--- a/awswrangler/athena/_read.py
+++ b/awswrangler/athena/_read.py
@@ -149,8 +149,8 @@ def _fetch_parquet_result(
         return df
     if not pyarrow_additional_kwargs:
         pyarrow_additional_kwargs = {}
-        if categories:
-            pyarrow_additional_kwargs["categories"] = categories
+    if categories:
+        pyarrow_additional_kwargs["categories"] = categories
     _logger.debug("Reading Parquet result from %d paths", len(paths))
     ret = s3.read_parquet(
         path=paths,


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
- Fix indentation for categories in `_fetch_parquet_result`. As it's currently setup, `categories` is never passed if `pyarrow_additional_kwargs` is passed by the user

### Relates
- #2700

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
