### PR TITLE
fix: do not remove new columns values

### DIFF
--- a/awswrangler/athena/_write_iceberg.py
+++ b/awswrangler/athena/_write_iceberg.py
@@ -548,7 +548,7 @@ def to_iceberg(  # noqa: PLR0913
 
                 # Ensure that the ordering of the DF is the same as in the catalog.
                 # This is required for the INSERT command to work.
-                df = df[catalog_cols]
+                df = df[catalog_cols + [col_name for col_name, _ in schema_differences["new_columns"].items()]]
 
             if schema_evolution is False and any([schema_differences[x] for x in schema_differences]):  # type: ignore[literal-required]
                 raise exceptions.InvalidArgumentValue(f"Schema change detected: {schema_differences}")


### PR DESCRIPTION
### Feature or Bugfix

- Bugfix

### Detail

- When calling the function `to_iceberg` with a DataFrame that has new columns in it, the process adds the new columns to the schema, but doesn't upload the values. Therefore, a second call to the function is needed to actually upload the new columns values.

### Relates
- https://github.com/aws/aws-sdk-pandas/issues/2997 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
