### PR TITLE
fix: layers - add gcc10 to AL2 build image; build numpy and pandas from source

### DIFF
--- a/building/lambda/Dockerfile
+++ b/building/lambda/Dockerfile
@@ -10,8 +10,8 @@ RUN yum install -y \
     libxslt-devel \
     bison \
     make \
-    gcc \
-    gcc-c++ \
+    gcc10 \
+    gcc10-c++ \
     flex \
     autoconf \
     zip \
@@ -20,12 +20,24 @@ RUN yum install -y \
 
 WORKDIR /root
 
+ENV CC=/usr/bin/gcc10-cc
+ENV CXX=/usr/bin/gcc10-c++
+ENV LD=/usr/bin/gcc10-gcc
+
+RUN ln -s /usr/bin/gcc10-gcc /usr/bin/gcc
+RUN ln -s /usr/bin/gcc10-g++ /usr/bin/g++
+RUN ln -s /usr/bin/gcc10-nm /usr/bin/nm
+RUN ln -s /usr/bin/gcc10-ar /usr/bin/ar
+RUN ln -s /usr/bin/gcc10-mpn /usr/bin/mpn
+RUN ln -s /usr/bin/gcc10-ld /usr/bin/ld
+
 FROM ${python_version}
 COPY pyproject.toml poetry.lock ./
 
 RUN pip3 install --upgrade pip wheel setuptools>=64 setuptools_scm>=8
 RUN pip3 install --upgrade urllib3==1.26.16  # temporary to avoid https://github.com/urllib3/urllib3/issues/2168 (TODO remove when the AL2 image updates to support OpenSSL 1.1.1+)
 RUN pip3 install --upgrade six cython cmake hypothesis poetry
+ENV PIP_NO_BINARY="numpy,pandas"
 RUN poetry config virtualenvs.create false --local && poetry install --no-root --only main
 
 RUN rm -f pyproject.toml poetry.lock

--- a/building/lambda/Dockerfile.al2023
+++ b/building/lambda/Dockerfile.al2023
@@ -25,6 +25,7 @@ COPY pyproject.toml poetry.lock ./
 
 RUN pip3 install --upgrade pip wheel setuptools>=64 setuptools_scm>=8
 RUN pip3 install --upgrade six cython cmake hypothesis poetry
+ENV PIP_NO_BINARY="numpy,pandas"
 RUN poetry config virtualenvs.create false --local && poetry install --no-root --only main
 
 RUN rm -f pyproject.toml poetry.lock

--- a/building/lambda/build-lambda-layer.sh
+++ b/building/lambda/build-lambda-layer.sh
@@ -83,7 +83,7 @@ popd
 
 pushd /aws-sdk-pandas
 
-pip3 install . -t ./python ".[redshift,mysql,postgres,gremlin,opensearch,openpyxl]"
+pip3 install . --no-binary numpy,pandas -t ./python ".[redshift,mysql,postgres,gremlin,opensearch,openpyxl]"
 
 rm -rf python/pyarrow*
 rm -rf python/boto*


### PR DESCRIPTION
### Feature or Bugfix
- Fix

### Detail
- fixes python 3.10 ARM lambda layers exploding in size (from 44MB to 97MB) due to pandas containing .so for all Python versions
- fixes incorrect numpy packaging `Error importing numpy: you should not try to import numpy from its source directory;`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
