### PR TITLE
chore: unpin numpy in lambda layers (allow numpy 2.x)

### DIFF
--- a/building/lambda/build-lambda-layer.sh
+++ b/building/lambda/build-lambda-layer.sh
@@ -85,9 +85,6 @@ pushd /aws-sdk-pandas
 
 pip3 install . -t ./python ".[redshift,mysql,postgres,gremlin,opensearch,openpyxl]"
 
-# Install Numpy 1.x because 2.x is not support in layers right now
-pip3 install -t ./python --upgrade "numpy==1.*"
-
 rm -rf python/pyarrow*
 rm -rf python/boto*
 rm -rf python/urllib3*


### PR DESCRIPTION
- Now that python 3.8 is deprecated, we can upgrade lambda layers to numpy 2.x.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
