### PR TITLE
feat: Support client-side parameter resolution in athena.create_ctas_table

### DIFF
--- a/awswrangler/athena/_read.py
+++ b/awswrangler/athena/_read.py
@@ -337,7 +337,8 @@ def _resolve_query_without_cache_ctas(
         wait=True,
         athena_query_wait_polling_delay=athena_query_wait_polling_delay,
         boto3_session=boto3_session,
-        execution_params=execution_params,
+        params=execution_params,
+        paramstyle="qmark",
     )
     fully_qualified_name: str = f'"{ctas_query_info["ctas_database"]}"."{ctas_query_info["ctas_table"]}"'
     ctas_query_metadata = cast(_QueryMetadata, ctas_query_info["ctas_query_metadata"])


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
- Support client-side parameter resolution in athena.create_ctas_table

### Relates
- #2787

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
