### PR TITLE
feat(emr): support bootstrap arguments in create_cluster

### DIFF
--- a/awswrangler/emr.py
+++ b/awswrangler/emr.py
@@ -801,8 +801,10 @@ def create_cluster(  # noqa: PLR0913
     args: dict[str, Any] = _build_cluster_args(**locals())
     client_emr = _utils.client(service_name="emr", session=boto3_session)
     response = client_emr.run_job_flow(**args)
-    _logger.debug("response: \n%s", pprint.pformat(response))
-    return response["JobFlowId"]
+    # Add returned JobFlowId into cluster definition
+    args["JobFlowId"] = response["JobFlowId"]
+
+    return args
 
 
 def get_cluster_state(cluster_id: str, boto3_session: boto3.Session | None = None) -> str:

--- a/awswrangler/emr.py
+++ b/awswrangler/emr.py
@@ -296,7 +296,7 @@ def _build_cluster_args(**pars: Any) -> dict[str, Any]:  # noqa: PLR0912,PLR0915
     # Bootstraps
     # if pars["bootstraps_paths"]:
     #     args["BootstrapActions"] = [{"Name": x, "ScriptBootstrapAction": {"Path": x}} for x in pars["bootstraps_paths"]]
-    
+
     # Backward compatibility: if user uses old bootstraps_paths parameter
     if pars.get("bootstraps") is None and pars["bootstraps_paths"]:
         pars["bootstraps"] = pars["bootstraps_paths"]
@@ -305,7 +305,6 @@ def _build_cluster_args(**pars: Any) -> dict[str, Any]:  # noqa: PLR0912,PLR0915
         bootstrap_actions = []
 
         for item in pars["bootstraps"]:
-
             # Case 1: user passed a simple S3 path string
             if isinstance(item, str):
                 bootstrap_actions.append(
@@ -331,12 +330,10 @@ def _build_cluster_args(**pars: Any) -> dict[str, Any]:  # noqa: PLR0912,PLR0915
 
             else:
                 raise TypeError(
-                    "Each bootstrap must be either a string path or a dict with keys: "
-                    "{'name', 'path', 'args'}."
+                    "Each bootstrap must be either a string path or a dict with keys: {'name', 'path', 'args'}."
                 )
 
         args["BootstrapActions"] = bootstrap_actions
-
 
     # Debugging and Steps
     if (pars["debugging"] is True) or (pars["steps"] is not None):

--- a/awswrangler/emr.py
+++ b/awswrangler/emr.py
@@ -345,10 +345,14 @@ def _build_cluster_args(**pars: Any) -> dict[str, Any]:  # noqa: PLR0912,PLR0915
                     }
                 )
 
-            else:
-                raise TypeError("Each bootstrap must be a string or a dict.")
+        # ✅ THIS WAS MISSING
+        if bootstrap_actions:
+            args["BootstrapActions"] = bootstrap_actions
 
-                args["BootstrapActions"] = bootstrap_actions
+        else:
+            raise TypeError("Each bootstrap must be a string or a dict.")
+
+            args["BootstrapActions"] = bootstrap_actions
 
     # Debugging and Steps
     if (pars["debugging"] is True) or (pars["steps"] is not None):

--- a/awswrangler/emr.py
+++ b/awswrangler/emr.py
@@ -318,6 +318,7 @@ def _build_cluster_args(**pars: Any) -> dict[str, Any]:  # noqa: PLR0912,PLR0915
 
             # Case 2: user passed full bootstrap config dict
             elif isinstance(item, dict):
+                item = dict(item)  # helps mypy infer correctly
                 bootstrap_actions.append(
                     {
                         "Name": item.get("name", "bootstrap"),
@@ -508,7 +509,7 @@ def create_cluster(  # noqa: PLR0913
     consistent_view_retry_count: int = 5,
     consistent_view_table_name: str = "EmrFSMetadata",
     bootstraps_paths: list[str] | None = None,
-    bootstraps: list[str | dict] | None = None,
+    bootstraps: list[str | dict[str, Any]] | None = None,
     debugging: bool = True,
     applications: list[str] | None = None,
     visible_to_all_users: bool = True,

--- a/awswrangler/emr.py
+++ b/awswrangler/emr.py
@@ -318,13 +318,16 @@ def _build_cluster_args(**pars: Any) -> dict[str, Any]:  # noqa: PLR0912,PLR0915
 
             # Case 2: user passed full bootstrap config dict
             elif isinstance(item, dict):
-                item = dict(item)  # helps mypy infer correctly
+                name = item.get("name", "bootstrap")
+                path = item["path"]
+                args_list = item.get("args", [])
+
                 bootstrap_actions.append(
                     {
-                        "Name": item.get("name", "bootstrap"),
+                        "Name": name,
                         "ScriptBootstrapAction": {
-                            "Path": item["path"],
-                            "Args": item.get("args", []),
+                            "Path": path,
+                            "Args": args_list,
                         },
                     }
                 )

--- a/awswrangler/emr.py
+++ b/awswrangler/emr.py
@@ -801,10 +801,7 @@ def create_cluster(  # noqa: PLR0913
     args: dict[str, Any] = _build_cluster_args(**locals())
     client_emr = _utils.client(service_name="emr", session=boto3_session)
     response = client_emr.run_job_flow(**args)
-    # Add returned JobFlowId into cluster definition
-    args["JobFlowId"] = response["JobFlowId"]
-
-    return args
+    return response["JobFlowId"]
 
 
 def get_cluster_state(cluster_id: str, boto3_session: boto3.Session | None = None) -> str:

--- a/tests/unit/test_emr.py
+++ b/tests/unit/test_emr.py
@@ -185,3 +185,33 @@ def test_docker(bucket, cloudformation_outputs, emr_security_configuration):
 )
 def test_get_emr_integer_version(version, result):
     assert wr.emr._get_emr_classification_lib(version) == result
+
+
+def test_create_cluster_bootstrap_with_args():
+    cluster = wr.emr.create_cluster(
+        cluster_name="test",
+        bootstraps=[
+            {
+                "name": "cw agent",
+                "path": "s3://bucket/install.sh",
+                "args": ["--target-account", "121213"],
+            }
+        ],
+    )
+
+    action = cluster["BootstrapActions"][0]
+
+    assert action["Name"] == "cw agent"
+    assert action["ScriptBootstrapAction"]["Path"] == "s3://bucket/install.sh"
+    assert action["ScriptBootstrapAction"]["Args"] == ["--target-account", "121213"]
+
+
+def test_create_cluster_bootstrap_paths_still_work():
+    cluster = wr.emr.create_cluster(
+        cluster_name="test",
+        bootstraps_paths=["s3://bucket/old.sh"],
+    )
+
+    action = cluster["BootstrapActions"][0]
+
+    assert action["ScriptBootstrapAction"]["Path"] == "s3://bucket/old.sh"

--- a/tests/unit/test_emr.py
+++ b/tests/unit/test_emr.py
@@ -5,6 +5,7 @@ import pytest
 
 import awswrangler as wr
 
+from unittest.mock import patch
 logging.getLogger("awswrangler").setLevel(logging.DEBUG)
 
 
@@ -187,7 +188,6 @@ def test_get_emr_integer_version(version, result):
     assert wr.emr._get_emr_classification_lib(version) == result
 
 
-from unittest.mock import patch
 
 
 def test_create_cluster_bootstrap_with_args():

--- a/tests/unit/test_emr.py
+++ b/tests/unit/test_emr.py
@@ -189,17 +189,16 @@ def test_get_emr_integer_version(version, result):
 
 def test_create_cluster_bootstrap_with_args():
     cluster = wr.emr.create_cluster(
-    cluster_name="test",
-    subnet_id="subnet-12345678",
-    bootstraps=[
-        {
-            "name": "cw agent",
-            "path": "s3://bucket/install.sh",
-            "args": ["--target-account", "121213"],
-        }
-    ],
-)
-
+        cluster_name="test",
+        subnet_id="subnet-12345678",
+        bootstraps=[
+            {
+                "name": "cw agent",
+                "path": "s3://bucket/install.sh",
+                "args": ["--target-account", "121213"],
+            }
+        ],
+    )
 
     action = cluster["BootstrapActions"][0]
 
@@ -210,11 +209,10 @@ def test_create_cluster_bootstrap_with_args():
 
 def test_create_cluster_bootstrap_paths_still_work():
     cluster = wr.emr.create_cluster(
-    cluster_name="test",
-    subnet_id="subnet-12345678",
-    bootstraps_paths=["s3://bucket/old.sh"],
-)
-
+        cluster_name="test",
+        subnet_id="subnet-12345678",
+        bootstraps_paths=["s3://bucket/old.sh"],
+    )
 
     action = cluster["BootstrapActions"][0]
 

--- a/tests/unit/test_emr.py
+++ b/tests/unit/test_emr.py
@@ -189,6 +189,7 @@ def test_get_emr_integer_version(version, result):
 
 from unittest.mock import patch
 
+
 def test_create_cluster_bootstrap_with_args():
     with patch("boto3.client") as mock_client:
         wr.emr.create_cluster(
@@ -213,7 +214,6 @@ def test_create_cluster_bootstrap_with_args():
         assert action["ScriptBootstrapAction"]["Args"] == ["--target-account", "121213"]
 
 
-
 def test_create_cluster_bootstrap_paths_still_work():
     with patch("boto3.client") as mock_client:
         wr.emr.create_cluster(
@@ -226,4 +226,3 @@ def test_create_cluster_bootstrap_paths_still_work():
         action = args["BootstrapActions"][0]
 
         assert action["ScriptBootstrapAction"]["Path"] == "s3://bucket/old.sh"
-

--- a/tests/unit/test_emr.py
+++ b/tests/unit/test_emr.py
@@ -189,15 +189,17 @@ def test_get_emr_integer_version(version, result):
 
 def test_create_cluster_bootstrap_with_args():
     cluster = wr.emr.create_cluster(
-        cluster_name="test",
-        bootstraps=[
-            {
-                "name": "cw agent",
-                "path": "s3://bucket/install.sh",
-                "args": ["--target-account", "121213"],
-            }
-        ],
-    )
+    cluster_name="test",
+    subnet_id="subnet-12345678",
+    bootstraps=[
+        {
+            "name": "cw agent",
+            "path": "s3://bucket/install.sh",
+            "args": ["--target-account", "121213"],
+        }
+    ],
+)
+
 
     action = cluster["BootstrapActions"][0]
 
@@ -208,9 +210,11 @@ def test_create_cluster_bootstrap_with_args():
 
 def test_create_cluster_bootstrap_paths_still_work():
     cluster = wr.emr.create_cluster(
-        cluster_name="test",
-        bootstraps_paths=["s3://bucket/old.sh"],
-    )
+    cluster_name="test",
+    subnet_id="subnet-12345678",
+    bootstraps_paths=["s3://bucket/old.sh"],
+)
+
 
     action = cluster["BootstrapActions"][0]
 


### PR DESCRIPTION
Fixes #3191

- Added support for bootstrap actions with additional args
- Introduced new `bootstraps` parameter accepting str or dict configs
- Maintained backward compatibility with `bootstraps_paths`
- Added unit tests for both formats
- Note: Unit tests updated to include required subnet_id parameter.


