### PR TITLE
docs: Fix enumerations in doc pages

### DIFF
--- a/awswrangler/athena/_statements.py
+++ b/awswrangler/athena/_statements.py
@@ -59,6 +59,7 @@ def create_prepared_statement(
 
         - ``update`` - updates statement if already exists
         - ``error`` - throws an error if table exists
+
     boto3_session : boto3.Session(), optional
         Boto3 Session. The default boto3 session will be used if boto3_session receive None.
 

--- a/awswrangler/postgresql.py
+++ b/awswrangler/postgresql.py
@@ -528,38 +528,44 @@ def to_sql(
 
     Parameters
     ----------
-    df : pandas.DataFrame
-        Pandas DataFrame https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html
-    con : pg8000.Connection
-        Use pg8000.connect() to use credentials directly or wr.postgresql.connect() to fetch it from the Glue Catalog.
-    table : str
+    df: pandas.DataFrame
+        `Pandas DataFrame <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html>`_
+    con: pg8000.Connection
+        Use ``pg8000.connect()`` to use credentials directly or ``wr.postgresql.connect()`` to fetch it from the Glue Catalog.
+    table: str
         Table name
-    schema : str
+    schema: str
         Schema name
-    mode : str
+    mode: str
         Append, overwrite or upsert.
-            append: Inserts new records into table.
-            overwrite: Drops table and recreates.
-            upsert: Perform an upsert which checks for conflicts on columns given by `upsert_conflict_columns` and
-            sets the new values on conflicts. Note that `upsert_conflict_columns` is required for this mode.
-    overwrite_method : str
+
+        - append: Inserts new records into table.
+        - overwrite: Drops table and recreates.
+        - upsert: Perform an upsert which checks for conflicts on columns given by ``upsert_conflict_columns`` and
+          sets the new values on conflicts. Note that ``upsert_conflict_columns`` is required for this mode.
+
+    overwrite_method: str
         Drop, cascade, truncate, or truncate cascade. Only applicable in overwrite mode.
 
-        "drop" - ``DROP ... RESTRICT`` - drops the table. Fails if there are any views that depend on it.
-        "cascade" - ``DROP ... CASCADE`` - drops the table, and all views that depend on it.
-        "truncate" - ``TRUNCATE ... RESTRICT`` - truncates the table. Fails if any of the tables have foreign-key references from tables that are not listed in the command.
-        "truncate cascade" - ``TRUNCATE ... CASCADE`` - truncates the table, and all tables that have foreign-key references to any of the named tables.
-    index : bool
+        - "drop" - ``DROP ... RESTRICT`` - drops the table. Fails if there are any views that depend on it.
+        - "cascade" - ``DROP ... CASCADE`` - drops the table, and all views that depend on it.
+        - "truncate" - ``TRUNCATE ... RESTRICT`` - truncates the table.
+          Fails if any of the tables have foreign-key references from tables that are not listed in the command.
+        - "truncate cascade" - ``TRUNCATE ... CASCADE`` - truncates the table, and all tables that have
+          foreign-key references to any of the named tables.
+
+    index: bool
         True to store the DataFrame index as a column in the table,
         otherwise False to ignore it.
     dtype: Dict[str, str], optional
         Dictionary of columns names and PostgreSQL types to be casted.
         Useful when you have columns with undetermined or mixed data types.
-        (e.g. {'col name': 'TEXT', 'col2 name': 'FLOAT'})
-    varchar_lengths : Dict[str, int], optional
-        Dict of VARCHAR length by columns. (e.g. {"col1": 10, "col5": 200}).
+        (e.g. ``{'col name': 'TEXT', 'col2 name': 'FLOAT'}``)
+    varchar_lengths: Dict[str, int], optional
+        Dict of VARCHAR length by columns. (e.g. ``{"col1": 10, "col5": 200}``).
     use_column_names: bool
         If set to True, will use the column names of the DataFrame for generating the INSERT SQL Query.
+
         E.g. If the DataFrame has two columns `col1` and `col3` and `use_column_names` is True, data will only be
         inserted into the database columns `col1` and `col3`.
     chunksize: int
@@ -583,14 +589,13 @@ def to_sql(
     Writing to PostgreSQL using a Glue Catalog Connections
 
     >>> import awswrangler as wr
-    >>> con = wr.postgresql.connect("MY_GLUE_CONNECTION")
-    >>> wr.postgresql.to_sql(
-    ...     df=df,
-    ...     table="my_table",
-    ...     schema="public",
-    ...     con=con
-    ... )
-    >>> con.close()
+    >>> with wr.postgresql.connect("MY_GLUE_CONNECTION") as con:
+    ...     wr.postgresql.to_sql(
+    ...         df=df,
+    ...         table="my_table",
+    ...         schema="public",
+    ...         con=con
+    ...     )
 
     """
     if df.empty is True:

--- a/awswrangler/redshift/_write.py
+++ b/awswrangler/redshift/_write.py
@@ -111,11 +111,12 @@ def to_sql(
     overwrite_method : str
         Drop, cascade, truncate, or delete. Only applicable in overwrite mode.
 
-        "drop" - ``DROP ... RESTRICT`` - drops the table. Fails if there are any views that depend on it.
-        "cascade" - ``DROP ... CASCADE`` - drops the table, and all views that depend on it.
-        "truncate" - ``TRUNCATE ...`` - truncates the table, but immediately commits current
-        transaction & starts a new one, hence the overwrite happens in two transactions and is not atomic.
-        "delete" - ``DELETE FROM ...`` - deletes all rows from the table. Slow relative to the other methods.
+        - "drop" - ``DROP ... RESTRICT`` - drops the table. Fails if there are any views that depend on it.
+        - "cascade" - ``DROP ... CASCADE`` - drops the table, and all views that depend on it.
+        - "truncate" - ``TRUNCATE ...`` - truncates the table, but immediately commits current transaction &
+          starts a new one, hence the overwrite happens in two transactions and is not atomic.
+        - "delete" - ``DELETE FROM ...`` - deletes all rows from the table. Slow relative to the other methods.
+
     index : bool
         True to store the DataFrame index as a column in the table,
         otherwise False to ignore it.

--- a/awswrangler/s3/_copy.py
+++ b/awswrangler/s3/_copy.py
@@ -201,27 +201,27 @@ def copy_objects(
     Note
     ----
     In case of `use_threads=True` the number of threads
-    that will be spawned will be gotten from os.cpu_count().
+    that will be spawned will be gotten from `os.cpu_count()`.
 
     Parameters
     ----------
-    paths : List[str]
-        List of S3 objects paths (e.g. [s3://bucket/dir0/key0, s3://bucket/dir0/key1]).
-    source_path : str,
+    paths: List[str]
+        List of S3 objects paths (e.g. ``["s3://bucket/dir0/key0", "s3://bucket/dir0/key1"]``).
+    source_path: str
         S3 Path for the source directory.
-    target_path : str,
+    target_path: str
         S3 Path for the target directory.
-    replace_filenames : Dict[str, str], optional
-        e.g. {"old_name.csv": "new_name.csv", "old_name2.csv": "new_name2.csv"}
-    use_threads : bool, int
+    replace_filenames: Dict[str, str], optional
+        e.g. ``{"old_name.csv": "new_name.csv", "old_name2.csv": "new_name2.csv"}``
+    use_threads: bool, int
         True to enable concurrent requests, False to disable multiple threads.
-        If enabled os.cpu_count() will be used as the max number of threads.
+        If enabled ``os.cpu_count()`` will be used as the max number of threads.
         If integer is provided, specified number is used.
-    boto3_session : boto3.Session(), optional
+    boto3_session: boto3.Session(), optional
         Boto3 Session. The default boto3 session will be used if boto3_session receive None.
     s3_additional_kwargs: dict[str, Any], optional
         Forwarded to botocore requests.
-        e.g. s3_additional_kwargs={'ServerSideEncryption': 'aws:kms', 'SSEKMSKeyId': 'YOUR_KMS_KEY_ARN'}
+        e.g. ``s3_additional_kwargs={'ServerSideEncryption': 'aws:kms', 'SSEKMSKeyId': 'YOUR_KMS_KEY_ARN'}``
 
     Returns
     -------


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
Fix enumerations in doc pages:
1. [awswrangler.postgresql.to_sql](https://aws-sdk-pandas.readthedocs.io/en/3.7.3/stubs/awswrangler.postgresql.to_sql.html)
2. [awswrangler.redshift.to_sql](https://aws-sdk-pandas.readthedocs.io/en/3.7.3/stubs/awswrangler.redshift.to_sql.html#awswrangler.redshift.to_sql)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
