### PR TITLE
fix: concat with union categories

### DIFF
--- a/awswrangler/s3/_read.py
+++ b/awswrangler/s3/_read.py
@@ -116,7 +116,8 @@ def _extract_partitions_dtypes_from_table_details(response: "GetTableResponseTyp
     return dtypes
 
 
-def _union(dfs: list[pd.DataFrame], ignore_index: bool) -> pd.DataFrame:
+def _concat_union_categoricals(dfs: list[pd.DataFrame], ignore_index: bool) -> pd.DataFrame:
+    """Concatenate dataframes with union of categorical columns."""
     cats: tuple[set[str], ...] = tuple(set(df.select_dtypes(include="category").columns) for df in dfs)
     for col in set.intersection(*cats):
         cat = union_categoricals([df[col] for df in dfs])

--- a/awswrangler/s3/_read_parquet.py
+++ b/awswrangler/s3/_read_parquet.py
@@ -38,6 +38,7 @@ from awswrangler.s3._read import (
     _get_path_ignore_suffix,
     _get_path_root,
     _get_paths_for_glue_table,
+    _concat_union_categoricals,
     _InternalReadTableMetadataReturnValue,
     _TableMetadataReader,
 )
@@ -264,7 +265,7 @@ def _read_parquet_chunked(
                         yield df
                     else:
                         if next_slice is not None:
-                            df = pd.concat(objs=[next_slice, df], sort=False, copy=False)
+                            df = _concat_union_categoricals(dfs=[next_slice, df], ignore_index=False)
                         while len(df.index) >= chunked:
                             yield df.iloc[:chunked, :].copy()
                             df = df.iloc[chunked:, :]

--- a/awswrangler/s3/_read_parquet.py
+++ b/awswrangler/s3/_read_parquet.py
@@ -33,12 +33,12 @@ from awswrangler.s3._list import _path2list
 from awswrangler.s3._read import (
     _apply_partition_filter,
     _check_version_id,
+    _concat_union_categoricals,
     _extract_partitions_dtypes_from_table_details,
     _get_num_output_blocks,
     _get_path_ignore_suffix,
     _get_path_root,
     _get_paths_for_glue_table,
-    _concat_union_categoricals,
     _InternalReadTableMetadataReturnValue,
     _TableMetadataReader,
 )

--- a/awswrangler/s3/_read_text.py
+++ b/awswrangler/s3/_read_text.py
@@ -19,10 +19,10 @@ from awswrangler.s3._list import _path2list
 from awswrangler.s3._read import (
     _apply_partition_filter,
     _check_version_id,
+    _concat_union_categoricals,
     _get_num_output_blocks,
     _get_path_ignore_suffix,
     _get_path_root,
-    _concat_union_categoricals,
 )
 from awswrangler.s3._read_text_core import _read_text_file, _read_text_files_chunked
 from awswrangler.typing import RaySettings

--- a/awswrangler/s3/_read_text.py
+++ b/awswrangler/s3/_read_text.py
@@ -22,7 +22,7 @@ from awswrangler.s3._read import (
     _get_num_output_blocks,
     _get_path_ignore_suffix,
     _get_path_root,
-    _union,
+    _concat_union_categoricals,
 )
 from awswrangler.s3._read_text_core import _read_text_file, _read_text_files_chunked
 from awswrangler.typing import RaySettings
@@ -70,7 +70,7 @@ def _read_text(
         itertools.repeat(s3_additional_kwargs),
         itertools.repeat(dataset),
     )
-    return _union(dfs=tables, ignore_index=ignore_index)
+    return _concat_union_categoricals(dfs=tables, ignore_index=ignore_index)
 
 
 def _read_text_format(


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- When executing chunked reads over multiple files that contain different categories, category information is lost due to `pd.concat()` not preserving unmatched categories. Luckily, we already have a utility that concatenates data frames and unions categories.

### Relates
- https://github.com/aws/aws-sdk-pandas/issues/3123

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
