### PR TITLE
[FIX] Add `s3_output` parameter to `_start_query_execution` call in "overwrite" mode

### DIFF
--- a/awswrangler/athena/_write_iceberg.py
+++ b/awswrangler/athena/_write_iceberg.py
@@ -593,6 +593,7 @@ def to_iceberg(  # noqa: PLR0913
                 wg_config=wg_config,
                 database=database,
                 data_source=data_source,
+                s3_output=s3_output,
                 encryption=encryption,
                 kms_key=kms_key,
                 boto3_session=boto3_session,


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Add `s3_output` parameter to `_start_query_execution` call in "overwrite" mode. Otherwise, default S3 location from Athena workgroup is used to store query outputs (and query fails if user doesn't have access there).

### Relates
- https://github.com/aws/aws-sdk-pandas/pull/2829

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
