### PR TITLE
fix(athena): ensure thread safety when reading local Athena cache

### DIFF
--- a/awswrangler/athena/_cache.py
+++ b/awswrangler/athena/_cache.py
@@ -73,9 +73,10 @@ class _LocalMetadataCacheManager:
             Returns successful DDL and DML queries sorted by query completion time.
         """
         filtered: list["QueryExecutionTypeDef"] = []
-        for query in self._cache.values():
-            if (query["Status"].get("State") == "SUCCEEDED") and (query.get("StatementType") in ["DDL", "DML"]):
-                filtered.append(query)
+        with self._lock:
+            for query in self._cache.values():
+                if (query["Status"].get("State") == "SUCCEEDED") and (query.get("StatementType") in ["DDL", "DML"]):
+                    filtered.append(query)
         return sorted(filtered, key=lambda e: str(e["Status"]["CompletionDateTime"]), reverse=True)
 
     def __contains__(self, key: str) -> bool:


### PR DESCRIPTION


### Feature or Bugfix
- Bugfix

### Detail
- Wrapped the loop in `_LocalMetadataCacheManager.get_queries` with a lock to ensure thread safety when accessing the cache. This prevents potential race conditions in multithreaded environments.

### Relates
- https://github.com/aws/aws-sdk-pandas/issues/3136

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
