### PR TITLE
fix: athena-iceberg/schema-evolution/new-columns-empty-in-athena

### DIFF
--- a/awswrangler/athena/_write_iceberg.py
+++ b/awswrangler/athena/_write_iceberg.py
@@ -569,17 +569,16 @@ def to_iceberg(  # noqa: PLR0913
             # Ensure that the ordering of the DF is the same as in the catalog.
             # This is required for the INSERT command to work.
             # update catalog_cols after altering table
-            catalog_column_types = typing.cast(
-                Dict[str, str],
-                catalog.get_table_types(
-                    database=database,
-                    table=table,
-                    catalog_id=catalog_id,
-                    filter_iceberg_current=True,
-                    boto3_session=boto3_session,
-                ),
+            _, catalog_cols = _determine_differences(
+                df=df,
+                database=database,
+                table=table,
+                index=index,
+                partition_cols=partition_cols,
+                boto3_session=boto3_session,
+                dtype=dtype,
+                catalog_id=catalog_id,
             )
-            catalog_cols = [key for key in catalog_column_types]
             df = df[catalog_cols]
 
         # if mode == "overwrite_partitions", drop matched partitions

--- a/awswrangler/athena/_write_iceberg.py
+++ b/awswrangler/athena/_write_iceberg.py
@@ -546,7 +546,7 @@ def to_iceberg(
 
                 # Ensure that the ordering of the DF is the same as in the catalog.
                 # This is required for the INSERT command to work.
-                df = df[catalog_cols]
+                df = df[catalog_cols + list(schema_differences["new_columns"].keys())]
 
             if schema_evolution is False and any([schema_differences[x] for x in schema_differences]):  # type: ignore[literal-required]
                 raise exceptions.InvalidArgumentValue(f"Schema change detected: {schema_differences}")


### PR DESCRIPTION


### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
- Using the catalog columns only meant the new columns were being dropped. This caused the insert into statements to fail to write data for new columns.


### Relates
[Issue-2997](https://github.com/aws/aws-sdk-pandas/issues/2997)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
