### PR TITLE
fix(athena): support partition transform expressions with mode=overwrite_partitions (#2845)

### DIFF
--- a/awswrangler/athena/_write_iceberg.py
+++ b/awswrangler/athena/_write_iceberg.py
@@ -260,6 +260,42 @@ def _extract_column_from_partition_transform(col: str) -> str:
     return col
 
 
+def _apply_partition_transform_to_side(col: str, side_alias: str) -> str:
+    """Rewrite a partition expression so it references a specific table alias.
+
+    For a plain column ``"name"`` and ``side_alias="target"`` this returns
+    ``target."name"``. For a transform such as ``"day(ts)"`` it returns
+    ``day(target."ts")``, and for ``"truncate(10, col_name)"`` it returns
+    ``truncate(10, target."col_name")``. This allows the same partition
+    expression supplied as ``partition_cols`` to be used inside MERGE INTO
+    conditions on either the ``target`` or ``source`` side of the join.
+    """
+    pattern = r"([A-Za-z0-9_]+)\((.+)\)"
+    match = re.match(pattern, col)
+    if match:
+        func_name = match.group(1)
+        args = [arg.strip() for arg in match.group(2).split(",")]
+        # Last argument is the column reference; preceding args (if any) are literals
+        column_arg = args[-1]
+        prefix_args = args[:-1]
+        rendered_args = prefix_args + [f'{side_alias}."{column_arg}"']
+        return f"{func_name}({', '.join(rendered_args)})"
+    return f'{side_alias}."{col}"'
+
+
+def _build_partition_merge_conditions(partition_cols: list[str]) -> list[str]:
+    """Build the ON-clause equality fragments used to delete matching partitions.
+
+    Each partition expression is applied to both sides of the join so transform
+    functions such as ``day(ts)`` line up correctly between the target Iceberg
+    table and the source temporary table (which still stores raw columns).
+    """
+    return [
+        f"({_apply_partition_transform_to_side(col, 'target')} = {_apply_partition_transform_to_side(col, 'source')})"
+        for col in partition_cols
+    ]
+
+
 def _build_order_by_clause(partition_cols: list[str] | None) -> str:
     """Build an ORDER BY clause from partition columns.
 
@@ -271,6 +307,119 @@ def _build_order_by_clause(partition_cols: list[str] | None) -> str:
 
     order_cols = [f'"{_extract_column_from_partition_transform(col)}"' for col in partition_cols]
     return f"ORDER BY {', '.join(order_cols)}"
+
+
+def _build_partition_delete_sql(database: str, table: str, source_table: str, partition_cols: list[str]) -> str:
+    """Build the MERGE INTO ... DELETE statement that removes matched partitions.
+
+    Applies the partition transform expressions on both sides of the join so
+    transforms such as ``day(ts)`` are handled correctly. The source table is
+    expected to expose the underlying raw columns referenced by each partition
+    expression.
+    """
+    on_conditions = _build_partition_merge_conditions(partition_cols)
+    return f"""
+        MERGE INTO "{database}"."{table}" target
+        USING "{database}"."{source_table}" source
+        ON {" AND ".join(on_conditions)}
+        WHEN MATCHED THEN
+            DELETE
+    """
+
+
+def _delete_partitions_from_iceberg(
+    df: pd.DataFrame,
+    database: str,
+    table: str,
+    partition_cols: list[str],
+    wg_config: _WorkGroupConfig,
+    temp_path: str | None,
+    data_source: str | None,
+    workgroup: str,
+    s3_output: str | None,
+    encryption: str | None,
+    kms_key: str | None,
+    boto3_session: boto3.Session | None,
+    s3_additional_kwargs: dict[str, Any] | None,
+    catalog_id: str | None,
+) -> None:
+    """Delete partitions from an Iceberg table that match values present in ``df``.
+
+    Unlike :func:`delete_from_iceberg_table`, this helper accepts ``partition_cols``
+    that may contain Iceberg partition transform expressions such as ``day(ts)``
+    or ``truncate(10, col_name)``. It writes the underlying raw columns to a
+    temporary table and issues a ``MERGE INTO ... DELETE`` whose ON clause
+    re-applies the partition transform on both sides of the join.
+    """
+    if not partition_cols:
+        raise exceptions.InvalidArgumentValue("partition_cols must be specified.")
+
+    # Extract the underlying raw column names referenced by the partition expressions,
+    # deduplicating while preserving order so we can project them out of the DataFrame.
+    raw_cols: list[str] = []
+    seen: set[str] = set()
+    for col in partition_cols:
+        raw = _extract_column_from_partition_transform(col)
+        if raw not in seen:
+            raw_cols.append(raw)
+            seen.add(raw)
+
+    missing = [c for c in raw_cols if c not in df.columns]
+    if missing:
+        raise exceptions.InvalidArgumentValue(
+            f"Partition columns {missing} are not present in the DataFrame. "
+            "When using partition transforms (e.g. 'day(ts)'), the DataFrame must "
+            "contain the underlying raw column ('ts')."
+        )
+
+    temp_table: str = f"temp_table_{uuid.uuid4().hex}"
+    df_partitions = df[raw_cols].drop_duplicates(ignore_index=True)
+
+    try:
+        s3.to_parquet(
+            df=df_partitions,
+            path=temp_path or wg_config.s3_output,
+            dataset=True,
+            database=database,
+            table=temp_table,
+            boto3_session=boto3_session,
+            s3_additional_kwargs=s3_additional_kwargs,
+            catalog_id=catalog_id,
+            index=False,
+        )
+
+        sql_statement = _build_partition_delete_sql(
+            database=database,
+            table=table,
+            source_table=temp_table,
+            partition_cols=partition_cols,
+        )
+
+        query_execution_id: str = _start_query_execution(
+            sql=sql_statement,
+            workgroup=workgroup,
+            wg_config=wg_config,
+            database=database,
+            data_source=data_source,
+            s3_output=s3_output,
+            encryption=encryption,
+            kms_key=kms_key,
+            boto3_session=boto3_session,
+        )
+        wait_query(query_execution_id=query_execution_id, boto3_session=boto3_session)
+
+    finally:
+        catalog.delete_table_if_exists(
+            database=database, table=temp_table, boto3_session=boto3_session, catalog_id=catalog_id
+        )
+
+        # Always remove the temp parquet objects we just wrote; keep_files only
+        # applies to the user-facing data write, not these internal staging files.
+        s3.delete_objects(
+            path=temp_path or wg_config.s3_output,  # type: ignore[arg-type]
+            boto3_session=boto3_session,
+            s3_additional_kwargs=s3_additional_kwargs,
+        )
 
 
 def _merge_iceberg(
@@ -603,15 +752,19 @@ def to_iceberg(  # noqa: PLR0913
                 boto3_session=boto3_session,
             )
 
-        # if mode == "overwrite_partitions", drop matched partitions
+        # if mode == "overwrite_partitions", drop matched partitions.
+        # Routed through a dedicated helper (rather than delete_from_iceberg_table)
+        # so that partition transform expressions like 'day(ts)' or
+        # 'truncate(10, col_name)' are applied on both sides of the MERGE join,
+        # while the temp staging table only stores the underlying raw columns.
         if mode == "overwrite_partitions":
-            delete_from_iceberg_table(
+            _delete_partitions_from_iceberg(
                 df=df,
                 database=database,
                 table=table,
-                merge_cols=partition_cols,  # type: ignore[arg-type]
+                partition_cols=partition_cols,  # type: ignore[arg-type]
+                wg_config=wg_config,
                 temp_path=temp_path,
-                keep_files=False,
                 data_source=data_source,
                 workgroup=workgroup,
                 s3_output=s3_output,

--- a/tests/unit/test_athena_iceberg.py
+++ b/tests/unit/test_athena_iceberg.py
@@ -1270,3 +1270,142 @@ def test_build_order_by_clause_multiple() -> None:
 
     result = _build_order_by_clause(["name", "day(ts)"])
     assert result == 'ORDER BY "name", "ts"'
+
+
+# ---- Pure unit tests for partition transform handling in overwrite_partitions ----
+# These cover the fix for https://github.com/aws/aws-sdk-pandas/issues/2845, where
+# `to_iceberg(mode='overwrite_partitions')` failed when partition_cols contained
+# transform expressions like `day(ts)` because the underlying delete path treated
+# them as plain column names.
+
+
+def test_apply_partition_transform_to_side_plain() -> None:
+    from awswrangler.athena._write_iceberg import _apply_partition_transform_to_side
+
+    assert _apply_partition_transform_to_side("name", "target") == 'target."name"'
+    assert _apply_partition_transform_to_side("name", "source") == 'source."name"'
+
+
+def test_apply_partition_transform_to_side_simple_transform() -> None:
+    from awswrangler.athena._write_iceberg import _apply_partition_transform_to_side
+
+    assert _apply_partition_transform_to_side("day(ts)", "target") == 'day(target."ts")'
+    assert _apply_partition_transform_to_side("hour(ts)", "source") == 'hour(source."ts")'
+
+
+def test_apply_partition_transform_to_side_truncate() -> None:
+    from awswrangler.athena._write_iceberg import _apply_partition_transform_to_side
+
+    # truncate(10, col_name) should keep the literal width and qualify the column
+    assert _apply_partition_transform_to_side("truncate(10, col_name)", "target") == 'truncate(10, target."col_name")'
+
+
+def test_apply_partition_transform_to_side_bucket() -> None:
+    from awswrangler.athena._write_iceberg import _apply_partition_transform_to_side
+
+    assert _apply_partition_transform_to_side("bucket(16, user_id)", "source") == 'bucket(16, source."user_id")'
+
+
+def test_build_partition_merge_conditions_plain_only() -> None:
+    from awswrangler.athena._write_iceberg import _build_partition_merge_conditions
+
+    conditions = _build_partition_merge_conditions(["name"])
+    assert conditions == ['(target."name" = source."name")']
+
+
+def test_build_partition_merge_conditions_mixed() -> None:
+    from awswrangler.athena._write_iceberg import _build_partition_merge_conditions
+
+    conditions = _build_partition_merge_conditions(["name", "day(ts)", "truncate(10, col_name)"])
+    assert conditions == [
+        '(target."name" = source."name")',
+        '(day(target."ts") = day(source."ts"))',
+        '(truncate(10, target."col_name") = truncate(10, source."col_name"))',
+    ]
+
+
+def test_build_partition_delete_sql_plain() -> None:
+    from awswrangler.athena._write_iceberg import _build_partition_delete_sql
+
+    sql = _build_partition_delete_sql(
+        database="db",
+        table="t",
+        source_table="src",
+        partition_cols=["name"],
+    )
+    # MERGE INTO uses both target and source aliases, with the equality on the plain column.
+    assert 'MERGE INTO "db"."t" target' in sql
+    assert 'USING "db"."src" source' in sql
+    assert 'ON (target."name" = source."name")' in sql
+    assert "WHEN MATCHED THEN" in sql
+    assert "DELETE" in sql
+
+
+def test_build_partition_delete_sql_transform() -> None:
+    from awswrangler.athena._write_iceberg import _build_partition_delete_sql
+
+    sql = _build_partition_delete_sql(
+        database="db",
+        table="t",
+        source_table="src",
+        partition_cols=["day(ts)"],
+    )
+    # The transform must be applied on both sides of the join.
+    assert "(day(target.\"ts\") = day(source.\"ts\"))" in sql
+    # The bug: the previous implementation produced 'target."day(ts)" = source."day(ts)"',
+    # which Athena rejects because there is no literal column with that name.
+    assert 'target."day(ts)"' not in sql
+    assert 'source."day(ts)"' not in sql
+
+
+def test_build_partition_delete_sql_multi_transform() -> None:
+    from awswrangler.athena._write_iceberg import _build_partition_delete_sql
+
+    sql = _build_partition_delete_sql(
+        database="db",
+        table="t",
+        source_table="src",
+        partition_cols=["name", "hour(ts)", "truncate(10, col_name)"],
+    )
+    assert '(target."name" = source."name")' in sql
+    assert '(hour(target."ts") = hour(source."ts"))' in sql
+    assert '(truncate(10, target."col_name") = truncate(10, source."col_name"))' in sql
+    # All three conditions are AND-ed together
+    assert sql.count(" AND ") == 2
+
+
+def test_delete_partitions_from_iceberg_rejects_missing_underlying_column() -> None:
+    """When a partition transform references a column not present in the DataFrame,
+    the helper must raise InvalidArgumentValue with a clear message rather than
+    failing deep inside `df[merge_cols]` with a confusing KeyError."""
+    import pandas as _pd
+
+    from awswrangler import exceptions
+    from awswrangler.athena._write_iceberg import _delete_partitions_from_iceberg
+
+    # DataFrame has only 'id' and 'day' columns; the partition expression references
+    # the raw column 'ts' (used by `hour(ts)`), which does not exist in the frame.
+    df = _pd.DataFrame({"id": [1, 2], "day": ["1", "2"]})
+
+    class _DummyWg:
+        s3_output: str | None = "s3://placeholder/"
+
+    with pytest.raises(exceptions.InvalidArgumentValue) as excinfo:
+        _delete_partitions_from_iceberg(
+            df=df,
+            database="db",
+            table="t",
+            partition_cols=["hour(ts)"],
+            wg_config=_DummyWg(),  # type: ignore[arg-type]
+            temp_path="s3://placeholder/",
+            data_source=None,
+            workgroup="primary",
+            s3_output=None,
+            encryption=None,
+            kms_key=None,
+            boto3_session=None,
+            s3_additional_kwargs=None,
+            catalog_id=None,
+        )
+
+    assert "ts" in str(excinfo.value)

--- a/tests/unit/test_athena_iceberg.py
+++ b/tests/unit/test_athena_iceberg.py
@@ -1351,7 +1351,7 @@ def test_build_partition_delete_sql_transform() -> None:
         partition_cols=["day(ts)"],
     )
     # The transform must be applied on both sides of the join.
-    assert "(day(target.\"ts\") = day(source.\"ts\"))" in sql
+    assert '(day(target."ts") = day(source."ts"))' in sql
     # The bug: the previous implementation produced 'target."day(ts)" = source."day(ts)"',
     # which Athena rejects because there is no literal column with that name.
     assert 'target."day(ts)"' not in sql


### PR DESCRIPTION
## Summary
Fixes #2845. `athena.to_iceberg(mode="overwrite_partitions")` previously failed when `partition_cols` contained partition transform expressions like `day(ts)`, `hour(ts)`, or `truncate(10, col_name)`.

## Root cause
In `awswrangler/athena/_write_iceberg.py`, the `mode == "overwrite_partitions"` branch reused `delete_from_iceberg_table` and passed `partition_cols` as `merge_cols`. That function did `df[merge_cols]` (KeyErrors on transform expressions) and emitted `target."day(ts)" = source."day(ts)"` (Athena rejects — no literal column with that name).

## Fix
Added a dedicated `_delete_partitions_from_iceberg` helper plus three composable utilities (`_apply_partition_transform_to_side`, `_build_partition_merge_conditions`, `_build_partition_delete_sql`). The helper extracts underlying raw column names, writes only those to staging, and builds the MERGE ON clause by re-applying each transform on both sides — `day(target."ts") = day(source."ts")`. Raises `InvalidArgumentValue` with a clear message when the underlying column is missing from the DataFrame.

## Test plan
- 17/17 partition-related unit tests pass (10 new + 7 existing).
- New tests cover plain cols, `day`, `hour`, `truncate`, `bucket`, mixed multi-transform partition lists, and the missing-underlying-column guard.
- Integration tests not run (require AWS).
