### PR TITLE
fix: remove _default_metadata_providers

### DIFF
--- a/awswrangler/distributed/ray/datasources/arrow_parquet_datasource.py
+++ b/awswrangler/distributed/ray/datasources/arrow_parquet_datasource.py
@@ -30,11 +30,9 @@ from ray.data._internal.util import _is_local_scheme
 from ray.data.block import Block
 from ray.data.context import DataContext
 from ray.data.datasource import Datasource
-from ray.data.datasource._default_metadata_providers import (
-    get_generic_metadata_provider,
-)
 from ray.data.datasource.datasource import ReadTask
 from ray.data.datasource.file_meta_provider import (
+    DefaultFileMetadataProvider,
     _handle_read_os_error,
 )
 from ray.data.datasource.parquet_meta_provider import (
@@ -219,7 +217,7 @@ class ArrowParquetDatasource(Datasource):
         # files. To avoid this, we expand the input paths with the default metadata
         # provider and then apply the partition filter or file extensions.
         if partition_filter is not None or file_extensions is not None:
-            default_meta_provider = get_generic_metadata_provider(file_extensions=None)
+            default_meta_provider = DefaultFileMetadataProvider()
             expanded_paths, _ = map(list, zip(*default_meta_provider.expand_paths(paths, filesystem)))
 
             paths = list(expanded_paths)


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
- remove _default_metadata_provider as it's not supported in ray 2.38.0+

### Relates
- #3004

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
