### PR TITLE
fix: allow s3_output in athena.to_iceberg

### DIFF
--- a/awswrangler/athena/_write_iceberg.py
+++ b/awswrangler/athena/_write_iceberg.py
@@ -241,6 +241,7 @@ def to_iceberg(
     merge_cols: list[str] | None = None,
     keep_files: bool = True,
     data_source: str | None = None,
+    s3_output: str | None = None,
     workgroup: str = "primary",
     mode: Literal["append", "overwrite", "overwrite_partitions"] = "append",
     encryption: str | None = None,
@@ -288,6 +289,8 @@ def to_iceberg(
         Whether staging files produced by Athena are retained. 'True' by default.
     data_source : str, optional
         Data Source / Catalog name. If None, 'AwsDataCatalog' will be used by default.
+    s3_output : str, optional
+        Amazon S3 path used for query execution.
     workgroup : str
         Athena workgroup. Primary by default.
     mode: str
@@ -498,6 +501,7 @@ def to_iceberg(
             wg_config=wg_config,
             database=database,
             data_source=data_source,
+            s3_output=s3_output,
             encryption=encryption,
             kms_key=kms_key,
             boto3_session=boto3_session,

--- a/tests/unit/test_athena_iceberg.py
+++ b/tests/unit/test_athena_iceberg.py
@@ -68,6 +68,7 @@ def test_athena_to_iceberg(
 def test_athena_to_iceberg_append(
     path: str,
     path2: str,
+    path3: str,
     glue_database: str,
     glue_table: str,
     partition_cols: list[str] | None,
@@ -102,6 +103,7 @@ def test_athena_to_iceberg_append(
         partition_cols=partition_cols,
         keep_files=False,
         mode="append",
+        s3_output=path3,
     )
 
     df_actual = wr.athena.read_sql_query(


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
- Allow passing `s3_output` in athena.to_iceberg

### Relates
- #2710

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
