### PR TITLE
docs: fix `redshift.to_sql` doc indentation error

### DIFF
--- a/awswrangler/redshift/_write.py
+++ b/awswrangler/redshift/_write.py
@@ -122,7 +122,7 @@ def to_sql(
         Dictionary of columns names and Redshift types to be casted.
         Useful when you have columns with undetermined or mixed data types.
         (e.g. {'col name': 'VARCHAR(10)', 'col2 name': 'FLOAT'})
-        diststyle : str
+    diststyle : str
         Redshift distribution styles. Must be in ["AUTO", "EVEN", "ALL", "KEY"].
         https://docs.aws.amazon.com/redshift/latest/dg/t_Distributing_data.html
     distkey : str, optional


### PR DESCRIPTION
### Feature or Bugfix
- Documentation

### Detail
- fix `redshift.to_sql` doc indentation error

### Relates
- #2704

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
