### PR TITLE
docs: Fix readthedocs errors by pinning sphinx version

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -9,7 +9,7 @@ dependencies:
     - myst_parser
     - nbsphinx
     - nbsphinx-link
-    - sphinx
+    - sphinx==7.1.2
     - sphinx_bootstrap_theme
     - sphinx-copybutton
     - IPython


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Fix readthedocs errors by pinning sphinx version

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
