### PR TITLE
fix(athena): fixed write_iceberg which could fire a ICEBERG_TOO_MANY_OPEN_PARTITIONS Athena error

### DIFF
--- a/awswrangler/athena/_write_iceberg.py
+++ b/awswrangler/athena/_write_iceberg.py
@@ -319,7 +319,9 @@ def _create_partitioned_dataframes(
     chunks = _utils.chunkify(unique_combinations.values.tolist(), max_length=100)
     partitioned_dfs = []
     for chunk in chunks:
-        chunk_df = pd.DataFrame(chunk, columns=partition_cols)
+        chunk_df = pd.DataFrame(chunk, columns=partition_cols).astype(
+            dtype={partition_col_name: df.dtypes[partition_col_name] for partition_col_name in partition_cols}
+        )
         # Merge the original DataFrame with the chunk to get the corresponding rows
         partitioned_df = df.merge(chunk_df, on=partition_cols)
         partitioned_dfs.append(partitioned_df)

--- a/tests/unit/test_athena_iceberg.py
+++ b/tests/unit/test_athena_iceberg.py
@@ -21,7 +21,7 @@ logging.getLogger("awswrangler").setLevel(logging.DEBUG)
 pytestmark = pytest.mark.distributed
 
 
-@pytest.mark.parametrize("partition_cols", [None, ["name"], ["name", "day(ts)"]])
+@pytest.mark.parametrize("partition_cols", [None, ["name"], ["name", "ts"]])
 @pytest.mark.parametrize(
     "additional_table_properties",
     [None, {"write_target_data_file_size_bytes": 536870912, "optimize_rewrite_delete_file_threshold": 10}],
@@ -856,7 +856,7 @@ def test_athena_to_iceberg_no_table_location_error(
         )
 
 
-@pytest.mark.parametrize("partition_cols", [None, ["name"], ["name", "day(ts)"]])
+@pytest.mark.parametrize("partition_cols", [None, ["name"], ["name", "ts"]])
 def test_athena_delete_from_iceberg_table(
     path: str,
     path2: str,
@@ -1014,7 +1014,7 @@ def test_athena_iceberg_use_partition_function(
         table=glue_table,
         table_location=path,
         temp_path=path2,
-        partition_cols=["day(ts)"],
+        partition_cols=["ts"],
         keep_files=False,
     )
 
@@ -1032,7 +1032,7 @@ def test_athena_iceberg_use_partition_function(
         table=glue_table,
         table_location=path,
         temp_path=path2,
-        partition_cols=["day(ts)"],
+        partition_cols=["ts"],
         keep_files=False,
     )
 

--- a/tests/unit/test_athena_iceberg.py
+++ b/tests/unit/test_athena_iceberg.py
@@ -43,6 +43,7 @@ def test_athena_to_iceberg(
     )
     df["id"] = df["id"].astype("Int64")  # Cast as nullable int64 type
     df["name"] = df["name"].astype("string")
+    df["ts"] = pd.to_datetime(df["ts"]).dt.floor("D")
 
     wr.athena.to_iceberg(
         df=df,
@@ -873,6 +874,7 @@ def test_athena_delete_from_iceberg_table(
     )
     df["id"] = df["id"].astype("Int64")  # Cast as nullable int64 type
     df["name"] = df["name"].astype("string")
+    df["ts"] = pd.to_datetime(df["ts"]).dt.floor("D")
 
     wr.athena.to_iceberg(
         df=df,


### PR DESCRIPTION
Feature or Bugfix

    Bugfix

Detail

    Athena: fixed write_iceberg which could fire a ICEBERG_TOO_MANY_OPEN_PARTITIONS Athena error

Relates

    None

Details

This is not really a bugfix given that this is a problem with Athena, not aws-sdk-pandas.

When you try to write an Iceberg table with Athena with partition keys, if there is more than 100 different created partitions, then Athena will fail with error ICEBERG_TOO_MANY_OPEN_PARTITIONS (see [post here](https://repost.aws/questions/QUlMgUNkMpSVicSeEfR85WNQ/error-when-creating-iceberg-tables-with-hidden-partitions-using-athena-too-many-open-writers)). This is really difficult to use Iceberg at scale with Athena with this limitation. One workaround is of course to use Spark, but I think it would be great if aws-sdk-for-pandas included a workaround.

So you will find my approach to a solution to this problem, simply chunk the dataframe to write to include at maximum 100 different partition keys combinations and write them sequentially using Athena.

Also edited unit tests to make them work.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.