### PR TITLE
fix: handle case of str to bool env variable in config

### DIFF
--- a/awswrangler/_config.py
+++ b/awswrangler/_config.py
@@ -244,7 +244,7 @@ class _Config:
     @staticmethod
     def _cast_bool(name: str, value: str) -> bool:
         _true = ("true", "1")
-        _false = ("false", "0")
+        _false = ("false", "0", "")
         if value not in _true + _false:
             raise exceptions.InvalidArgumentValue(f"{name} configuration only accepts True/False or 0/1.")
         return value in _true

--- a/awswrangler/_config.py
+++ b/awswrangler/_config.py
@@ -224,6 +224,8 @@ class _Config:
             raise exceptions.InvalidArgumentValue(
                 f"{name} configuration does not accept a null value. Please pass {dtype}."
             )
+        if isinstance(value, str) and dtype is bool:
+            return _Config._cast_bool(name=name, value=value.lower())
         try:
             return dtype(value) if isinstance(value, dtype) is False else value
         except ValueError as ex:
@@ -238,6 +240,14 @@ class _Config:
             if value.lower() in ("none", "null", "nil"):
                 return True
         return False
+
+    @staticmethod
+    def _cast_bool(name: str, value: str) -> bool:
+        _true = ("true", "1")
+        _false = ("false", "0")
+        if value not in _true + _false:
+            raise exceptions.InvalidArgumentValue(f"{name} configuration only accepts True/False or 0/1.")
+        return value in _true
 
     @property
     def catalog_id(self) -> str | None:

--- a/awswrangler/_config.py
+++ b/awswrangler/_config.py
@@ -224,9 +224,9 @@ class _Config:
             raise exceptions.InvalidArgumentValue(
                 f"{name} configuration does not accept a null value. Please pass {dtype}."
             )
-        # Handle case where string is empty, "False" or "0"
+        # Handle case where string is empty, "False" or "0". Anything else is True
         if isinstance(value, str) and dtype is bool:
-            return value.lower() in ("false", "0", "")
+            return value.lower() not in ("false", "0", "")
         try:
             return dtype(value) if isinstance(value, dtype) is False else value
         except ValueError as ex:

--- a/awswrangler/_config.py
+++ b/awswrangler/_config.py
@@ -224,8 +224,9 @@ class _Config:
             raise exceptions.InvalidArgumentValue(
                 f"{name} configuration does not accept a null value. Please pass {dtype}."
             )
+        # Handle case where string is empty, "False" or "0"
         if isinstance(value, str) and dtype is bool:
-            return _Config._cast_bool(name=name, value=value.lower())
+            return value.lower() in ("false", "0", "")
         try:
             return dtype(value) if isinstance(value, dtype) is False else value
         except ValueError as ex:
@@ -240,14 +241,6 @@ class _Config:
             if value.lower() in ("none", "null", "nil"):
                 return True
         return False
-
-    @staticmethod
-    def _cast_bool(name: str, value: str) -> bool:
-        _true = ("true", "1")
-        _false = ("false", "0", "")
-        if value not in _true + _false:
-            raise exceptions.InvalidArgumentValue(f"{name} configuration only accepts True/False or 0/1.")
-        return value in _true
 
     @property
     def catalog_id(self) -> str | None:


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
Handling the special case where `WR_` environment variables are read as str but are intended as bool. This is similar to how we currently handle null values.

### Relates
- #2965

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
