### PR TITLE
feat(emr): support per-action arguments in bootstraps_paths (#3191)

### DIFF
--- a/awswrangler/emr.py
+++ b/awswrangler/emr.py
@@ -104,6 +104,36 @@ def _get_emr_classification_lib(emr_version: str) -> str:
     return "spark-log4j2" if number > 670 else "spark-log4j"
 
 
+def _build_bootstrap_actions(bootstraps_paths: list[str | dict[str, Any]]) -> list[dict[str, Any]]:
+    """Normalize ``bootstraps_paths`` into the boto3 ``BootstrapActions`` shape.
+
+    Each entry may be either:
+    - a ``str`` path (legacy) — converted to ``{Name, ScriptBootstrapAction: {Path}}``
+    - a ``dict`` with ``path`` (required), optional ``args`` (list[str]), and optional ``name``
+    """
+    actions: list[dict[str, Any]] = []
+    for entry in bootstraps_paths:
+        if isinstance(entry, str):
+            actions.append({"Name": entry, "ScriptBootstrapAction": {"Path": entry}})
+            continue
+        if not isinstance(entry, dict):
+            raise exceptions.InvalidArgumentValue(
+                f"bootstraps_paths entries must be a str or a dict, got {type(entry).__name__}."
+            )
+        path = entry.get("path") or entry.get("Path")
+        if not path:
+            raise exceptions.InvalidArgumentValue("bootstraps_paths dict entries must include a 'path' key.")
+        name = entry.get("name") or entry.get("Name") or path
+        script: dict[str, Any] = {"Path": path}
+        args = entry.get("args", entry.get("Args"))
+        if args is not None:
+            if not isinstance(args, list) or not all(isinstance(a, str) for a in args):
+                raise exceptions.InvalidArgumentValue("bootstraps_paths 'args' must be a list of strings.")
+            script["Args"] = args
+        actions.append({"Name": name, "ScriptBootstrapAction": script})
+    return actions
+
+
 def _build_cluster_args(**pars: Any) -> dict[str, Any]:  # noqa: PLR0912,PLR0915
     account_id: str = sts.get_account_id(boto3_session=pars["boto3_session"])
     region: str = _utils.get_region_from_session(boto3_session=pars["boto3_session"])
@@ -295,7 +325,7 @@ def _build_cluster_args(**pars: Any) -> dict[str, Any]:  # noqa: PLR0912,PLR0915
 
     # Bootstraps
     if pars["bootstraps_paths"]:
-        args["BootstrapActions"] = [{"Name": x, "ScriptBootstrapAction": {"Path": x}} for x in pars["bootstraps_paths"]]
+        args["BootstrapActions"] = _build_bootstrap_actions(pars["bootstraps_paths"])
 
     # Debugging and Steps
     if (pars["debugging"] is True) or (pars["steps"] is not None):
@@ -469,7 +499,7 @@ def create_cluster(  # noqa: PLR0913
     consistent_view_retry_seconds: int = 10,
     consistent_view_retry_count: int = 5,
     consistent_view_table_name: str = "EmrFSMetadata",
-    bootstraps_paths: list[str] | None = None,
+    bootstraps_paths: list[str | dict[str, Any]] | None = None,
     debugging: bool = True,
     applications: list[str] | None = None,
     visible_to_all_users: bool = True,
@@ -594,7 +624,14 @@ def create_cluster(  # noqa: PLR0913
     consistent_view_table_name
         Name of the DynamoDB table to store the consistent view data.
     bootstraps_paths
-        Bootstraps paths (e.g ["s3://BUCKET_NAME/script.sh"]).
+        Bootstrap actions for the cluster. Accepts either a list of script paths or
+        a list of dicts that map to the boto3 ``ScriptBootstrapAction`` shape.
+
+        Path-only form (back-compat): ``["s3://BUCKET_NAME/script.sh"]``
+
+        Dict form (allows arguments): ``[{"path": "s3://BUCKET_NAME/script.sh",
+        "args": ["--flag", "value"], "name": "my-bootstrap"}]``. Only ``path`` is
+        required; ``name`` defaults to the path and ``args`` is optional.
     debugging
         Debugging enabled?
     applications

--- a/tests/unit/test_emr.py
+++ b/tests/unit/test_emr.py
@@ -185,3 +185,99 @@ def test_docker(bucket, cloudformation_outputs, emr_security_configuration):
 )
 def test_get_emr_integer_version(version, result):
     assert wr.emr._get_emr_classification_lib(version) == result
+
+
+def test_build_bootstrap_actions_paths_only():
+    """Strings remain backward compatible: produce {Name, ScriptBootstrapAction:{Path}}."""
+    actions = wr.emr._build_bootstrap_actions(["s3://bucket/a.sh", "s3://bucket/b.sh"])
+    assert actions == [
+        {"Name": "s3://bucket/a.sh", "ScriptBootstrapAction": {"Path": "s3://bucket/a.sh"}},
+        {"Name": "s3://bucket/b.sh", "ScriptBootstrapAction": {"Path": "s3://bucket/b.sh"}},
+    ]
+
+
+def test_build_bootstrap_actions_dicts_with_args():
+    """Dict entries pass through args and accept an optional name."""
+    actions = wr.emr._build_bootstrap_actions(
+        [
+            {"path": "s3://bucket/a.sh", "args": ["--flag", "value"], "name": "install"},
+            {"path": "s3://bucket/b.sh"},
+        ]
+    )
+    assert actions == [
+        {
+            "Name": "install",
+            "ScriptBootstrapAction": {"Path": "s3://bucket/a.sh", "Args": ["--flag", "value"]},
+        },
+        {
+            "Name": "s3://bucket/b.sh",
+            "ScriptBootstrapAction": {"Path": "s3://bucket/b.sh"},
+        },
+    ]
+
+
+def test_build_bootstrap_actions_mixed_str_and_dict():
+    """A list may freely mix legacy strings and new dict entries."""
+    actions = wr.emr._build_bootstrap_actions(
+        ["s3://bucket/legacy.sh", {"path": "s3://bucket/new.sh", "args": ["--x"]}]
+    )
+    assert actions == [
+        {"Name": "s3://bucket/legacy.sh", "ScriptBootstrapAction": {"Path": "s3://bucket/legacy.sh"}},
+        {"Name": "s3://bucket/new.sh", "ScriptBootstrapAction": {"Path": "s3://bucket/new.sh", "Args": ["--x"]}},
+    ]
+
+
+def test_build_bootstrap_actions_invalid_type():
+    with pytest.raises(wr.exceptions.InvalidArgumentValue):
+        wr.emr._build_bootstrap_actions([123])  # type: ignore[list-item]
+
+
+def test_build_bootstrap_actions_missing_path():
+    with pytest.raises(wr.exceptions.InvalidArgumentValue):
+        wr.emr._build_bootstrap_actions([{"args": ["--x"]}])
+
+
+def test_build_bootstrap_actions_invalid_args():
+    with pytest.raises(wr.exceptions.InvalidArgumentValue):
+        wr.emr._build_bootstrap_actions([{"path": "s3://bucket/a.sh", "args": "not-a-list"}])
+
+
+def test_build_bootstrap_actions_accepts_capitalized_keys():
+    """Allow the boto3-style keys (Path/Args/Name) to be passed straight through."""
+    actions = wr.emr._build_bootstrap_actions([{"Path": "s3://bucket/a.sh", "Args": ["--x"], "Name": "boto-style"}])
+    assert actions == [
+        {"Name": "boto-style", "ScriptBootstrapAction": {"Path": "s3://bucket/a.sh", "Args": ["--x"]}},
+    ]
+
+
+def test_create_cluster_passes_bootstrap_args_to_run_job_flow():
+    """End-to-end: ensure ``BootstrapActions`` are forwarded to ``run_job_flow`` with Args."""
+    import boto3
+    import moto
+
+    with moto.mock_aws():
+        ec2 = boto3.client("ec2", region_name="us-east-1")
+        vpc_id = ec2.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        subnet_id = ec2.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/24", AvailabilityZone="us-east-1a")["Subnet"][
+            "SubnetId"
+        ]
+        session = boto3.Session(region_name="us-east-1")
+        cluster_id = wr.emr.create_cluster(
+            subnet_id=subnet_id,
+            bootstraps_paths=[
+                "s3://bucket/legacy.sh",
+                {"path": "s3://bucket/new.sh", "args": ["--flag", "v"], "name": "with-args"},
+            ],
+            boto3_session=session,
+        )
+
+        emr_client = session.client("emr")
+        described = emr_client.describe_cluster(ClusterId=cluster_id)
+        assert described["Cluster"]["Id"] == cluster_id
+
+        bootstrap_response = emr_client.list_bootstrap_actions(ClusterId=cluster_id)
+        actions = {a["Name"]: a for a in bootstrap_response["BootstrapActions"]}
+        assert actions["s3://bucket/legacy.sh"]["ScriptPath"] == "s3://bucket/legacy.sh"
+        assert actions["s3://bucket/legacy.sh"].get("Args", []) == []
+        assert actions["with-args"]["ScriptPath"] == "s3://bucket/new.sh"
+        assert actions["with-args"]["Args"] == ["--flag", "v"]


### PR DESCRIPTION
## Summary
Closes #3191. Extends `EMR.create_cluster`'s `bootstraps_paths` to support per-action arguments and a custom name, while preserving the existing string-list shape for backwards compatibility.

## API
- Existing: `bootstraps_paths=["s3://bucket/init.sh"]`
- New: `bootstraps_paths=[{"path": "s3://bucket/init.sh", "args": ["--flag", "x"], "name": "init"}]`
- Both forms can be mixed in the same list.

## Files
- `awswrangler/emr.py` — added `_build_bootstrap_actions()` helper; rewrote the `BootstrapActions` build site to use it; widened the `bootstraps_paths` annotation; expanded the docstring with both forms.
- `tests/unit/test_emr.py` — 7 unit tests for the helper (paths-only, dicts with args, mixed, capitalized boto3 keys, invalid type, missing path, invalid args type) plus 1 end-to-end moto test that creates a cluster and asserts `BootstrapActions` arrive at `run_job_flow` with `Args` populated.

## Test plan
- 12/12 tests pass (`pytest tests/unit/test_emr.py -k "bootstrap or run_job_flow or get_emr"`).
- `ruff check` and `ruff format` clean.
- Backwards compatible: existing string-list usage unchanged.
