### PR TITLE
fix: Opensearch serverless vector search collections - remove default `_id`

### DIFF
--- a/awswrangler/opensearch/_write.py
+++ b/awswrangler/opensearch/_write.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import ast
 import json
 import logging
-from typing import Any, Generator, Iterable, Mapping
+from typing import Any, Generator, Iterable, Mapping, cast
 
 import boto3
 import numpy as np
@@ -48,7 +48,7 @@ def _actions_generator(
         if id_keys:
             _id = "-".join([str(document[id_key]) for id_key in id_keys])
         else:
-            _id = document.get("_id")
+            _id = cast(str, document.get("_id"))
         bulk_chunk_documents.append(
             {
                 "_index": index,

--- a/awswrangler/opensearch/_write.py
+++ b/awswrangler/opensearch/_write.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import ast
 import json
 import logging
-import uuid
 from typing import Any, Generator, Iterable, Mapping
 
 import boto3
@@ -49,7 +48,7 @@ def _actions_generator(
         if id_keys:
             _id = "-".join([str(document[id_key]) for id_key in id_keys])
         else:
-            _id = document.get("_id", uuid.uuid4())
+            _id = document.get("_id")
         bulk_chunk_documents.append(
             {
                 "_index": index,


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Remove redundant `_id` generation as it is generated by OpenSearch by default.
- Additionally, passing `_id` is [not supported](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-genref.html#serverless-operations)  by OpenSearch **vector search** collections (see PUT `<index>/_create/<id>` (for search collection types only):

```
opensearchpy.helpers.errors.BulkIndexError: ('3 document(s) failed to index.', [{'index': {'_index': 'dummy-vector-search-1', '_id': '32300c88-a52c-4a14-95f6-aad4919b1b7b', 'status': 400, 'error': {'type': 'illegal_argument_exception', 'reason': 'Document ID is not supported in create/index operation request'}, 'data': {'name': 'John'}}}, {'index': {'_index': 'dummy-vector-search-1', '_id': '4c5f5d5d-6337-460f-9efc-31f4c1dd5df1', 'status': 400, 'error': {'type': 'illegal_argument_exception', 'reason': 'Document ID is not supported in create/index operation request'}, 'data': {'name': 'George'}}}, {'index': {'_index': 'dummy-vector-search-1', '_id': '0f924638-c83b-43b1-8c21-de42f6e3a22f', 'status': 400, 'error': {'type': 'illegal_argument_exception', 'reason': 'Document ID is not supported in create/index operation request'}, 'data': {'name': 'Julia'}}}])
```

### Relates
- Community Slack [convo](https://aws-sdk-pandas.slack.com/archives/C028ZDMB12L/p1708700547789269)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
