### PR TITLE
fix: Pin Cython version to workaround issue when building PyArrow from source

### DIFF
--- a/building/lambda/Dockerfile
+++ b/building/lambda/Dockerfile
@@ -25,7 +25,7 @@ COPY pyproject.toml poetry.lock ./
 
 RUN pip3 install --upgrade pip wheel
 RUN pip3 install --upgrade urllib3==1.26.16  # temporary to avoid https://github.com/urllib3/urllib3/issues/2168 (TODO remove when the AL2 image updates to support OpenSSL 1.1.1+)
-RUN pip3 install --upgrade six cython cmake hypothesis poetry
+RUN pip3 install --upgrade six cython==3.0.8 cmake hypothesis poetry
 RUN poetry config virtualenvs.create false --local && poetry install --no-root --only main
 
 RUN rm -f pyproject.toml poetry.lock

--- a/building/lambda/Dockerfile
+++ b/building/lambda/Dockerfile
@@ -25,7 +25,7 @@ COPY pyproject.toml poetry.lock ./
 
 RUN pip3 install --upgrade pip wheel
 RUN pip3 install --upgrade urllib3==1.26.16  # temporary to avoid https://github.com/urllib3/urllib3/issues/2168 (TODO remove when the AL2 image updates to support OpenSSL 1.1.1+)
-RUN pip3 install --upgrade six cython<3.0.9 cmake hypothesis poetry
+RUN pip3 install --upgrade six cython==3.0.8 cmake hypothesis poetry
 RUN poetry config virtualenvs.create false --local && poetry install --no-root --only main
 
 RUN rm -f pyproject.toml poetry.lock

--- a/building/lambda/Dockerfile
+++ b/building/lambda/Dockerfile
@@ -25,7 +25,7 @@ COPY pyproject.toml poetry.lock ./
 
 RUN pip3 install --upgrade pip wheel
 RUN pip3 install --upgrade urllib3==1.26.16  # temporary to avoid https://github.com/urllib3/urllib3/issues/2168 (TODO remove when the AL2 image updates to support OpenSSL 1.1.1+)
-RUN pip3 install --upgrade six cython==3.0.8 cmake hypothesis poetry
+RUN pip3 install --upgrade six cython<3.0.9 cmake hypothesis poetry
 RUN poetry config virtualenvs.create false --local && poetry install --no-root --only main
 
 RUN rm -f pyproject.toml poetry.lock

--- a/building/lambda/Dockerfile.al2023
+++ b/building/lambda/Dockerfile.al2023
@@ -24,7 +24,7 @@ FROM ${python_version}
 COPY pyproject.toml poetry.lock ./
 
 RUN pip3 install --upgrade pip wheel
-RUN pip3 install --upgrade six cython cmake hypothesis poetry
+RUN pip3 install --upgrade six cython==3.0.8 cmake hypothesis poetry
 RUN poetry config virtualenvs.create false --local && poetry install --no-root --only main
 
 RUN rm -f pyproject.toml poetry.lock

--- a/building/lambda/Dockerfile.al2023
+++ b/building/lambda/Dockerfile.al2023
@@ -24,7 +24,7 @@ FROM ${python_version}
 COPY pyproject.toml poetry.lock ./
 
 RUN pip3 install --upgrade pip wheel
-RUN pip3 install --upgrade six cython<3.0.9 cmake hypothesis poetry
+RUN pip3 install --upgrade six cython==3.0.8 cmake hypothesis poetry
 RUN poetry config virtualenvs.create false --local && poetry install --no-root --only main
 
 RUN rm -f pyproject.toml poetry.lock

--- a/building/lambda/Dockerfile.al2023
+++ b/building/lambda/Dockerfile.al2023
@@ -24,7 +24,7 @@ FROM ${python_version}
 COPY pyproject.toml poetry.lock ./
 
 RUN pip3 install --upgrade pip wheel
-RUN pip3 install --upgrade six cython==3.0.8 cmake hypothesis poetry
+RUN pip3 install --upgrade six cython<3.0.9 cmake hypothesis poetry
 RUN poetry config virtualenvs.create false --local && poetry install --no-root --only main
 
 RUN rm -f pyproject.toml poetry.lock


### PR DESCRIPTION
### Detail
Currently, we are unable to build our layers due to this issue in PyArrow: https://github.com/apache/arrow/issues/40375

Pinning Cython to an earlier version as a workaround.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
