### PR TITLE
docs: Fix YAML formatting in Ray Remote tutorial

### DIFF
--- a/tutorials/035 - Distributing Calls on Ray Remote Cluster.ipynb
+++ b/tutorials/035 - Distributing Calls on Ray Remote Cluster.ipynb
@@ -83,13 +83,17 @@
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
+    },
+    "vscode": {
+     "languageId": "raw"
     }
    },
    "source": [
+    "```yaml\n",
     "cluster_name: pandas-sdk-cluster\n",
     "\n",
     "min_workers: 2\n",
@@ -136,7 +140,8 @@
     "\n",
     "\n",
     "setup_commands:\n",
-    "- pip install \"awswrangler[modin,ray]\""
+    "- pip install \"awswrangler[modin,ray]\"\n",
+    "```"
    ]
   },
   {


### PR DESCRIPTION
### Detail
- The YAML in the Ray Remote tutorial is not displayed properly [in the documentation](https://aws-sdk-pandas.readthedocs.io/en/3.7.2/tutorials/035%20-%20Distributing%20Calls%20on%20Ray%20Remote%20Cluster.html#Configure-Ray-Cluster-Configuration)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
