### PR TITLE
fix: Adding NotebookVersion Parameter as specified in official AWS Docs

### DIFF
--- a/awswrangler/athena/_spark.py
+++ b/awswrangler/athena/_spark.py
@@ -94,7 +94,7 @@ def create_spark_session(
     default_executor_dpu_size: int = 1,
     additional_configs: dict[str, Any] | None = None,
     spark_properties: dict[str, Any] | None = None,
-    notebook_version: str = "Athena notebook version 1",
+    notebook_version: str | None = None,
     idle_timeout: int = 15,
     boto3_session: boto3.Session | None = None,
 ) -> str:
@@ -117,11 +117,11 @@ def create_spark_session(
     spark_properties: Dict[str, Any], optional
         Contains SparkProperties in the form of key-value pairs.Specifies custom jar files and Spark properties
         for use cases like cluster encryption, table formats, and general Spark tuning.
-    notebook_version: str
+    notebook_version: str, optional
         The notebook version. This value is supplied automatically for notebook sessions in the Athena console and is not required for programmatic session access.
         The only valid notebook version is Athena notebook version 1. If you specify a value for NotebookVersion, you must also specify a value for NotebookId
     idle_timeout : int, optional
-         The idle timeout in minutes for the session. The default is 15.
+        The idle timeout in minutes for the session. The default is 15.
     boto3_session : boto3.Session(), optional
         Boto3 Session. The default boto3 session will be used if boto3_session receive None.
 
@@ -146,11 +146,13 @@ def create_spark_session(
         engine_configuration["AdditionalConfigs"] = additional_configs
     if spark_properties:
         engine_configuration["SparkProperties"] = spark_properties
+    kwargs: Any = {"SessionIdleTimeoutInMinutes": idle_timeout}
+    if notebook_version:
+        kwargs["NotebookVersion"] = notebook_version
     response = client_athena.start_session(
         WorkGroup=workgroup,
         EngineConfiguration=engine_configuration,
-        SessionIdleTimeoutInMinutes=idle_timeout,
-        NotebookVersion=notebook_version,
+        **kwargs,
     )
     _logger.info("Session info:\n%s", response)
     session_id: str = response["SessionId"]

--- a/awswrangler/athena/_spark.py
+++ b/awswrangler/athena/_spark.py
@@ -173,7 +173,7 @@ def run_spark_calculation(
     default_executor_dpu_size: int = 1,
     additional_configs: dict[str, Any] | None = None,
     spark_properties: dict[str, Any] | None = None,
-    notebook_version: str = "Athena notebook version 1",
+    notebook_version: str | None = None,
     idle_timeout: int = 15,
     boto3_session: boto3.Session | None = None,
 ) -> dict[str, Any]:
@@ -200,7 +200,7 @@ def run_spark_calculation(
     spark_properties: Dict[str, Any], optional
         Contains SparkProperties in the form of key-value pairs.Specifies custom jar files and Spark properties
         for use cases like cluster encryption, table formats, and general Spark tuning.
-    notebook_version: str
+    notebook_version: str, optional
         The notebook version. This value is supplied automatically for notebook sessions in the Athena console and is not required for programmatic session access.
         The only valid notebook version is Athena notebook version 1. If you specify a value for NotebookVersion, you must also specify a value for NotebookId
     idle_timeout : int, optional

--- a/awswrangler/athena/_spark.py
+++ b/awswrangler/athena/_spark.py
@@ -94,6 +94,7 @@ def create_spark_session(
     default_executor_dpu_size: int = 1,
     additional_configs: dict[str, Any] | None = None,
     spark_properties: dict[str, Any] | None = None,
+    notebook_version: str = 'Athena notebook version 1',
     idle_timeout: int = 15,
     boto3_session: boto3.Session | None = None,
 ) -> str:
@@ -116,6 +117,9 @@ def create_spark_session(
     spark_properties: Dict[str, Any], optional
         Contains SparkProperties in the form of key-value pairs.Specifies custom jar files and Spark properties
         for use cases like cluster encryption, table formats, and general Spark tuning.
+    notebook_version: str
+        The notebook version. This value is supplied automatically for notebook sessions in the Athena console and is not required for programmatic session access. 
+        The only valid notebook version is Athena notebook version 1. If you specify a value for NotebookVersion, you must also specify a value for NotebookId
     idle_timeout : int, optional
          The idle timeout in minutes for the session. The default is 15.
     boto3_session : boto3.Session(), optional
@@ -146,6 +150,7 @@ def create_spark_session(
         WorkGroup=workgroup,
         EngineConfiguration=engine_configuration,
         SessionIdleTimeoutInMinutes=idle_timeout,
+        NotebookVersion=notebook_version,
     )
     _logger.info("Session info:\n%s", response)
     session_id: str = response["SessionId"]
@@ -166,6 +171,7 @@ def run_spark_calculation(
     default_executor_dpu_size: int = 1,
     additional_configs: dict[str, Any] | None = None,
     spark_properties: dict[str, Any] | None = None,
+    notebook_version: str = 'Athena notebook version 1',
     idle_timeout: int = 15,
     boto3_session: boto3.Session | None = None,
 ) -> dict[str, Any]:
@@ -192,6 +198,9 @@ def run_spark_calculation(
     spark_properties: Dict[str, Any], optional
         Contains SparkProperties in the form of key-value pairs.Specifies custom jar files and Spark properties
         for use cases like cluster encryption, table formats, and general Spark tuning.
+    notebook_version: str
+        The notebook version. This value is supplied automatically for notebook sessions in the Athena console and is not required for programmatic session access. 
+        The only valid notebook version is Athena notebook version 1. If you specify a value for NotebookVersion, you must also specify a value for NotebookId
     idle_timeout : int, optional
         The idle timeout in minutes for the session. The default is 15.
     boto3_session : boto3.Session(), optional
@@ -221,6 +230,7 @@ def run_spark_calculation(
             default_executor_dpu_size=default_executor_dpu_size,
             additional_configs=additional_configs,
             spark_properties=spark_properties,
+            notebook_version=notebook_version,
             idle_timeout=idle_timeout,
             boto3_session=boto3_session,
         )

--- a/awswrangler/athena/_spark.py
+++ b/awswrangler/athena/_spark.py
@@ -94,7 +94,7 @@ def create_spark_session(
     default_executor_dpu_size: int = 1,
     additional_configs: dict[str, Any] | None = None,
     spark_properties: dict[str, Any] | None = None,
-    notebook_version: str = 'Athena notebook version 1',
+    notebook_version: str = "Athena notebook version 1",
     idle_timeout: int = 15,
     boto3_session: boto3.Session | None = None,
 ) -> str:
@@ -118,7 +118,7 @@ def create_spark_session(
         Contains SparkProperties in the form of key-value pairs.Specifies custom jar files and Spark properties
         for use cases like cluster encryption, table formats, and general Spark tuning.
     notebook_version: str
-        The notebook version. This value is supplied automatically for notebook sessions in the Athena console and is not required for programmatic session access. 
+        The notebook version. This value is supplied automatically for notebook sessions in the Athena console and is not required for programmatic session access.
         The only valid notebook version is Athena notebook version 1. If you specify a value for NotebookVersion, you must also specify a value for NotebookId
     idle_timeout : int, optional
          The idle timeout in minutes for the session. The default is 15.
@@ -171,7 +171,7 @@ def run_spark_calculation(
     default_executor_dpu_size: int = 1,
     additional_configs: dict[str, Any] | None = None,
     spark_properties: dict[str, Any] | None = None,
-    notebook_version: str = 'Athena notebook version 1',
+    notebook_version: str = "Athena notebook version 1",
     idle_timeout: int = 15,
     boto3_session: boto3.Session | None = None,
 ) -> dict[str, Any]:
@@ -199,7 +199,7 @@ def run_spark_calculation(
         Contains SparkProperties in the form of key-value pairs.Specifies custom jar files and Spark properties
         for use cases like cluster encryption, table formats, and general Spark tuning.
     notebook_version: str
-        The notebook version. This value is supplied automatically for notebook sessions in the Athena console and is not required for programmatic session access. 
+        The notebook version. This value is supplied automatically for notebook sessions in the Athena console and is not required for programmatic session access.
         The only valid notebook version is Athena notebook version 1. If you specify a value for NotebookVersion, you must also specify a value for NotebookId
     idle_timeout : int, optional
         The idle timeout in minutes for the session. The default is 15.


### PR DESCRIPTION
https://docs.aws.amazon.com/athena/latest/APIReference/API_StartSession.html#athena-StartSession-request-NotebookVersion, this parameter is necessary to create session using Spark

### Feature or Bugfix
- Bugfix

### Detail
Functions called from library
- run_spark_calculation
- create_spark_session

Missing Parameter for starting Session on Boto3.
After calling those two function this error is being raised:
InvalidRequestException: An error occurred (InvalidRequestException) when calling the StartSession operation: NotebookVersion is required when NotebookId is provided.

### Relates
- (https://docs.aws.amazon.com/athena/latest/APIReference/API_StartSession.html#athena-StartSession-request-NotebookVersion)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
