### PR TITLE
fix: s3.read_parquet_metadata not throwing proper error for empty path

### DIFF
--- a/awswrangler/s3/_read.py
+++ b/awswrangler/s3/_read.py
@@ -265,6 +265,10 @@ class _TableMetadataReader(ABC):
             ignore_empty=ignore_empty,
             s3_additional_kwargs=s3_additional_kwargs,
         )
+
+        if len(paths) < 1:
+            raise exceptions.NoFilesFound(f"No files Found: {path}.")
+
         version_ids = _check_version_id(paths=paths, version_id=version_id)
 
         # Files

--- a/tests/unit/test_s3_parquet.py
+++ b/tests/unit/test_s3_parquet.py
@@ -57,6 +57,11 @@ def test_read_parquet_metadata_nulls(path):
     assert columns_types.get("c2") == "string"
 
 
+def test_read_parquet_metadata_nonexistent_file(path):
+    with pytest.raises(wr.exceptions.NoFilesFound):
+        wr.s3.read_parquet_metadata(path + "non-existent-file.parquet")
+
+
 @pytest.mark.parametrize(
     "partition_cols",
     [


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- `wr.s3.read_parquet_metadata` not throwing proper error for empty path

### Relates
- #2842

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
