### PR TITLE
fix: Iceberg schema evolution fails for map, array and struct types

### DIFF
--- a/awswrangler/_data_types.py
+++ b/awswrangler/_data_types.py
@@ -375,7 +375,7 @@ def athena2pandas(dtype: str, dtype_backend: str | None = None) -> str:  # noqa:
         return "decimal" if dtype_backend != "pyarrow" else "double[pyarrow]"
     if dtype in ("binary", "varbinary"):
         return "bytes" if dtype_backend != "pyarrow" else "binary[pyarrow]"
-    if dtype in ("array", "row", "map"):
+    if any(dtype.startswith(t) for t in ["array", "row", "map"]):
         return "object"
     if dtype == "geometry":
         return "string"

--- a/awswrangler/_data_types.py
+++ b/awswrangler/_data_types.py
@@ -308,6 +308,7 @@ def _split_map(s: str) -> list[str]:
 
 def athena2pyarrow(dtype: str) -> pa.DataType:  # noqa: PLR0911,PLR0912
     """Athena to PyArrow data types conversion."""
+    dtype = dtype.strip()
     if dtype.startswith(("array", "struct", "map")):
         orig_dtype: str = dtype
     dtype = dtype.lower().replace(" ", "")
@@ -375,7 +376,7 @@ def athena2pandas(dtype: str, dtype_backend: str | None = None) -> str:  # noqa:
         return "decimal" if dtype_backend != "pyarrow" else "double[pyarrow]"
     if dtype in ("binary", "varbinary"):
         return "bytes" if dtype_backend != "pyarrow" else "binary[pyarrow]"
-    if any(dtype.startswith(t) for t in ["array", "row", "map"]):
+    if any(dtype.startswith(t) for t in ["array", "row", "map", "struct"]):
         return "object"
     if dtype == "geometry":
         return "string"

--- a/tests/unit/test_athena_iceberg.py
+++ b/tests/unit/test_athena_iceberg.py
@@ -926,7 +926,7 @@ def test_to_iceberg_uppercase_columns(
     assert_pandas_equals(df, df_output)
 
 
-def test_to_iceberg_fill_missing_columns(
+def test_to_iceberg_fill_missing_columns_map(
     path: str,
     path2: str,
     glue_database: str,

--- a/tests/unit/test_athena_iceberg.py
+++ b/tests/unit/test_athena_iceberg.py
@@ -926,7 +926,7 @@ def test_to_iceberg_uppercase_columns(
     assert_pandas_equals(df, df_output)
 
 
-def test_to_iceberg_fill_missing_columns_map(
+def test_to_iceberg_fill_missing_columns_with_complex_types(
     path: str,
     path2: str,
     glue_database: str,
@@ -937,6 +937,12 @@ def test_to_iceberg_fill_missing_columns_map(
             "partition": [1, 1, 2, 2],
             "column2": ["A", "B", "C", "D"],
             "map_col": [{"s": "d"}, {"s": "h"}, {"i": "l"}, {}],
+            "struct_col": [
+                {"a": "val1", "b": {"c": "val21"}},
+                {"a": "val1", "b": {"c": None}},
+                {"a": "val1", "b": None},
+                {},
+            ],
         }
     )
     df_missing_col = pd.DataFrame(
@@ -950,6 +956,7 @@ def test_to_iceberg_fill_missing_columns_map(
         "partition": "int",
         "column2": "string",
         "map_col": "map<string, string>",
+        "struct_col": "struct<a: string, b: struct<c: string>>",
     }
 
     wr.athena.to_iceberg(


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Iceberg schema evolution fails for map, array, and struct types

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
