### PR TITLE
fix: athena.read_sql_query failing for time columns

### DIFF
--- a/awswrangler/_data_types.py
+++ b/awswrangler/_data_types.py
@@ -372,6 +372,10 @@ def athena2pandas(dtype: str, dtype_backend: str | None = None) -> str:  # noqa:
         return "datetime64" if dtype_backend != "pyarrow" else "timestamp[ns][pyarrow]"
     if dtype == "date":
         return "date" if dtype_backend != "pyarrow" else "date32[pyarrow]"
+    if dtype == "time":
+        # Pandas does not have a type for time of day, so we are returning a string.
+        # However, if the backend is pyarrow, we can return time32[ms]
+        return "string" if dtype_backend != "pyarrow" else "time32[ms][pyarrow]"
     if dtype.startswith("decimal"):
         return "decimal" if dtype_backend != "pyarrow" else "double[pyarrow]"
     if dtype in ("binary", "varbinary"):

--- a/tests/unit/test_athena.py
+++ b/tests/unit/test_athena.py
@@ -705,6 +705,17 @@ def test_athena_time_zone(glue_database):
     assert df["value"][0].year == datetime.datetime.utcnow().year
 
 
+@pytest.mark.parametrize("dtype_backend", ["numpy_nullable", "pyarrow"])
+def test_athena_time_type(glue_database: str, dtype_backend: str) -> None:
+    df = wr.athena.read_sql_query(
+        "SELECT time '13:24:11' as col", glue_database, ctas_approach=False, dtype_backend=dtype_backend
+    )
+    if dtype_backend == "pyarrow":
+        assert df["col"].iloc[0] == datetime.time(13, 24, 11)
+    else:
+        assert df["col"].iloc[0] == "13:24:11"
+
+
 @pytest.mark.parametrize(
     "ctas_approach",
     [


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- fix `athena.read_sql_query` failing for time columns

### Relates
- #2893

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
