### PR TITLE
fix(athena): verify bucket ownership and manifest integrity

### DIFF
--- a/awswrangler/athena/_read.py
+++ b/awswrangler/athena/_read.py
@@ -60,11 +60,23 @@ def _cast_geometry(df: pd.DataFrame, parse_geometry: list[str] = None):
 
 
 def _extract_ctas_manifest_paths(path: str, boto3_session: boto3.Session | None = None) -> list[str]:
-    """Get the list of paths of the generated files."""
+    """Get the list of paths of the generated files.
+
+    Each path listed in the manifest is validated to point at the same bucket
+    as the manifest itself, so that a tampered manifest cannot redirect result
+    reads to an unrelated (attacker-controlled) S3 location.
+    """
     bucket_name, key_path = _utils.parse_path(path)
     client_s3 = _utils.client(service_name="s3", session=boto3_session)
     body: bytes = client_s3.get_object(Bucket=bucket_name, Key=key_path)["Body"].read()
     paths = [x for x in body.decode("utf-8").split("\n") if x]
+    for p in paths:
+        manifest_entry_bucket, _ = _utils.parse_path(p)
+        if manifest_entry_bucket != bucket_name:
+            raise exceptions.InvalidArgumentValue(
+                f"CTAS manifest at {path} references an unexpected bucket "
+                f"'{manifest_entry_bucket}'. Refusing to follow to prevent result hijacking."
+            )
     _logger.debug("Read %d paths from manifest file in: %s", len(paths), path)
     return paths
 

--- a/awswrangler/athena/_utils.py
+++ b/awswrangler/athena/_utils.py
@@ -74,6 +74,15 @@ def _get_s3_output(
         return s3_output
     if wg_config.s3_output is not None:
         return wg_config.s3_output
+    warnings.warn(
+        "No `s3_output` was provided and the workgroup has no ResultConfiguration set. "
+        "Falling back to the default bucket `aws-athena-query-results-{account}-{region}`. "
+        "Because S3 bucket names are global, relying on this predictable default is "
+        "discouraged: pass an explicit `s3_output`, or configure a workgroup with "
+        "EnforceWorkGroupConfiguration=true and a ResultConfiguration.",
+        UserWarning,
+        stacklevel=2,
+    )
     return create_athena_bucket(boto3_session=boto3_session)
 
 
@@ -452,6 +461,13 @@ def get_query_columns_types(query_execution_id: str, boto3_session: boto3.Sessio
 def create_athena_bucket(boto3_session: boto3.Session | None = None) -> str:
     """Create the default Athena bucket if it doesn't exist.
 
+    The bucket name is derived from the caller's account ID and region
+    (``aws-athena-query-results-{account_id}-{region}``). Because S3 bucket
+    names are global, this function verifies that the bucket is owned by the
+    caller's account before returning; if another account owns it, a
+    :class:`~awswrangler.exceptions.InvalidArgumentValue` is raised to prevent
+    query results from being written to a bucket controlled by a third party.
+
     Parameters
     ----------
     boto3_session
@@ -476,12 +492,33 @@ def create_athena_bucket(boto3_session: boto3.Session | None = None) -> str:
     args = {} if region_name == "us-east-1" else {"CreateBucketConfiguration": {"LocationConstraint": region_name}}
     try:
         client_s3.create_bucket(Bucket=bucket_name, **args)  # type: ignore[arg-type]
-    except (client_s3.exceptions.BucketAlreadyExists, client_s3.exceptions.BucketAlreadyOwnedByYou):
-        _logger.debug("Bucket %s already exists.", bucket_name)
+    except client_s3.exceptions.BucketAlreadyOwnedByYou:
+        _logger.debug("Bucket %s already exists in this account.", bucket_name)
+    except client_s3.exceptions.BucketAlreadyExists as ex:
+        raise exceptions.InvalidArgumentValue(
+            f"Default Athena results bucket '{bucket_name}' exists but is not owned by "
+            f"account {account_id}. Refusing to use it to prevent cross-account data leakage. "
+            f"Pass an explicit `s3_output` or configure a workgroup ResultConfiguration."
+        ) from ex
     except botocore.exceptions.ClientError as err:
         if err.response["Error"]["Code"] == "OperationAborted":
             _logger.debug("A conflicting conditional operation is currently in progress against this resource.")
     client_s3.get_waiter("bucket_exists").wait(Bucket=bucket_name)
+    # Defence in depth: the above may race (BucketAlreadyOwnedByYou can be returned
+    # by S3 even when the actual owner is a different account under certain conditions,
+    # and a squatter may appear between create_bucket and the first query). Verify
+    # ownership explicitly using ExpectedBucketOwner, which returns 403 on mismatch.
+    try:
+        client_s3.head_bucket(Bucket=bucket_name, ExpectedBucketOwner=account_id)
+    except botocore.exceptions.ClientError as err:
+        code = err.response.get("Error", {}).get("Code")
+        if code in ("403", "AccessDenied", "Forbidden"):
+            raise exceptions.InvalidArgumentValue(
+                f"Default Athena results bucket '{bucket_name}' is not owned by "
+                f"account {account_id}. Refusing to use it to prevent cross-account data leakage. "
+                f"Pass an explicit `s3_output` or configure a workgroup ResultConfiguration."
+            ) from err
+        raise
     return path
 
 

--- a/tests/unit/test_moto.py
+++ b/tests/unit/test_moto.py
@@ -720,3 +720,43 @@ def test_data_api_rds_read_sql_no_results():
     mock_data_api_connector(con, has_result_set=False)
     dataframe = wr.data_api.rds.read_sql_query("DROP TABLE test", con=con)
     assert dataframe.empty is True
+
+
+def test_create_athena_bucket_owned_by_caller_succeed(moto_aws) -> None:
+    region = "us-east-1"
+    session = boto3.Session(region_name=region)
+    account_id = boto3.client("sts", region_name=region).get_caller_identity()["Account"]
+
+    path = wr.athena.create_athena_bucket(boto3_session=session)
+
+    assert path == f"s3://aws-athena-query-results-{account_id}-{region}/"
+    # The bucket must exist and be owned by the caller (moto's default account).
+    s3 = session.client("s3")
+    s3.head_bucket(Bucket=f"aws-athena-query-results-{account_id}-{region}", ExpectedBucketOwner=account_id)
+
+
+def test_extract_ctas_manifest_paths_same_bucket_succeed(moto_s3_client: "S3Client") -> None:
+    from awswrangler.athena._read import _extract_ctas_manifest_paths
+
+    manifest_key = "manifest.csv"
+    manifest_body = "s3://bucket/results/part-0.parquet\ns3://bucket/results/part-1.parquet\n"
+    moto_s3_client.put_object(Bucket="bucket", Key=manifest_key, Body=manifest_body.encode("utf-8"))
+
+    paths = _extract_ctas_manifest_paths(path=f"s3://bucket/{manifest_key}")
+
+    assert paths == [
+        "s3://bucket/results/part-0.parquet",
+        "s3://bucket/results/part-1.parquet",
+    ]
+
+
+def test_extract_ctas_manifest_paths_cross_bucket_raises(moto_s3_client: "S3Client") -> None:
+    """A manifest that redirects reads to another bucket must be rejected."""
+    from awswrangler.athena._read import _extract_ctas_manifest_paths
+
+    manifest_key = "manifest.csv"
+    manifest_body = "s3://attacker-bucket/poison/part-0.parquet\n"
+    moto_s3_client.put_object(Bucket="bucket", Key=manifest_key, Body=manifest_body.encode("utf-8"))
+
+    with pytest.raises(InvalidArgumentValue, match="unexpected bucket"):
+        _extract_ctas_manifest_paths(path=f"s3://bucket/{manifest_key}")


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail

- The default Athena results bucket name `aws-athena-query-results-{account}-{region}` is predictable, and S3 bucket names are global. If a bucket with this name already exists in a different account, `create_athena_bucket` previously proceeded to use it silently. It now verifies ownership via `ExpectedBucketOwner` and raises if the bucket belongs to another account. 
- A `UserWarning` is also emitted when `_get_s3_output` falls back to the predictable default, encouraging callers to pass an explicit `s3_output` or configure a workgroup `ResultConfiguration`.
- CTAS manifest handling now validates that every path listed in the manifest points to the same bucket as the manifest itself, so a modified manifest cannot redirect result reads to an unrelated S3 location.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
