### PR TITLE
fix: return only "current" iceberg columns

### DIFF
--- a/awswrangler/athena/_write_iceberg.py
+++ b/awswrangler/athena/_write_iceberg.py
@@ -119,7 +119,7 @@ def _determine_differences(
             database=database,
             table=table,
             catalog_id=catalog_id,
-            return_iceberg_current=True,
+            filter_iceberg_current=True,
             boto3_session=boto3_session,
         ),
     )

--- a/awswrangler/athena/_write_iceberg.py
+++ b/awswrangler/athena/_write_iceberg.py
@@ -115,7 +115,13 @@ def _determine_differences(
 
     catalog_column_types = typing.cast(
         Dict[str, str],
-        catalog.get_table_types(database=database, table=table, catalog_id=catalog_id, boto3_session=boto3_session),
+        catalog.get_table_types(
+            database=database,
+            table=table,
+            catalog_id=catalog_id,
+            return_iceberg_current=True,
+            boto3_session=boto3_session,
+        ),
     )
 
     original_column_names = set(catalog_column_types)

--- a/awswrangler/catalog/_get.py
+++ b/awswrangler/catalog/_get.py
@@ -107,7 +107,7 @@ def get_table_types(
     database: str,
     table: str,
     catalog_id: str | None = None,
-    return_iceberg_current: bool = False,
+    filter_iceberg_current: bool = False,
     boto3_session: boto3.Session | None = None,
 ) -> dict[str, str] | None:
     """Get all columns and types from a table.
@@ -121,9 +121,9 @@ def get_table_types(
     catalog_id
         The ID of the Data Catalog from which to retrieve Databases.
         If ``None`` is provided, the AWS account ID is used by default.
-    return_iceberg_current
-            If True, returns only current iceberg fields (fields marked with iceberg.field.current: true).
-            Otherwise, returns the all fields. False by default (return all fields).
+    filter_iceberg_current
+        If True, returns only current iceberg fields (fields marked with iceberg.field.current: true).
+        Otherwise, returns the all fields. False by default (return all fields).
     boto3_session
         The default boto3 session will be used if **boto3_session** receive ``None``.
 
@@ -145,7 +145,7 @@ def get_table_types(
         return None
     return _extract_dtypes_from_table_details(
         response=response,
-        return_iceberg_current=return_iceberg_current,
+        filter_iceberg_current=filter_iceberg_current,
     )
 
 

--- a/awswrangler/catalog/_get.py
+++ b/awswrangler/catalog/_get.py
@@ -107,6 +107,7 @@ def get_table_types(
     database: str,
     table: str,
     catalog_id: str | None = None,
+    return_iceberg_current: bool = False,
     boto3_session: boto3.Session | None = None,
 ) -> dict[str, str] | None:
     """Get all columns and types from a table.
@@ -120,6 +121,9 @@ def get_table_types(
     catalog_id
         The ID of the Data Catalog from which to retrieve Databases.
         If ``None`` is provided, the AWS account ID is used by default.
+    return_iceberg_current
+            If True, returns only current iceberg fields (fields marked with iceberg.field.current: true).
+            Otherwise, returns the all fields. False by default (return all fields).
     boto3_session
         The default boto3 session will be used if **boto3_session** receive ``None``.
 
@@ -139,7 +143,10 @@ def get_table_types(
         response = client_glue.get_table(**_catalog_id(catalog_id=catalog_id, DatabaseName=database, Name=table))
     except client_glue.exceptions.EntityNotFoundException:
         return None
-    return _extract_dtypes_from_table_details(response=response)
+    return _extract_dtypes_from_table_details(
+        response=response,
+        return_iceberg_current=return_iceberg_current,
+    )
 
 
 def get_databases(

--- a/awswrangler/catalog/_utils.py
+++ b/awswrangler/catalog/_utils.py
@@ -33,12 +33,12 @@ def _sanitize_name(name: str) -> str:
 
 def _extract_dtypes_from_table_details(
     response: "GetTableResponseTypeDef",
-    return_iceberg_current: bool = False,
+    filter_iceberg_current: bool = False,
 ) -> dict[str, str]:
     dtypes: dict[str, str] = {}
     for col in response["Table"]["StorageDescriptor"]["Columns"]:
         # Only return current fields if flag is enabled
-        if not return_iceberg_current or col.get("Parameters", {}).get("iceberg.field.current") == "true":
+        if not filter_iceberg_current or col.get("Parameters", {}).get("iceberg.field.current") == "true":
             dtypes[col["Name"]] = col["Type"]
     # Add partition keys as columns
     if "PartitionKeys" in response["Table"]:

--- a/awswrangler/catalog/_utils.py
+++ b/awswrangler/catalog/_utils.py
@@ -34,7 +34,9 @@ def _sanitize_name(name: str) -> str:
 def _extract_dtypes_from_table_details(response: "GetTableResponseTypeDef") -> dict[str, str]:
     dtypes: dict[str, str] = {}
     for col in response["Table"]["StorageDescriptor"]["Columns"]:
-        dtypes[col["Name"]] = col["Type"]
+        # Do not return "hidden" iceberg columns
+        if col.get("Parameters", {}).get("iceberg.field.current") != "false":
+            dtypes[col["Name"]] = col["Type"]
     if "PartitionKeys" in response["Table"]:
         for par in response["Table"]["PartitionKeys"]:
             dtypes[par["Name"]] = par["Type"]

--- a/awswrangler/catalog/_utils.py
+++ b/awswrangler/catalog/_utils.py
@@ -31,12 +31,16 @@ def _sanitize_name(name: str) -> str:
     return re.sub("[^A-Za-z0-9_]+", "_", name).lower()  # Replacing non alphanumeric characters by underscore
 
 
-def _extract_dtypes_from_table_details(response: "GetTableResponseTypeDef") -> dict[str, str]:
+def _extract_dtypes_from_table_details(
+    response: "GetTableResponseTypeDef",
+    return_iceberg_current: bool = False,
+) -> dict[str, str]:
     dtypes: dict[str, str] = {}
     for col in response["Table"]["StorageDescriptor"]["Columns"]:
-        # Do not return "hidden" iceberg columns
-        if col.get("Parameters", {}).get("iceberg.field.current") != "false":
+        # Only return current fields if flag is enabled
+        if not return_iceberg_current or col.get("Parameters", {}).get("iceberg.field.current") == "true":
             dtypes[col["Name"]] = col["Type"]
+    # Add partition keys as columns
     if "PartitionKeys" in response["Table"]:
         for par in response["Table"]["PartitionKeys"]:
             dtypes[par["Name"]] = par["Type"]

--- a/tests/unit/test_athena_iceberg.py
+++ b/tests/unit/test_athena_iceberg.py
@@ -1205,7 +1205,7 @@ def test_athena_to_iceberg_alter_schema(
     )
 
     df_actual = wr.athena.read_sql_query(
-        sql=f"SELECT new_id, name FROM '{glue_table}' ORDER BY new_id",
+        sql=f"SELECT new_id, name FROM {glue_table} ORDER BY new_id",
         database=glue_database,
         ctas_approach=False,
     )


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- `wr.catalog.get_table_types` returns all columns including Iceberg columns that have been removed from the schema (and are marked with `iceberg.field.current: false`) that confuses subsequent `wr.athena.to_iceberg` `INSERT's`.

### Relates
- https://github.com/aws/aws-sdk-pandas/issues/2978
- https://github.com/apache/iceberg/issues/7584

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
