### PR TITLE
refactor: Remove legacy Numpy code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,7 @@ line-length = 120
 target-version = "py38"
 
 [tool.ruff.lint]
-select = ["D", "E", "F", "I", "PL", "RUF100", "W", "FA", "UP", "PYI036"]
+select = ["D", "E", "F", "I", "PL", "RUF100", "W", "FA", "UP", "PYI036", "NPY"]
 ignore = ["E501", "PLR2004", "UP037"]
 fixable = ["ALL"]
 

--- a/tests/load/test_s3.py
+++ b/tests/load/test_s3.py
@@ -238,14 +238,16 @@ def test_wait_object_not_exists(path: str, benchmark_time: int, request: pytest.
 
 @pytest.mark.parametrize("size", [(5000, 5000), (1, 5000), (5000, 1), (1, 1)])
 def test_wide_df(size: tuple[int, int], path: str) -> None:
-    df = pd.DataFrame(np.random.randint(0, 100, size=size))
+    rand_gen = np.random.Generator()
+
+    df = pd.DataFrame(rand_gen.integers(0, 100, size=size))
     df.columns = df.columns.map(str)
 
     num_cols = size[0]
-    df["int"] = np.random.choice(["1", "2", None], num_cols)
-    df["decimal"] = np.random.choice(["1.0", "2.0", None], num_cols)
-    df["date"] = np.random.choice(["2020-01-01", "2020-01-02", None], num_cols)
-    df["par0"] = np.random.choice(["A", "B"], num_cols)
+    df["int"] = rand_gen.choice(["1", "2", None], num_cols)
+    df["decimal"] = rand_gen.choice(["1.0", "2.0", None], num_cols)
+    df["date"] = rand_gen.choice(["2020-01-01", "2020-01-02", None], num_cols)
+    df["par0"] = rand_gen.choice(["A", "B"], num_cols)
 
     partitions_shape = np.array(unwrap_partitions(df)).shape
     assert partitions_shape[1] == min(math.ceil(len(df.columns) / cfg.MinPartitionSize.get()), cfg.NPartitions.get())

--- a/tests/unit/test_athena.py
+++ b/tests/unit/test_athena.py
@@ -969,8 +969,8 @@ def test_athena_nan_inf(glue_database, ctas_approach, data_source):
     assert df.shape == (1, 4)
     assert df.dtypes.to_list() == ["float64", "float64", "float64", "float64"]
     assert np.isnan(df.nan.iloc[0])
-    assert df.inf.iloc[0] == np.PINF
-    assert df.inf_n.iloc[0] == np.NINF
+    assert df.inf.iloc[0] == np.inf
+    assert df.inf_n.iloc[0] == -np.inf
     assert df.regular.iloc[0] == 1.2
 
 


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Detail
- Ruff has a checker that warns against legacy Numpy code (like constants that are removed in Numpy 2.0)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
