### PR TITLE
feat: manage `NULL` values in `athena.to_iceberg` merge statement

### DIFF
--- a/awswrangler/athena/_write_iceberg.py
+++ b/awswrangler/athena/_write_iceberg.py
@@ -515,7 +515,9 @@ def to_iceberg(
             sql_statement = f"""
                 MERGE INTO "{database}"."{table}" target
                 USING "{database}"."{temp_table}" source
-                ON {' AND '.join([f'target."{x}" = source."{x}"' for x in merge_cols])}
+                ON {' AND '.join([
+                    f'(target."{x}" = source."{x}" OR (target."{x}" IS NULL AND source."{x}" IS NULL))'
+                    for x in merge_cols])}
                 {match_condition}
                 WHEN NOT MATCHED THEN
                     INSERT ({', '.join([f'"{x}"' for x in df.columns])})

--- a/tests/unit/test_athena_iceberg.py
+++ b/tests/unit/test_athena_iceberg.py
@@ -712,7 +712,10 @@ def test_athena_to_iceberg_merge_into_nulls(path: str, path2: str, glue_database
         unload_approach=False,
     )
 
-    assert_pandas_equals(df_expected.sort_values(df_expected.columns), df_out.sort_values(df_out.columns))
+    assert_pandas_equals(
+        df_out.sort_values(df_out.columns.to_list()).reset_index(drop=True),
+        df_expected.sort_values(df_expected.columns.to_list()).reset_index(drop=True),
+    )
 
 
 def test_athena_to_iceberg_merge_into_ignore(path: str, path2: str, glue_database: str, glue_table: str) -> None:

--- a/tests/unit/test_athena_iceberg.py
+++ b/tests/unit/test_athena_iceberg.py
@@ -651,10 +651,16 @@ def test_athena_to_iceberg_merge_into(path: str, path2: str, glue_database: str,
 
 
 def test_athena_to_iceberg_merge_into_nulls(path: str, path2: str, glue_database: str, glue_table: str) -> None:
-    df = pd.DataFrame({'col1':  ['a', 'a', np.nan], 'col2':  [1.1, np.nan, 2.2], 'action': ['insert', 'insert', 'insert']})
-    df['col1'] = df['col1'].astype('string')
-    df['col2'] = df['col2'].astype('float64')
-    df['action'] = df['action'].astype('string')
+    df = pd.DataFrame(
+        {
+            "col1": ["a", "a", "a", np.nan],
+            "col2": [0.0, 1.1, np.nan, 2.2],
+            "action": ["insert", "insert", "insert", "insert"],
+        }
+    )
+    df["col1"] = df["col1"].astype("string")
+    df["col2"] = df["col2"].astype("float64")
+    df["action"] = df["action"].astype("string")
 
     wr.athena.to_iceberg(
         df=df,
@@ -666,10 +672,16 @@ def test_athena_to_iceberg_merge_into_nulls(path: str, path2: str, glue_database
     )
 
     # Perform MERGE INTO
-    df2 = pd.DataFrame({'col1':  ['a', 'a', np.nan, 'b'], 'col2':  [1.1, np.nan, 2.2, 3.3], 'action': ['update', 'update', 'update', 'insert']})
-    df2['col1'] = df2['col1'].astype('string')
-    df2['col2'] = df2['col2'].astype('float64')
-    df2['action'] = df2['action'].astype('string')
+    df2 = pd.DataFrame(
+        {
+            "col1": ["a", "a", np.nan, "b"],
+            "col2": [1.1, np.nan, 2.2, 3.3],
+            "action": ["update", "update", "update", "insert"],
+        }
+    )
+    df2["col1"] = df2["col1"].astype("string")
+    df2["col2"] = df2["col2"].astype("float64")
+    df2["action"] = df2["action"].astype("string")
 
     wr.athena.to_iceberg(
         df=df2,
@@ -678,14 +690,20 @@ def test_athena_to_iceberg_merge_into_nulls(path: str, path2: str, glue_database
         table_location=path,
         temp_path=path2,
         keep_files=False,
-        merge_cols=['col1', 'col2'],
+        merge_cols=["col1", "col2"],
     )
 
     # Expected output
-    df_expected = pd.DataFrame({'col1':  ['a', 'a', np.nan, 'b'], 'col2':  [1.1, np.nan, 2.2, 3.3], 'action': ['update', 'update', 'update', 'insert']})
-    df_expected['col1'] = df_expected['col1'].astype('string')
-    df_expected['col2'] = df_expected['col2'].astype('float64')
-    df_expected['action'] = df_expected['action'].astype('string')
+    df_expected = pd.DataFrame(
+        {
+            "col1": ["a", "a", "a", np.nan, "b"],
+            "col2": [0.0, 1.1, np.nan, 2.2, 3.3],
+            "action": ["insert", "update", "update", "update", "insert"],
+        }
+    )
+    df_expected["col1"] = df_expected["col1"].astype("string")
+    df_expected["col2"] = df_expected["col2"].astype("float64")
+    df_expected["action"] = df_expected["action"].astype("string")
 
     df_out = wr.athena.read_sql_query(
         sql=f'SELECT * FROM "{glue_table}"',


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail

When performing a merge operation between two Iceberg tables on Athena, join fields that contain NULL values do not 
match with corresponding NULL values in the other table. This issue is due to the generic behavior in SQL where NULL != NULL. As a result, rows with NULL values in the join columns fail to find matches, causing incomplete merges and data inconsistencies.

This pull request implement this feature by extending the join condition to account for NULL values. The enhanced join condition ensures that rows with NULL values in the join columns are correctly matched with corresponding rows in the other table that also have NULL values. 

The following example illustrates the differences between join condition:
- join condition that doesn't handle null values
```
MERGE INTO table1 target
USING table2 source
ON 
    target.field1 = source.field1 AND target.field2=source AND ...
WHEN MATCHED THEN ...
WHEN NOT MATCHED THEN ...
```

- join condition that does handle null values
```
MERGE INTO table1 target
USING table2 source
ON
    (target.field1 = source.field1 OR (target.field1 IS NULL AND source.field1 IS NULL)) AND
    (target.field2 = source.field2 OR (target.field2 IS NULL AND source.field2 IS NULL)) AND
    ...
WHEN MATCHED THEN ...
WHEN NOT MATCHED THEN ...
```


Example use-case:

df1:
```
| field1   |   field2 | action   |
|:---------|---------:|:---------|
| a        |      0.0 | insert   |
| a        |      1.1 | insert   |
| a        |    nan   | insert   |
| nan      |      2.2 | insert   |

wr.athena.to_iceberg(df1, ...)
```

df2:
```
| field1   |   field2 | action   |
|:---------|---------:|:---------|
| a        |      1.1 | update   |
| a        |    nan   | update   |
| nan      |      2.2 | update   |
| b        |      3.3 | insert   |

wr.athena.to_iceberg(df2, merge_cols=['field1','field2'], ...)
```
:x: current output:
```
| field1   |   field2 | action   |
|:---------|---------:|:---------|
| a        |      0.0 | insert   | [OK] old field untouched as no match found
| a        |      1.1 | update   | [OK] old field updated as a match has been found
| a        |    nan   | insert   | [KO] old pair (a, nan) should've been updated
| a        |    nan   | update   | [KO] new pair (a, nan) has been inserted without matching with previous one
| nan      |      2.2 | insert   | [KO] old pair (nan, 2.2) should've been updated
| nan      |      2.2 | update   | [KO] new pair (nan, 2.2) has been inserted without matching with previous one
| b        |      3.3 | insert   | [OK] new field inserted as didn't find a match
```
:white_check_mark: expected output:
```
| field1   |   field2 | action   |
|:---------|---------:|:---------|
| a        |      0.0 | insert   |
| a        |      1.1 | update   |
| a        |    nan   | update   |
| nan      |      2.2 | update   |
| b        |      3.3 | insert   |
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
