### PR TITLE
fix: Athena to_iceberg fails with non-lowercase column names

### DIFF
--- a/awswrangler/athena/_write_iceberg.py
+++ b/awswrangler/athena/_write_iceberg.py
@@ -108,6 +108,9 @@ def _determine_differences(
     )
     frame_columns_types.update(frame_partitions_types)
 
+    # lowercase DataFrame columns, as all the column names from Athena will be lowercased
+    frame_columns_types = {k.lower(): v for k, v in frame_columns_types.items()}
+
     catalog_column_types = typing.cast(
         Dict[str, str],
         catalog.get_table_types(database=database, table=table, catalog_id=catalog_id, boto3_session=boto3_session),


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- fix Athena `to_iceberg` failing with non-lowercase column names

### Relates
- #2734

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
