### PR TITLE
feat(redshift): Automatically add new DataFrame columns to Redshift tables during write operation

### DIFF
--- a/awswrangler/redshift/_utils.py
+++ b/awswrangler/redshift/_utils.py
@@ -119,7 +119,10 @@ def _add_table_columns(
     cursor: "redshift_connector.Cursor", schema: str, table: str, new_columns: dict[str, str]
 ) -> None:
     for column_name, column_type in new_columns.items():
-        sql = f"ALTER TABLE {_identifier(schema)}.{_identifier(table)}\n ADD COLUMN {_identifier(column_name)} {column_type};"
+        sql = (
+            f"ALTER TABLE {_identifier(schema)}.{_identifier(table)}"
+            f"\nADD COLUMN {_identifier(column_name)} {column_type};"
+        )
         _logger.debug("Executing alter query:\n%s", sql)
         cursor.execute(sql)
 

--- a/awswrangler/redshift/_utils.py
+++ b/awswrangler/redshift/_utils.py
@@ -364,15 +364,15 @@ def _get_rsh_columns_types(
 def _add_new_table_columns(
     cursor: "redshift_connector.Cursor", schema: str, table: str, redshift_columns_types: dict[str, str]
 ) -> None:
-    # Check if the cluster is configured as case sensitive or no
+    # Check if Redshift is configured as case sensitive or not
     is_case_sensitive = False
     if _get_parameter_setting(cursor=cursor, parameter_name="enable_case_sensitive_identifier").lower() in [
         "on",
-        "true",  # @todo choose one
+        "true",
     ]:
         is_case_sensitive = True
 
-    # If it is case-insensitive, convert all DataFrame column names to lowercase before performing the comparison
+    # If it is case-insensitive, convert all the DataFrame columns names to lowercase before performing the comparison
     if is_case_sensitive is False:
         redshift_columns_types = {key.lower(): value for key, value in redshift_columns_types.items()}
     actual_table_columns = set(_get_table_columns(cursor=cursor, schema=schema, table=table))

--- a/awswrangler/redshift/_utils.py
+++ b/awswrangler/redshift/_utils.py
@@ -358,9 +358,9 @@ def _get_rsh_columns_types(
     return redshift_types
 
 
-def _add_new_columns(
+def _add_new_table_columns(
     cursor: "redshift_connector.Cursor", schema: str, table: str, redshift_columns_types: dict[str, str]
-):
+) -> None:
     # Check if the cluster is configured as case sensitive or no
     is_case_sensitive = False
     if _get_parameter_setting(cursor=cursor, parameter_name="enable_case_sensitive_identifier").lower() in [

--- a/awswrangler/redshift/_utils.py
+++ b/awswrangler/redshift/_utils.py
@@ -301,7 +301,7 @@ def _get_rsh_types(
     use_threads: bool | int = True,
     boto3_session: boto3.Session | None = None,
     s3_additional_kwargs: dict[str, str] | None = None,
-) -> dict[str:str]:
+) -> dict[str, str]:
     if df is not None:
         redshift_types: dict[str, str] = _data_types.database_types_from_pandas(
             df=df,
@@ -348,7 +348,7 @@ def _get_rsh_types(
     return redshift_types
 
 
-def _create_table(  # noqa: PLR0912,PLR0913,PLR0915
+def _create_table(  # noqa: PLR0913
     df: pd.DataFrame | None,
     path: str | list[str] | None,
     con: "redshift_connector.Connection",

--- a/awswrangler/redshift/_utils.py
+++ b/awswrangler/redshift/_utils.py
@@ -151,8 +151,8 @@ def _get_parameter_setting(cursor: "redshift_connector.Cursor", parameter_name: 
     _logger.debug("Executing select query:\n%s", sql)
     cursor.execute(sql)
     result = cursor.fetchall()
-    status = result[0][0]
-    print(f"{status=}")  # @todo remove
+    status = str(result[0][0])
+    _logger.debug(f"{parameter_name}='{status}'")
     return status
 
 

--- a/awswrangler/redshift/_utils.py
+++ b/awswrangler/redshift/_utils.py
@@ -119,7 +119,7 @@ def _add_table_columns(
     cursor: "redshift_connector.Cursor", schema: str, table: str, new_columns: dict[str, str]
 ) -> None:
     for column_name, column_type in new_columns.items():
-        sql = f"ALTER TABLE {_identifier(schema)}.{_identifier(table)}\n ADD COLUMN {column_name} {column_type};"
+        sql = f"ALTER TABLE {_identifier(schema)}.{_identifier(table)}\n ADD COLUMN {_identifier(column_name)} {column_type};"
         _logger.debug("Executing alter query:\n%s", sql)
         cursor.execute(sql)
 

--- a/awswrangler/redshift/_utils.py
+++ b/awswrangler/redshift/_utils.py
@@ -107,22 +107,19 @@ def _get_primary_keys(cursor: "redshift_connector.Cursor", schema: str, table: s
 
 
 def _get_table_columns(cursor: "redshift_connector.Cursor", schema: str, table: str) -> list[str]:
-    sql = (f"SELECT column_name FROM svv_columns\n"
-           f"WHERE table_schema = '{schema}' AND table_name = '{table}'")
+    sql = f"SELECT column_name FROM svv_columns\n" f"WHERE table_schema = '{schema}' AND table_name = '{table}'"
     _logger.debug("Executing select query:\n%s", sql)
     cursor.execute(sql)
     result: tuple[list[str]] = cursor.fetchall()
-    columns = [''.join(lst) for lst in result]
+    columns = ["".join(lst) for lst in result]
     return columns
 
 
-def _add_table_columns(cursor: "redshift_connector.Cursor", schema: str,
-                       table: str, new_columns: dict[str, str]) -> None:
+def _add_table_columns(
+    cursor: "redshift_connector.Cursor", schema: str, table: str, new_columns: dict[str, str]
+) -> None:
     for column_name, column_type in new_columns.items():
-        sql = (
-            f"ALTER TABLE {_identifier(schema)}.{_identifier(table)}\n"
-            f"ADD COLUMN {column_name} {column_type};"
-        )
+        sql = f"ALTER TABLE {_identifier(schema)}.{_identifier(table)}\n" f"ADD COLUMN {column_name} {column_type};"
         _logger.debug("Executing alter query:\n%s", sql)
         cursor.execute(sql)
 
@@ -289,22 +286,22 @@ def _redshift_types_from_path(
 
 
 def _get_rsh_types(
-        df: pd.DataFrame | None,
-        path: str | list[str] | None,
-        index: bool,
-        dtype: dict[str, str] | None,
-        varchar_lengths_default: int,
-        varchar_lengths: dict[str, int] | None,
-        data_format: Literal["parquet", "orc", "csv"] = "parquet",
-        redshift_column_types: dict[str, str] | None = None,
-        parquet_infer_sampling: float = 1.0,
-        path_suffix: str | None = None,
-        path_ignore_suffix: str | list[str] | None = None,
-        manifest: bool | None = False,
-        use_threads: bool | int = True,
-        boto3_session: boto3.Session | None = None,
-        s3_additional_kwargs: dict[str, str] | None = None,
-) -> dict[str: str]:
+    df: pd.DataFrame | None,
+    path: str | list[str] | None,
+    index: bool,
+    dtype: dict[str, str] | None,
+    varchar_lengths_default: int,
+    varchar_lengths: dict[str, int] | None,
+    data_format: Literal["parquet", "orc", "csv"] = "parquet",
+    redshift_column_types: dict[str, str] | None = None,
+    parquet_infer_sampling: float = 1.0,
+    path_suffix: str | None = None,
+    path_ignore_suffix: str | list[str] | None = None,
+    manifest: bool | None = False,
+    use_threads: bool | int = True,
+    boto3_session: boto3.Session | None = None,
+    s3_additional_kwargs: dict[str, str] | None = None,
+) -> dict[str:str]:
     if df is not None:
         redshift_types: dict[str, str] = _data_types.database_types_from_pandas(
             df=df,
@@ -397,13 +394,14 @@ def _create_table(  # noqa: PLR0912,PLR0913,PLR0915
         s3_additional_kwargs=s3_additional_kwargs,
         data_format=data_format,
         redshift_column_types=redshift_column_types,
-        manifest=manifest
+        manifest=manifest,
     )
     if add_new_columns is True:
         if _does_table_exist(cursor=cursor, schema=schema, table=table) is True:
             actual_table_columns = set(_get_table_columns(cursor=cursor, schema=schema, table=table))
-            new_df_columns = {key: value for key, value in redshift_types.items()
-                           if key.lower() not in actual_table_columns}
+            new_df_columns = {
+                key: value for key, value in redshift_types.items() if key.lower() not in actual_table_columns
+            }
             _add_table_columns(cursor=cursor, schema=schema, table=table, new_columns=new_df_columns)
 
     if mode == "overwrite":

--- a/awswrangler/redshift/_write.py
+++ b/awswrangler/redshift/_write.py
@@ -213,7 +213,7 @@ def to_sql(
                 varchar_lengths_default=varchar_lengths_default,
                 varchar_lengths=varchar_lengths,
                 lock=lock,
-                add_new_columns=add_new_columns
+                add_new_columns=add_new_columns,
             )
             if index:
                 df.reset_index(level=df.index.names, inplace=True)

--- a/awswrangler/redshift/_write.py
+++ b/awswrangler/redshift/_write.py
@@ -460,7 +460,7 @@ def copy_from_files(  # noqa: PLR0913
                     use_threads=use_threads,
                     boto3_session=boto3_session,
                     s3_additional_kwargs=s3_additional_kwargs,
-                    data_format=data_format,  # type: ignore[arg-type]
+                    data_format=data_format,
                     redshift_column_types=redshift_column_types,
                     manifest=manifest,
                 )

--- a/awswrangler/redshift/_write.py
+++ b/awswrangler/redshift/_write.py
@@ -210,8 +210,9 @@ def to_sql(
                     varchar_lengths_default=varchar_lengths_default,
                     varchar_lengths=varchar_lengths,
                 )
-                _add_new_table_columns(cursor=cursor, schema=schema, table=table,
-                                       redshift_columns_types=redshift_columns_types)
+                _add_new_table_columns(
+                    cursor=cursor, schema=schema, table=table, redshift_columns_types=redshift_columns_types
+                )
 
             created_table, created_schema = _create_table(
                 df=df,
@@ -463,8 +464,9 @@ def copy_from_files(  # noqa: PLR0913
                     redshift_column_types=redshift_column_types,
                     manifest=manifest,
                 )
-                _add_new_table_columns(cursor=cursor, schema=schema, table=table,
-                                       redshift_columns_types=redshift_columns_types)
+                _add_new_table_columns(
+                    cursor=cursor, schema=schema, table=table, redshift_columns_types=redshift_columns_types
+                )
             created_table, created_schema = _create_table(
                 df=None,
                 path=path,

--- a/awswrangler/redshift/_write.py
+++ b/awswrangler/redshift/_write.py
@@ -11,6 +11,7 @@ import awswrangler.pandas as pd
 from awswrangler import _databases as _db_utils
 from awswrangler import _utils, exceptions, s3
 from awswrangler._config import apply_configs
+
 from ._connect import _validate_connection
 from ._utils import _create_table, _make_s3_auth_string, _upsert
 
@@ -24,6 +25,7 @@ else:
 
 _logger: logging.Logger = logging.getLogger(__name__)
 _ToSqlModeLiteral = Literal["append", "overwrite", "upsert"]
+
 _ToSqlOverwriteModeLiteral = Literal["drop", "cascade", "truncate", "delete"]
 _ToSqlDistStyleLiteral = Literal["AUTO", "EVEN", "ALL", "KEY"]
 _ToSqlSortStyleLiteral = Literal["COMPOUND", "INTERLEAVED"]

--- a/awswrangler/redshift/_write.py
+++ b/awswrangler/redshift/_write.py
@@ -14,7 +14,7 @@ from awswrangler._config import apply_configs
 
 from ._connect import _validate_connection
 from ._utils import (
-    _add_new_columns,
+    _add_new_table_columns,
     _create_table,
     _does_table_exist,
     _get_rsh_columns_types,
@@ -210,9 +210,8 @@ def to_sql(
                     varchar_lengths_default=varchar_lengths_default,
                     varchar_lengths=varchar_lengths,
                 )
-                _add_new_columns(
-                    cursor=cursor, schema=schema, table=table, redshift_columns_types=redshift_columns_types
-                )
+                _add_new_table_columns(cursor=cursor, schema=schema, table=table,
+                                       redshift_columns_types=redshift_columns_types)
 
             created_table, created_schema = _create_table(
                 df=df,
@@ -464,9 +463,8 @@ def copy_from_files(  # noqa: PLR0913
                     redshift_column_types=redshift_column_types,
                     manifest=manifest,
                 )
-                _add_new_columns(
-                    cursor=cursor, schema=schema, table=table, redshift_columns_types=redshift_columns_types
-                )
+                _add_new_table_columns(cursor=cursor, schema=schema, table=table,
+                                       redshift_columns_types=redshift_columns_types)
             created_table, created_schema = _create_table(
                 df=None,
                 path=path,

--- a/awswrangler/redshift/_write.py
+++ b/awswrangler/redshift/_write.py
@@ -24,8 +24,8 @@ else:
     redshift_connector = _utils.import_optional_dependency("redshift_connector")
 
 _logger: logging.Logger = logging.getLogger(__name__)
-_ToSqlModeLiteral = Literal["append", "overwrite", "upsert"]
 
+_ToSqlModeLiteral = Literal["append", "overwrite", "upsert"]
 _ToSqlOverwriteModeLiteral = Literal["drop", "cascade", "truncate", "delete"]
 _ToSqlDistStyleLiteral = Literal["AUTO", "EVEN", "ALL", "KEY"]
 _ToSqlSortStyleLiteral = Literal["COMPOUND", "INTERLEAVED"]

--- a/tests/unit/test_redshift.py
+++ b/tests/unit/test_redshift.py
@@ -1476,8 +1476,8 @@ def test_copy_add_new_columns(
     )
     df2 = wr.redshift.read_sql_query(sql=f"SELECT * FROM public.{redshift_table}", con=redshift_con)
     assert df2.columns.tolist() == df.columns.tolist()
-    assert df2["abc"].tolist() == [pd.NA, pd.NA, pd.NA, "f", "g", "h"]
-    assert df2["bce"].tolist() == [pd.NA, pd.NA, pd.NA, "j", "k", "l"]
+    assert df2["abc"].tolist() == ["f", "g", "h"]
+    assert df2["bce"].tolist() == ["j", "k", "l"]
 
     # Assert error when trying to add a new column with 'add_new_columns' set to False
     df["cde"] = ["m", "n", "o"]
@@ -1540,8 +1540,8 @@ def test_to_sql_add_new_columns(
 
     df2 = wr.redshift.read_sql_query(sql=f"SELECT * FROM public.{redshift_table}", con=redshift_con)
     assert df2.columns.tolist() == df.columns.tolist()
-    assert df2["cba"].tolist() == [pd.NA, pd.NA, pd.NA, "f", "g", "h"]
-    assert df2["ebc"].tolist() == [pd.NA, pd.NA, pd.NA, "j", "k", "l"]
+    assert df2["cba"].tolist() == ["f", "g", "h"]
+    assert df2["ebc"].tolist() == ["j", "k", "l"]
 
     # Assert error when trying to add a new column with 'add_new_columns' set to False
     df["cde"] = ["m", "n", "o"]
@@ -1565,7 +1565,7 @@ def test_add_new_columns_case_sensitive(
 
     # Set enable_case_sensitive_identifier to False (default value)
     with redshift_con.cursor() as cursor:
-        cursor.execute("SET enable_case_sensitive_identifier TO false;")
+        cursor.execute("SET enable_case_sensitive_identifier TO off;")
     redshift_con.commit()
 
     df["Boo"] = ["f", "g", "h"]
@@ -1586,7 +1586,7 @@ def test_add_new_columns_case_sensitive(
 
     # Enable enable_case_sensitive_identifier
     with redshift_con.cursor() as cursor:
-        cursor.execute("SET enable_case_sensitive_identifier TO true;")
+        cursor.execute("SET enable_case_sensitive_identifier TO on;")
         redshift_con.commit()
         wr.redshift.to_sql(df=df, con=redshift_con, table=redshift_table, schema="public", add_new_columns=True)
         cursor.execute("RESET enable_case_sensitive_identifier;")

--- a/tests/unit/test_redshift.py
+++ b/tests/unit/test_redshift.py
@@ -1557,8 +1557,9 @@ def test_add_new_columns_case_sensitive(
     path: str, redshift_table: str, redshift_con: redshift_connector.Connection, databases_parameters: dict[str, Any]
 ) -> None:
     schema = "public"
-
     df = pd.DataFrame({"foo": ["a", "b", "c"]})
+
+    # Create table
     wr.redshift.to_sql(df=df, con=redshift_con, table=redshift_table, schema=schema, add_new_columns=True)
 
     # Set enable_case_sensitive_identifier to False (default value)
@@ -1592,8 +1593,5 @@ def test_add_new_columns_case_sensitive(
 
     # Ensure that the new uppercase columns have been added correctly
     df2 = wr.redshift.read_sql_query(sql=f"SELECT * FROM {schema}.{redshift_table}", con=redshift_con)
-    assert df.columns.tolist() + ["boo"] == df2.columns.tolist()
-    assert "foo" in df2.columns
-    assert "boo" in df2.columns
-    assert "Boo" in df2.columns
-    assert "BOO" in df2.columns
+    expected_columns = list(sorted(df.columns.tolist() + ["boo"]))
+    assert expected_columns == list(sorted(df2.columns.tolist()))

--- a/tests/unit/test_redshift.py
+++ b/tests/unit/test_redshift.py
@@ -1537,7 +1537,7 @@ def test_to_sql_add_new_columns(
     assert df.columns.tolist() == df2.columns.tolist()
 
     # Assert error when trying to add a new column without 'add_new_columns' parameter (False as default) in "append"
-    # or "upsert". No error are expected in ('drop', 'cascade') overwrite_method
+    # or "upsert". No errors expected in ('drop', 'cascade') overwrite_method
     df["abc"] = ["m", "n", "o"]
     if overwrite_method in ("drop", "cascade"):
         wr.redshift.to_sql(**to_sql_kwargs)
@@ -1576,7 +1576,7 @@ def test_add_new_columns_case_sensitive(
     assert "boo" in df2.columns
 
     # Trying to add a new column 'BOO' causes an exception because Redshift attempts to lowercase it, resulting in a
-    # column mismatch between the DataFrame and the table schema
+    # columns mismatch between the DataFrame and the table schema
     df["BOO"] = ["j", "k", "l"]
     with pytest.raises(redshift_connector.error.ProgrammingError) as exc_info:
         wr.redshift.to_sql(df=df, con=redshift_con, table=redshift_table, schema=schema, add_new_columns=True)
@@ -1590,9 +1590,10 @@ def test_add_new_columns_case_sensitive(
         cursor.execute("RESET enable_case_sensitive_identifier;")
         redshift_con.commit()
 
-    # Ensure that the new uppercase column has been added correctly
+    # Ensure that the new uppercase columns have been added correctly
     df2 = wr.redshift.read_sql_query(sql=f"SELECT * FROM {schema}.{redshift_table}", con=redshift_con)
-    assert df2.columns.tolist() == df.columns.tolist()
+    assert df.columns.tolist() + ["boo"] == df2.columns.tolist()
     assert "foo" in df2.columns
     assert "boo" in df2.columns
+    assert "Boo" in df2.columns
     assert "BOO" in df2.columns


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Feature

### Detail
I would like to propose a new feature for the Redshift table write methods.
Currently, if there's a columns mismatch between the input DataFrame and the target Redshift table, the write methods generate an exception. 
I propose adding an option to automatically handle this scenario by creating new columns in the Redshift table if they are present in the input DataFrame but missing in the table schema.

Specifically, I suggest introducing an additional argument like `add_new_columns: bool = False` to `_utils._create_table ` method.
If `True` and if new columns are found comparing input DataFrame and target table columns, it will automatically execute an `ALTER TABLE ADD COLUMN` on the target table.
This enhancement would align with the existing behavior of the `s3.to_parquet` method, which already automatically updates the Glue Catalog with new columns.

At this stage, this is just a proposal. I understand that specific unit tests are required to support this feature, but before proceeding, I would like to understand if in your opinion could make sense to add this.
Your thoughts and feedback would be greatly appreciated, thanks.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
