### PR TITLE
fix: OpenSearch import errors

### DIFF
--- a/awswrangler/_utils.py
+++ b/awswrangler/_utils.py
@@ -105,6 +105,7 @@ INSTALL_MAPPING = {
     "pyodbc": "sqlserver",
     "gremlin_python": "gremlin",
     "opensearchpy": "opensearch",
+    "jsonpath_ng": "opensearch",
     "oracledb": "oracle",
 }
 

--- a/awswrangler/opensearch/_read.py
+++ b/awswrangler/opensearch/_read.py
@@ -3,13 +3,19 @@
 
 from __future__ import annotations
 
-from typing import Any, Collection, Mapping
+from typing import TYPE_CHECKING, Any, Collection, Mapping
 
 import awswrangler.pandas as pd
 from awswrangler import _utils, exceptions
 from awswrangler.opensearch._utils import _get_distribution, _is_serverless
 
-opensearchpy = _utils.import_optional_dependency("opensearchpy")
+if TYPE_CHECKING:
+    try:
+        import opensearchpy
+    except ImportError:
+        pass
+else:
+    opensearchpy = _utils.import_optional_dependency("opensearchpy")
 
 
 def _resolve_fields(row: Mapping[str, Any]) -> Mapping[str, Any]:


### PR DESCRIPTION
### Detail
If a customer has `opensearchpy` installed but not `jsonpath_ng`, the import of awswrangler will fail. This goes against our current protocol, which is that we throw an appropriate import error when the customer tries to invoke a method which requires an optional dependency.

The `jsonpath_ng` dependency is also only required for certain cases when loading JSON data, so I'm only appending the annotation to the `_get_documents_w_json_path` function.

### Issue
#2938

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.*
