### PR TITLE
fix: Changing dtype lowercasing to start of athena2pyarrow function

### DIFF
--- a/awswrangler/_data_types.py
+++ b/awswrangler/_data_types.py
@@ -309,10 +309,10 @@ def _split_map(s: str) -> list[str]:
 
 def athena2pyarrow(dtype: str, df_type: str | None = None) -> pa.DataType:  # noqa: PLR0911,PLR0912
     """Athena to PyArrow data types conversion."""
-    dtype = dtype.strip()
+    dtype = dtype.strip().lower()
     if dtype.startswith(("array", "struct", "map")):
         orig_dtype: str = dtype
-    dtype = dtype.lower().replace(" ", "")
+    dtype = dtype.replace(" ", "")
     if dtype == "tinyint":
         return pa.int8()
     if dtype == "smallint":


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
Because of a bug, we cannot send an uppercase `dtype` parameter to the athena2pyarrow function.
This is due to the fact that this snippet happens prior to lowercasing the `dtype` variable - 
```
    if dtype.startswith(("array", "struct", "map")):
        orig_dtype: str = dtype
```

I changed the order to make the dtype parameter lowercased before entering this condition, thus even an uppercased ARRAY/STRUCT/MAP type will initialize the orig_dtype variable and avoid the bug.

### Relates
https://github.com/aws/aws-sdk-pandas/issues/3121

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
