### PR TITLE
feat: Support S3 Vectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Read our [docs](https://aws-sdk-pandas.readthedocs.io/en/3.16.1/scale.html) or h
   - [039 - Athena Iceberg](https://github.com/aws/aws-sdk-pandas/blob/main/tutorials/039%20-%20Athena%20Iceberg.ipynb)
   - [040 - EMR Serverless](https://github.com/aws/aws-sdk-pandas/blob/main/tutorials/040%20-%20EMR%20Serverless.ipynb)
   - [041 - Apache Spark on Amazon Athena](https://github.com/aws/aws-sdk-pandas/blob/main/tutorials/041%20-%20Apache%20Spark%20on%20Amazon%20Athena.ipynb)
+  - [043 - Amazon S3 Vectors](https://github.com/aws/aws-sdk-pandas/blob/main/tutorials/043%20-%20Amazon%20S3%20Vectors.ipynb)
 - [**API Reference**](https://aws-sdk-pandas.readthedocs.io/en/3.16.1/api.html)
   - [Amazon S3](https://aws-sdk-pandas.readthedocs.io/en/3.16.1/api.html#amazon-s3)
   - [AWS Glue Catalog](https://aws-sdk-pandas.readthedocs.io/en/3.16.1/api.html#aws-glue-catalog)

--- a/awswrangler/_utils.py
+++ b/awswrangler/_utils.py
@@ -67,6 +67,7 @@ if TYPE_CHECKING:
 
     ServiceName = Literal[
         "athena",
+        "bedrock-runtime",
         "cleanrooms",
         "dynamodb",
         "ec2",
@@ -85,6 +86,7 @@ if TYPE_CHECKING:
         "secretsmanager",
         "sts",
         "s3tables",
+        "s3vectors",
         "timestream-query",
         "timestream-write",
     ]

--- a/awswrangler/s3/__init__.py
+++ b/awswrangler/s3/__init__.py
@@ -21,6 +21,22 @@ from awswrangler.s3._s3_tables_mgmt import (
 )
 from awswrangler.s3._select import select_query
 from awswrangler.s3._upload import upload
+from awswrangler.s3._vectors import (
+    create_vector_bucket,
+    create_vector_index,
+    delete_vector_bucket,
+    delete_vector_index,
+    delete_vectors,
+    get_vector_bucket,
+    get_vector_index,
+    get_vectors,
+    list_vector_buckets,
+    list_vector_indexes,
+    list_vectors,
+    put_vectors,
+    put_vectors_from_df,
+    query_vectors,
+)
 from awswrangler.s3._wait import wait_objects_exist, wait_objects_not_exist
 from awswrangler.s3._write_deltalake import to_deltalake, to_deltalake_streaming
 from awswrangler.s3._write_excel import to_excel
@@ -71,4 +87,18 @@ __all__ = [
     "delete_table",
     "from_iceberg",
     "to_iceberg",
+    "create_vector_bucket",
+    "delete_vector_bucket",
+    "list_vector_buckets",
+    "get_vector_bucket",
+    "create_vector_index",
+    "delete_vector_index",
+    "list_vector_indexes",
+    "get_vector_index",
+    "put_vectors",
+    "put_vectors_from_df",
+    "get_vectors",
+    "delete_vectors",
+    "list_vectors",
+    "query_vectors",
 ]

--- a/awswrangler/s3/_vectors/__init__.py
+++ b/awswrangler/s3/_vectors/__init__.py
@@ -1,0 +1,43 @@
+"""Amazon S3 Vectors (PRIVATE subpackage).
+
+Public functions are re-exported through ``awswrangler.s3``. This module is private —
+its layout may change without notice.
+"""
+
+from awswrangler.s3._vectors._mgmt import (
+    create_vector_bucket,
+    create_vector_index,
+    delete_vector_bucket,
+    delete_vector_index,
+    get_vector_bucket,
+    get_vector_index,
+    list_vector_buckets,
+    list_vector_indexes,
+)
+from awswrangler.s3._vectors._read import (
+    get_vectors,
+    list_vectors,
+    query_vectors,
+)
+from awswrangler.s3._vectors._write import (
+    delete_vectors,
+    put_vectors,
+    put_vectors_from_df,
+)
+
+__all__ = [
+    "create_vector_bucket",
+    "delete_vector_bucket",
+    "list_vector_buckets",
+    "get_vector_bucket",
+    "create_vector_index",
+    "delete_vector_index",
+    "list_vector_indexes",
+    "get_vector_index",
+    "put_vectors",
+    "put_vectors_from_df",
+    "get_vectors",
+    "delete_vectors",
+    "list_vectors",
+    "query_vectors",
+]

--- a/awswrangler/s3/_vectors/_bedrock.py
+++ b/awswrangler/s3/_vectors/_bedrock.py
@@ -1,0 +1,73 @@
+"""Amazon S3 Vectors - Bedrock embedding helper (PRIVATE)."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any, Callable
+
+import boto3
+
+from awswrangler import _utils, exceptions
+from awswrangler._executor import _get_executor
+
+if TYPE_CHECKING:
+    from botocore.client import BaseClient
+
+_logger: logging.Logger = logging.getLogger(__name__)
+
+
+def embed_texts(
+    texts: list[str],
+    model_id: str,
+    model_kwargs: dict[str, Any] | None = None,
+    use_threads: bool | int = True,
+    boto3_session: boto3.Session | None = None,
+) -> list[list[float]]:
+    """Embed a list of strings via Amazon Bedrock, optionally in parallel.
+
+    Supported model id prefixes: ``amazon.titan-embed-text-*``, ``cohere.embed-*``.
+    """
+    if not texts:
+        return []
+
+    extra = dict(model_kwargs or {})
+    build_body: Callable[[str], dict[str, Any]]
+    parse_response: Callable[[dict[str, Any]], list[float]]
+
+    if model_id.startswith("amazon.titan-embed-text"):
+
+        def build_body(text: str) -> dict[str, Any]:
+            return {"inputText": text, **extra}
+
+        def parse_response(payload: dict[str, Any]) -> list[float]:
+            return list(payload["embedding"])
+
+    elif model_id.startswith("cohere.embed"):
+        extra.setdefault("input_type", "search_document")
+
+        def build_body(text: str) -> dict[str, Any]:
+            return {"texts": [text], **extra}
+
+        def parse_response(payload: dict[str, Any]) -> list[float]:
+            return list(payload["embeddings"][0])
+
+    else:
+        raise exceptions.InvalidArgument(
+            f"Unsupported Bedrock embedding model_id '{model_id}'. "
+            "Pre-compute embeddings and pass them via `vector_column` instead. "
+            "Supported model id prefixes: 'amazon.titan-embed-text', 'cohere.embed'."
+        )
+
+    def embed_one(client: "BaseClient", text: str) -> list[float]:
+        response = client.invoke_model(  # type: ignore[attr-defined]
+            modelId=model_id,
+            accept="application/json",
+            contentType="application/json",
+            body=json.dumps(build_body(text)).encode("utf-8"),
+        )
+        return parse_response(json.loads(response["body"].read()))
+
+    client = _utils.client(service_name="bedrock-runtime", session=boto3_session)
+    executor = _get_executor(use_threads=use_threads)
+    return list(executor.map(embed_one, client, texts))

--- a/awswrangler/s3/_vectors/_mgmt.py
+++ b/awswrangler/s3/_vectors/_mgmt.py
@@ -1,0 +1,286 @@
+"""Amazon S3 Vectors - Management (control plane) Module (PRIVATE)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import boto3
+
+from awswrangler import _utils, exceptions
+from awswrangler._config import apply_configs
+from awswrangler.s3._vectors._utils import _resolve_target
+
+_logger: logging.Logger = logging.getLogger(__name__)
+
+
+def _bucket_kwargs(name: str | None, arn: str | None) -> dict[str, str]:
+    if (name is None) == (arn is None):
+        raise exceptions.InvalidArgumentCombination("Exactly one of `name` and `arn` must be provided.")
+    if arn is not None:
+        return {"vectorBucketArn": arn}
+    return {"vectorBucketName": name}  # type: ignore[dict-item]
+
+
+def _encryption_block(sse_type: str | None, kms_key_arn: str | None) -> dict[str, str] | None:
+    if sse_type is None and kms_key_arn is None:
+        return None
+    block: dict[str, str] = {}
+    if sse_type is not None:
+        block["sseType"] = sse_type
+    if kms_key_arn is not None:
+        block["kmsKeyArn"] = kms_key_arn
+    return block
+
+
+# ---------------------------------------------------------------------------
+# Vector buckets
+# ---------------------------------------------------------------------------
+
+
+@apply_configs
+def create_vector_bucket(
+    name: str,
+    *,
+    encryption_kms_key_arn: str | None = None,
+    sse_type: str | None = None,
+    tags: dict[str, str] | None = None,
+    boto3_session: boto3.Session | None = None,
+) -> str:
+    """Create an Amazon S3 Vectors bucket.
+
+    Parameters
+    ----------
+    name
+        Name of the vector bucket to create. 3-63 chars.
+    encryption_kms_key_arn
+        Optional KMS key ARN for SSE-KMS encryption. Implies ``sse_type='aws:kms'`` if not specified.
+    sse_type
+        Server-side encryption type. ``'AES256'`` (default if encryption block omitted) or ``'aws:kms'``.
+    tags
+        Resource tags as a dict.
+    boto3_session
+        The default boto3 session will be used if **boto3_session** is ``None``.
+
+    Returns
+    -------
+        ARN of the created vector bucket.
+
+    Examples
+    --------
+    >>> import awswrangler as wr
+    >>> arn = wr.s3.create_vector_bucket("my-vector-bucket")
+    """
+    client = _utils.client(service_name="s3vectors", session=boto3_session)
+    kwargs: dict[str, Any] = {"vectorBucketName": name}
+    enc = _encryption_block(sse_type, encryption_kms_key_arn)
+    if enc is not None:
+        kwargs["encryptionConfiguration"] = enc
+    if tags:
+        kwargs["tags"] = tags
+    response = client.create_vector_bucket(**kwargs)  # type: ignore[attr-defined]
+    arn: str = response["vectorBucketArn"]
+    _logger.debug("Created vector bucket %s with ARN: %s", name, arn)
+    return arn
+
+
+@apply_configs
+def delete_vector_bucket(
+    name: str | None = None,
+    *,
+    arn: str | None = None,
+    boto3_session: boto3.Session | None = None,
+) -> None:
+    """Delete an Amazon S3 Vectors bucket. Specify either ``name`` or ``arn``."""
+    client = _utils.client(service_name="s3vectors", session=boto3_session)
+    client.delete_vector_bucket(**_bucket_kwargs(name, arn))  # type: ignore[attr-defined]
+    _logger.debug("Deleted vector bucket %s", name or arn)
+
+
+@apply_configs
+def list_vector_buckets(
+    prefix: str | None = None,
+    *,
+    boto3_session: boto3.Session | None = None,
+) -> list[dict[str, Any]]:
+    """List all Amazon S3 Vectors buckets in the account/region (paginates internally).
+
+    Parameters
+    ----------
+    prefix
+        Optional name prefix filter.
+    boto3_session
+        The default boto3 session will be used if **boto3_session** is ``None``.
+
+    Returns
+    -------
+        List of vector bucket summaries (each a dict with ``vectorBucketName``, ``vectorBucketArn``, ``creationTime``).
+    """
+    client = _utils.client(service_name="s3vectors", session=boto3_session)
+    buckets: list[dict[str, Any]] = []
+    next_token: str | None = None
+    while True:
+        kwargs: dict[str, Any] = {}
+        if prefix:
+            kwargs["prefix"] = prefix
+        if next_token:
+            kwargs["nextToken"] = next_token
+        response = client.list_vector_buckets(**kwargs)  # type: ignore[attr-defined]
+        buckets.extend(response.get("vectorBuckets", []))
+        next_token = response.get("nextToken")
+        if not next_token:
+            break
+    return buckets
+
+
+@apply_configs
+def get_vector_bucket(
+    name: str | None = None,
+    *,
+    arn: str | None = None,
+    boto3_session: boto3.Session | None = None,
+) -> dict[str, Any]:
+    """Get attributes of a vector bucket. Specify either ``name`` or ``arn``."""
+    client = _utils.client(service_name="s3vectors", session=boto3_session)
+    response = client.get_vector_bucket(**_bucket_kwargs(name, arn))  # type: ignore[attr-defined]
+    bucket: dict[str, Any] = response["vectorBucket"]
+    return bucket
+
+
+# ---------------------------------------------------------------------------
+# Vector indexes
+# ---------------------------------------------------------------------------
+
+
+@apply_configs
+def create_vector_index(
+    *,
+    name: str,
+    dimension: int,
+    distance_metric: str = "cosine",
+    vector_bucket: str | None = None,
+    vector_bucket_arn: str | None = None,
+    data_type: str = "float32",
+    non_filterable_metadata_keys: list[str] | None = None,
+    encryption_kms_key_arn: str | None = None,
+    sse_type: str | None = None,
+    tags: dict[str, str] | None = None,
+    boto3_session: boto3.Session | None = None,
+) -> str:
+    """Create a vector index inside an Amazon S3 Vectors bucket.
+
+    Parameters
+    ----------
+    name
+        Index name (3-63 chars).
+    dimension
+        Vector dimension (1-4096). All vectors written to the index must match.
+    distance_metric
+        ``'cosine'`` (default) or ``'euclidean'``.
+    vector_bucket / vector_bucket_arn
+        Target vector bucket. Specify exactly one.
+    data_type
+        Vector element type. Currently only ``'float32'`` is supported.
+    non_filterable_metadata_keys
+        Metadata keys excluded from filtering (up to 10). Cannot be changed after index creation.
+    encryption_kms_key_arn, sse_type
+        Encryption overrides; default is to inherit from the bucket.
+    tags
+        Resource tags.
+    boto3_session
+        The default boto3 session will be used if **boto3_session** is ``None``.
+
+    Returns
+    -------
+        ARN of the created vector index.
+
+    Examples
+    --------
+    >>> import awswrangler as wr
+    >>> arn = wr.s3.create_vector_index(
+    ...     vector_bucket="my-bucket", name="my-index", dimension=384
+    ... )
+    """
+    client = _utils.client(service_name="s3vectors", session=boto3_session)
+    kwargs: dict[str, Any] = {
+        "indexName": name,
+        "dataType": data_type,
+        "dimension": dimension,
+        "distanceMetric": distance_metric,
+        **_bucket_kwargs(vector_bucket, vector_bucket_arn),
+    }
+    if non_filterable_metadata_keys:
+        kwargs["metadataConfiguration"] = {"nonFilterableMetadataKeys": list(non_filterable_metadata_keys)}
+    enc = _encryption_block(sse_type, encryption_kms_key_arn)
+    if enc is not None:
+        kwargs["encryptionConfiguration"] = enc
+    if tags:
+        kwargs["tags"] = tags
+    response = client.create_index(**kwargs)  # type: ignore[attr-defined]
+    arn: str = response["indexArn"]
+    _logger.debug("Created vector index %s in bucket %s (ARN: %s)", name, vector_bucket or vector_bucket_arn, arn)
+    return arn
+
+
+@apply_configs
+def delete_vector_index(
+    *,
+    name: str | None = None,
+    arn: str | None = None,
+    vector_bucket: str | None = None,
+    vector_bucket_arn: str | None = None,
+    boto3_session: boto3.Session | None = None,
+) -> None:
+    """Delete a vector index. Specify either ``arn``, or ``name`` together with ``vector_bucket``/``vector_bucket_arn``."""
+    client = _utils.client(service_name="s3vectors", session=boto3_session)
+    target = _resolve_target(
+        vector_bucket=vector_bucket, vector_bucket_arn=vector_bucket_arn, index=name, index_arn=arn
+    )
+    client.delete_index(**target)  # type: ignore[attr-defined]
+    _logger.debug("Deleted vector index %s", name or arn)
+
+
+@apply_configs
+def list_vector_indexes(
+    *,
+    vector_bucket: str | None = None,
+    vector_bucket_arn: str | None = None,
+    prefix: str | None = None,
+    boto3_session: boto3.Session | None = None,
+) -> list[dict[str, Any]]:
+    """List all vector indexes in a bucket (paginates internally)."""
+    client = _utils.client(service_name="s3vectors", session=boto3_session)
+    indexes: list[dict[str, Any]] = []
+    next_token: str | None = None
+    base = _bucket_kwargs(vector_bucket, vector_bucket_arn)
+    while True:
+        kwargs: dict[str, Any] = {**base}
+        if prefix:
+            kwargs["prefix"] = prefix
+        if next_token:
+            kwargs["nextToken"] = next_token
+        response = client.list_indexes(**kwargs)  # type: ignore[attr-defined]
+        indexes.extend(response.get("indexes", []))
+        next_token = response.get("nextToken")
+        if not next_token:
+            break
+    return indexes
+
+
+@apply_configs
+def get_vector_index(
+    *,
+    name: str | None = None,
+    arn: str | None = None,
+    vector_bucket: str | None = None,
+    vector_bucket_arn: str | None = None,
+    boto3_session: boto3.Session | None = None,
+) -> dict[str, Any]:
+    """Get attributes of a vector index."""
+    client = _utils.client(service_name="s3vectors", session=boto3_session)
+    target = _resolve_target(
+        vector_bucket=vector_bucket, vector_bucket_arn=vector_bucket_arn, index=name, index_arn=arn
+    )
+    response = client.get_index(**target)  # type: ignore[attr-defined]
+    index: dict[str, Any] = response["index"]
+    return index

--- a/awswrangler/s3/_vectors/_read.py
+++ b/awswrangler/s3/_vectors/_read.py
@@ -1,0 +1,265 @@
+"""Amazon S3 Vectors - Read & query operations on vectors (PRIVATE)."""
+
+from __future__ import annotations
+
+import itertools
+import logging
+from typing import TYPE_CHECKING, Any
+
+import boto3
+import numpy as np
+
+import awswrangler.pandas as pd
+from awswrangler import _utils, exceptions
+from awswrangler._config import apply_configs
+from awswrangler._executor import _get_executor
+from awswrangler.s3._vectors._bedrock import embed_texts
+from awswrangler.s3._vectors._utils import _resolve_target, _to_float32_list, _vectors_response_to_df
+
+if TYPE_CHECKING:
+    from botocore.client import BaseClient
+
+_logger: logging.Logger = logging.getLogger(__name__)
+
+# API limits for read operations.
+_KEYS_PER_GET = 100
+_VECTORS_PER_LIST_PG = 1000
+_MAX_LIST_SEGMENTS = 16
+_MAX_TOPK = 100
+
+
+def _get_chunk(
+    client: "BaseClient",
+    chunk: list[str],
+    target: dict[str, str],
+    return_data: bool,
+    return_metadata: bool,
+) -> list[dict[str, Any]]:
+    response = client.get_vectors(  # type: ignore[attr-defined]
+        **target,
+        keys=chunk,
+        returnData=return_data,
+        returnMetadata=return_metadata,
+    )
+    return list(response.get("vectors", []))
+
+
+@apply_configs
+def get_vectors(
+    *,
+    keys: list[str],
+    return_data: bool = False,
+    return_metadata: bool = False,
+    vector_bucket: str | None = None,
+    vector_bucket_arn: str | None = None,
+    index: str | None = None,
+    index_arn: str | None = None,
+    use_threads: bool | int = True,
+    boto3_session: boto3.Session | None = None,
+) -> pd.DataFrame:
+    """Retrieve vectors by key. Returns a DataFrame with columns ``key`` and (optionally) ``vector``, ``metadata``.
+
+    Up to 100 keys per underlying API call (chunked automatically).
+    """
+    if not keys:
+        return _vectors_response_to_df([], include_data=return_data, include_metadata=return_metadata)
+
+    target = _resolve_target(
+        vector_bucket=vector_bucket, vector_bucket_arn=vector_bucket_arn, index=index, index_arn=index_arn
+    )
+
+    client = _utils.client(service_name="s3vectors", session=boto3_session)
+    chunks = _utils.chunkify(list(keys), max_length=_KEYS_PER_GET)
+    executor = _get_executor(use_threads=use_threads)
+    results: list[list[dict[str, Any]]] = executor.map(
+        _get_chunk,
+        client,
+        chunks,
+        [target] * len(chunks),
+        [return_data] * len(chunks),
+        [return_metadata] * len(chunks),
+    )
+    return _vectors_response_to_df(
+        list(itertools.chain.from_iterable(results)),
+        include_data=return_data,
+        include_metadata=return_metadata,
+    )
+
+
+def _list_segment(
+    client: "BaseClient",
+    target: dict[str, str],
+    return_data: bool,
+    return_metadata: bool,
+    segment_count: int | None,
+    segment_index: int | None,
+    max_items: int | None,
+) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    next_token: str | None = None
+    while True:
+        kwargs: dict[str, Any] = {
+            **target,
+            "returnData": return_data,
+            "returnMetadata": return_metadata,
+            "maxResults": _VECTORS_PER_LIST_PG,
+        }
+        if segment_count is not None and segment_index is not None:
+            kwargs["segmentCount"] = segment_count
+            kwargs["segmentIndex"] = segment_index
+        if next_token:
+            kwargs["nextToken"] = next_token
+        response = client.list_vectors(**kwargs)  # type: ignore[attr-defined]
+        items.extend(response.get("vectors", []))
+        if max_items is not None and len(items) >= max_items:
+            return items[:max_items]
+        next_token = response.get("nextToken")
+        if not next_token:
+            break
+    return items
+
+
+@apply_configs
+def list_vectors(
+    *,
+    return_data: bool = False,
+    return_metadata: bool = False,
+    max_items: int | None = None,
+    vector_bucket: str | None = None,
+    vector_bucket_arn: str | None = None,
+    index: str | None = None,
+    index_arn: str | None = None,
+    use_threads: bool | int = True,
+    boto3_session: boto3.Session | None = None,
+) -> pd.DataFrame:
+    """List all vectors in an index. Uses parallel segments (up to 16) when ``use_threads`` enables it.
+
+    Returns a DataFrame with columns ``key`` and (optionally) ``vector``, ``metadata``.
+    """
+    target = _resolve_target(
+        vector_bucket=vector_bucket, vector_bucket_arn=vector_bucket_arn, index=index, index_arn=index_arn
+    )
+    client = _utils.client(service_name="s3vectors", session=boto3_session)
+    n_segments = min(_MAX_LIST_SEGMENTS, _utils.ensure_worker_or_thread_count(use_threads=use_threads))
+
+    if n_segments <= 1:
+        items = _list_segment(client, target, return_data, return_metadata, None, None, max_items)
+    else:
+        # Cap per-segment fetch so the total isn't ~max_items × n_segments before truncation.
+        # Add 1 to handle uneven splits; final truncation guarantees the cap.
+        per_segment_cap = max_items // n_segments + 1 if max_items is not None else None
+        executor = _get_executor(use_threads=use_threads)
+        # Each worker handles one segment with its own pagination.
+        results: list[list[dict[str, Any]]] = executor.map(
+            _list_segment,
+            client,
+            [target] * n_segments,
+            [return_data] * n_segments,
+            [return_metadata] * n_segments,
+            [n_segments] * n_segments,
+            list(range(n_segments)),
+            [per_segment_cap] * n_segments,
+        )
+        items = list(itertools.chain.from_iterable(results))
+        if max_items is not None and len(items) > max_items:
+            items = items[:max_items]
+    return _vectors_response_to_df(items, include_data=return_data, include_metadata=return_metadata)
+
+
+@apply_configs
+def query_vectors(
+    *,
+    query_vector: list[float] | np.ndarray | None = None,
+    query_text: str | None = None,
+    top_k: int = 10,
+    filter: dict[str, Any] | None = None,
+    return_distance: bool = True,
+    return_metadata: bool = True,
+    bedrock_model_id: str | None = None,
+    bedrock_model_kwargs: dict[str, Any] | None = None,
+    vector_bucket: str | None = None,
+    vector_bucket_arn: str | None = None,
+    index: str | None = None,
+    index_arn: str | None = None,
+    boto3_session: boto3.Session | None = None,
+) -> pd.DataFrame:
+    """Approximate-nearest-neighbour query against an Amazon S3 Vectors index.
+
+    Parameters
+    ----------
+    query_vector
+        Pre-computed query embedding.
+    query_text
+        Text to embed via Bedrock (requires ``bedrock_model_id``).
+    top_k
+        Number of nearest neighbours to return (1-100).
+    filter
+        Metadata filter (MongoDB-style operators: $eq, $ne, $gt, $gte, $lt, $lte, $in, $nin, $exists, $and, $or).
+    return_distance, return_metadata
+        Whether to include each result's distance and metadata.
+    bedrock_model_id, bedrock_model_kwargs
+        Bedrock embedding configuration when using ``query_text``.
+    vector_bucket / vector_bucket_arn / index / index_arn
+        Target index.
+    boto3_session
+        The default boto3 session will be used if **boto3_session** is ``None``.
+
+    Returns
+    -------
+        DataFrame with columns ``key`` and (optionally) ``distance``, ``metadata``.
+        The configured distance metric is exposed via ``df.attrs['distance_metric']``.
+
+    Examples
+    --------
+    >>> import awswrangler as wr
+    >>> df = wr.s3.query_vectors(
+    ...     query_vector=[0.1, 0.2, 0.3],
+    ...     top_k=5,
+    ...     filter={"genre": {"$eq": "documentary"}},
+    ...     vector_bucket="my-bucket",
+    ...     index="my-index",
+    ... )
+    """
+    if (query_vector is None) == (query_text is None):
+        raise exceptions.InvalidArgumentCombination("Provide exactly one of `query_vector` or `query_text`.")
+    if query_text is not None and not bedrock_model_id:
+        raise exceptions.InvalidArgumentCombination("`bedrock_model_id` is required when `query_text` is provided.")
+    if not (1 <= top_k <= _MAX_TOPK):
+        raise exceptions.InvalidArgumentValue(f"`top_k` must be between 1 and {_MAX_TOPK}; got {top_k}.")
+
+    target = _resolve_target(
+        vector_bucket=vector_bucket, vector_bucket_arn=vector_bucket_arn, index=index, index_arn=index_arn
+    )
+
+    if query_vector is None:
+        query_vector = embed_texts(
+            texts=[query_text],  # type: ignore[list-item]
+            model_id=bedrock_model_id,  # type: ignore[arg-type]
+            model_kwargs=bedrock_model_kwargs,
+            use_threads=False,
+            boto3_session=boto3_session,
+        )[0]
+    floats = _to_float32_list(query_vector)
+
+    client = _utils.client(service_name="s3vectors", session=boto3_session)
+    kwargs: dict[str, Any] = {
+        **target,
+        "topK": top_k,
+        "queryVector": {"float32": floats},
+        "returnDistance": return_distance,
+        "returnMetadata": return_metadata,
+    }
+    if filter is not None:
+        kwargs["filter"] = filter
+    response = client.query_vectors(**kwargs)  # type: ignore[attr-defined]
+
+    df_out = _vectors_response_to_df(
+        response.get("vectors", []),
+        include_data=False,
+        include_metadata=return_metadata,
+        include_distance=return_distance,
+    )
+    distance_metric = response.get("distanceMetric")
+    if distance_metric is not None:
+        df_out.attrs["distance_metric"] = distance_metric
+    return df_out

--- a/awswrangler/s3/_vectors/_read.py
+++ b/awswrangler/s3/_vectors/_read.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import itertools
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Iterator
 
 import boto3
 import numpy as np
@@ -86,7 +86,7 @@ def get_vectors(
     )
 
 
-def _list_segment(
+def _iter_list_pages(
     client: "BaseClient",
     target: dict[str, str],
     return_data: bool,
@@ -94,9 +94,10 @@ def _list_segment(
     segment_count: int | None,
     segment_index: int | None,
     max_items: int | None,
-) -> list[dict[str, Any]]:
-    items: list[dict[str, Any]] = []
+) -> Iterator[list[dict[str, Any]]]:
+    """Yield one page of raw vector records per call, honouring ``max_items`` across pages."""
     next_token: str | None = None
+    emitted = 0
     while True:
         kwargs: dict[str, Any] = {
             **target,
@@ -110,13 +111,63 @@ def _list_segment(
         if next_token:
             kwargs["nextToken"] = next_token
         response = client.list_vectors(**kwargs)  # type: ignore[attr-defined]
-        items.extend(response.get("vectors", []))
-        if max_items is not None and len(items) >= max_items:
-            return items[:max_items]
+        page = list(response.get("vectors", []))
+        if max_items is not None and emitted + len(page) >= max_items:
+            yield page[: max_items - emitted]
+            return
+        emitted += len(page)
+        if page:
+            yield page
         next_token = response.get("nextToken")
         if not next_token:
-            break
-    return items
+            return
+
+
+def _list_segment(
+    client: "BaseClient",
+    target: dict[str, str],
+    return_data: bool,
+    return_metadata: bool,
+    segment_count: int | None,
+    segment_index: int | None,
+    max_items: int | None,
+) -> list[dict[str, Any]]:
+    return list(
+        itertools.chain.from_iterable(
+            _iter_list_pages(client, target, return_data, return_metadata, segment_count, segment_index, max_items)
+        )
+    )
+
+
+def _iter_list_vectors_chunked(
+    client: "BaseClient",
+    target: dict[str, str],
+    return_data: bool,
+    return_metadata: bool,
+    max_items: int | None,
+    chunksize: int | None,
+) -> Iterator[pd.DataFrame]:
+    """Stream list_vectors results as DataFrames.
+
+    ``chunksize=None`` emits one frame per API page; otherwise emits frames of exactly
+    ``chunksize`` rows (final frame may be shorter).
+    """
+    pages = _iter_list_pages(client, target, return_data, return_metadata, None, None, max_items)
+    if chunksize is None:
+        for page in pages:
+            yield _vectors_response_to_df(page, include_data=return_data, include_metadata=return_metadata)
+        return
+
+    buffer: list[dict[str, Any]] = []
+    for page in pages:
+        buffer.extend(page)
+        while len(buffer) >= chunksize:
+            yield _vectors_response_to_df(
+                buffer[:chunksize], include_data=return_data, include_metadata=return_metadata
+            )
+            buffer = buffer[chunksize:]
+    if buffer:
+        yield _vectors_response_to_df(buffer, include_data=return_data, include_metadata=return_metadata)
 
 
 @apply_configs
@@ -125,21 +176,49 @@ def list_vectors(
     return_data: bool = False,
     return_metadata: bool = False,
     max_items: int | None = None,
+    chunked: bool | int = False,
     vector_bucket: str | None = None,
     vector_bucket_arn: str | None = None,
     index: str | None = None,
     index_arn: str | None = None,
     use_threads: bool | int = True,
     boto3_session: boto3.Session | None = None,
-) -> pd.DataFrame:
+) -> pd.DataFrame | Iterator[pd.DataFrame]:
     """List all vectors in an index. Uses parallel segments (up to 16) when ``use_threads`` enables it.
 
-    Returns a DataFrame with columns ``key`` and (optionally) ``vector``, ``metadata``.
+    Parameters
+    ----------
+    return_data, return_metadata
+        Whether to include each vector's data and metadata.
+    max_items
+        Optional cap on total vectors returned across all pages/segments.
+    chunked
+        Batching (memory-friendly). Returns an iterator of DataFrames instead of one frame:
+
+        - ``True`` — yield one DataFrame per underlying API page.
+        - ``INTEGER`` — yield DataFrames of exactly this many rows (final frame may be shorter).
+
+        Chunked streaming is single-segment (sequential) regardless of ``use_threads``.
+    vector_bucket / vector_bucket_arn / index / index_arn
+        Target index.
+    use_threads
+        Concurrency for parallel-segment listing. Ignored when ``chunked`` is truthy.
+    boto3_session
+        The default boto3 session will be used if **boto3_session** is ``None``.
+
+    Returns
+    -------
+        DataFrame with columns ``key`` and (optionally) ``vector``, ``metadata`` — or an iterator of such DataFrames when ``chunked`` is truthy.
     """
     target = _resolve_target(
         vector_bucket=vector_bucket, vector_bucket_arn=vector_bucket_arn, index=index, index_arn=index_arn
     )
     client = _utils.client(service_name="s3vectors", session=boto3_session)
+
+    if chunked:
+        chunksize = chunked if isinstance(chunked, int) and not isinstance(chunked, bool) else None
+        return _iter_list_vectors_chunked(client, target, return_data, return_metadata, max_items, chunksize)
+
     n_segments = min(_MAX_LIST_SEGMENTS, _utils.ensure_worker_or_thread_count(use_threads=use_threads))
 
     if n_segments <= 1:

--- a/awswrangler/s3/_vectors/_read.py
+++ b/awswrangler/s3/_vectors/_read.py
@@ -169,7 +169,7 @@ def list_vectors(
 @apply_configs
 def query_vectors(
     *,
-    query_vector: list[float] | np.ndarray | None = None,
+    query_vector: list[float] | np.ndarray[Any, Any] | None = None,
     query_text: str | None = None,
     top_k: int = 10,
     filter: dict[str, Any] | None = None,

--- a/awswrangler/s3/_vectors/_utils.py
+++ b/awswrangler/s3/_vectors/_utils.py
@@ -1,0 +1,83 @@
+"""Amazon S3 Vectors - Shared internal helpers (PRIVATE)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+import awswrangler.pandas as pd
+from awswrangler import exceptions
+
+
+def _resolve_target(
+    *,
+    vector_bucket: str | None,
+    vector_bucket_arn: str | None,
+    index: str | None,
+    index_arn: str | None,
+) -> dict[str, str]:
+    """Resolve mutually-exclusive targeting params into a kwargs dict for the s3vectors client."""
+    if index_arn is not None:
+        if index is not None or vector_bucket is not None or vector_bucket_arn is not None:
+            raise exceptions.InvalidArgumentCombination(
+                "When `index_arn` is provided, `index`, `vector_bucket` and `vector_bucket_arn` must be omitted."
+            )
+        return {"indexArn": index_arn}
+
+    if index is None:
+        raise exceptions.InvalidArgumentCombination("Provide either `index_arn`, or `index` plus a vector bucket.")
+
+    if (vector_bucket is None) == (vector_bucket_arn is None):
+        raise exceptions.InvalidArgumentCombination(
+            "Exactly one of `vector_bucket` or `vector_bucket_arn` is required when targeting an index by name."
+        )
+
+    if vector_bucket_arn is not None:
+        return {"indexName": index, "vectorBucketArn": vector_bucket_arn}
+    return {"indexName": index, "vectorBucketName": vector_bucket}  # type: ignore[dict-item]
+
+
+def _to_float32_list(value: Any) -> list[float]:
+    """Coerce a vector-like value to a Python list[float] in float32 precision.
+
+    Non-finite values (``inf``, ``-inf``, ``nan``) are rejected — S3 Vectors will reject them
+    server-side anyway, and a clear client-side error beats an opaque ``ValidationException``.
+    """
+    arr = np.asarray(value, dtype=np.float32)
+    if arr.ndim != 1:
+        raise exceptions.InvalidArgumentValue(f"Vector data must be one-dimensional; got shape {arr.shape}.")
+    if not np.isfinite(arr).all():
+        raise exceptions.InvalidArgumentValue("Vector data contains non-finite values (inf or NaN).")
+    return [float(x) for x in arr.tolist()]
+
+
+def _vectors_response_to_df(
+    records: list[dict[str, Any]],
+    *,
+    include_data: bool = False,
+    include_metadata: bool = False,
+    include_distance: bool = False,
+) -> pd.DataFrame:
+    """Shape a list of s3vectors response records into a DataFrame."""
+    columns = ["key"]
+    if include_distance:
+        columns.append("distance")
+    if include_data:
+        columns.append("vector")
+    if include_metadata:
+        columns.append("metadata")
+
+    rows: list[dict[str, Any]] = []
+    for r in records:
+        row: dict[str, Any] = {"key": r.get("key")}
+        if include_distance and "distance" in r:
+            row["distance"] = r["distance"]
+        if include_data:
+            data = r.get("data")
+            row["vector"] = list(data["float32"]) if isinstance(data, dict) and "float32" in data else data
+        if include_metadata:
+            row["metadata"] = r.get("metadata")
+        rows.append(row)
+
+    return pd.DataFrame(rows, columns=columns) if rows else pd.DataFrame(columns=columns)

--- a/awswrangler/s3/_vectors/_write.py
+++ b/awswrangler/s3/_vectors/_write.py
@@ -1,0 +1,259 @@
+"""Amazon S3 Vectors - Write & delete operations on vectors (PRIVATE)."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import boto3
+import numpy as np
+
+import awswrangler.pandas as pd
+from awswrangler import _utils, exceptions
+from awswrangler._config import apply_configs
+from awswrangler._executor import _get_executor
+from awswrangler.s3._vectors._bedrock import embed_texts
+from awswrangler.s3._vectors._utils import _resolve_target, _to_float32_list
+
+if TYPE_CHECKING:
+    from botocore.client import BaseClient
+
+_logger: logging.Logger = logging.getLogger(__name__)
+
+# API limits for write/delete operations.
+_VECTORS_PER_PUT = 500
+_KEYS_PER_DELETE = 500
+
+
+def _drop_nan(metadata: dict[str, Any]) -> dict[str, Any]:
+    """Drop NaN / pd.NA / None metadata values (per-row).
+
+    Lists, dicts, and falsy scalars (0, False, '') are preserved.
+    """
+    cleaned: dict[str, Any] = {}
+    for k, v in metadata.items():
+        if v is None:
+            continue
+        # `pd.isna` handles float('nan'), np.nan, pd.NA, pd.NaT — but it returns an array
+        # for sequences, so guard iterables first.
+        if not isinstance(v, (list, tuple, dict, set, np.ndarray)) and pd.isna(v):
+            continue
+        cleaned[k] = v
+    return cleaned
+
+
+def _put_chunk(client: "BaseClient", chunk: list[dict[str, Any]], target: dict[str, str]) -> None:
+    client.put_vectors(**target, vectors=chunk)  # type: ignore[attr-defined]
+
+
+def _normalise_put_items(vectors: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Validate and float32-coerce the vector payload; pass metadata through unchanged."""
+    out: list[dict[str, Any]] = []
+    for v in vectors:
+        if "key" not in v:
+            raise exceptions.InvalidArgumentValue("Each vector must have a `key`.")
+        data = v.get("data")
+        # Accept either {"data": {"float32": [...]}} or {"data": [...]} or {"data": np.ndarray}.
+        if isinstance(data, dict) and "float32" in data:
+            floats = _to_float32_list(data["float32"])
+        elif data is None:
+            raise exceptions.InvalidArgumentValue(f"Vector '{v['key']}' is missing `data`.")
+        else:
+            floats = _to_float32_list(data)
+        item: dict[str, Any] = {"key": v["key"], "data": {"float32": floats}}
+        if "metadata" in v and v["metadata"] is not None:
+            item["metadata"] = v["metadata"]
+        out.append(item)
+    return out
+
+
+@apply_configs
+def put_vectors(
+    *,
+    vectors: list[dict[str, Any]],
+    vector_bucket: str | None = None,
+    vector_bucket_arn: str | None = None,
+    index: str | None = None,
+    index_arn: str | None = None,
+    use_threads: bool | int = True,
+    boto3_session: boto3.Session | None = None,
+) -> None:
+    """Insert one or more vectors into an Amazon S3 Vectors index.
+
+    Parameters
+    ----------
+    vectors
+        List of dicts, each shaped ``{"key": str, "data": list[float] | dict[str, list[float]] | np.ndarray, "metadata": dict | None}``.
+        ``data`` is automatically cast to float32. Up to 500 vectors per underlying API call.
+    vector_bucket / vector_bucket_arn / index / index_arn
+        Target index. See module docstring for resolution rules.
+    use_threads
+        Concurrency for batched calls.
+    boto3_session
+        The default boto3 session will be used if **boto3_session** is ``None``.
+    """
+    if not vectors:
+        return
+    target = _resolve_target(
+        vector_bucket=vector_bucket, vector_bucket_arn=vector_bucket_arn, index=index, index_arn=index_arn
+    )
+    items = _normalise_put_items(vectors)
+
+    client = _utils.client(service_name="s3vectors", session=boto3_session)
+    chunks = _utils.chunkify(items, max_length=_VECTORS_PER_PUT)
+    executor = _get_executor(use_threads=use_threads)
+    executor.map(_put_chunk, client, chunks, [target] * len(chunks))
+
+
+@apply_configs
+def put_vectors_from_df(
+    df: pd.DataFrame,
+    *,
+    key_column: str,
+    vector_column: str | None = None,
+    metadata_columns: list[str] | None = None,
+    text_column: str | None = None,
+    bedrock_model_id: str | None = None,
+    bedrock_model_kwargs: dict[str, Any] | None = None,
+    vector_bucket: str | None = None,
+    vector_bucket_arn: str | None = None,
+    index: str | None = None,
+    index_arn: str | None = None,
+    use_threads: bool | int = True,
+    boto3_session: boto3.Session | None = None,
+) -> None:
+    """Insert all rows of a DataFrame into an Amazon S3 Vectors index.
+
+    Either ``vector_column`` (precomputed embeddings) or ``text_column`` + ``bedrock_model_id``
+    (embed via Amazon Bedrock on the fly) must be provided.
+
+    Parameters
+    ----------
+    df
+        Input DataFrame.
+    key_column
+        Column containing the per-row vector key (string).
+    vector_column
+        Column containing the precomputed embedding (list[float] / np.ndarray per row).
+    metadata_columns
+        Columns to attach as filterable/non-filterable metadata. ``None`` means "all columns
+        except ``key_column``, ``vector_column`` and ``text_column``" — note ``text_column``
+        is excluded by default; pass it explicitly here (e.g. for RAG citations) to keep it.
+        NaN / ``pd.NA`` / ``None`` cells are dropped per row.
+    text_column
+        Column containing input text to embed via Bedrock. Mutually exclusive with ``vector_column``.
+    bedrock_model_id, bedrock_model_kwargs
+        Bedrock embedding model and optional model-specific kwargs (e.g. ``{"dimensions": 256}``).
+    vector_bucket / vector_bucket_arn / index / index_arn
+        Target index.
+    use_threads
+        Concurrency for batched put calls and for parallel Bedrock embedding.
+    boto3_session
+        The default boto3 session will be used if **boto3_session** is ``None``.
+
+    Examples
+    --------
+    Pre-computed vectors:
+
+    >>> import awswrangler as wr
+    >>> wr.s3.put_vectors_from_df(
+    ...     df=my_df,
+    ...     key_column="id",
+    ...     vector_column="embedding",
+    ...     vector_bucket="my-bucket",
+    ...     index="my-index",
+    ... )
+
+    Embed-on-write via Bedrock Titan:
+
+    >>> wr.s3.put_vectors_from_df(
+    ...     df=my_df,
+    ...     key_column="id",
+    ...     text_column="content",
+    ...     bedrock_model_id="amazon.titan-embed-text-v2:0",
+    ...     vector_bucket="my-bucket",
+    ...     index="my-index",
+    ... )
+    """
+    if (vector_column is None) == (text_column is None):
+        raise exceptions.InvalidArgumentCombination("Provide exactly one of `vector_column` or `text_column`.")
+    if text_column is not None and not bedrock_model_id:
+        raise exceptions.InvalidArgumentCombination("`bedrock_model_id` is required when `text_column` is provided.")
+
+    if df.empty:
+        return
+
+    # Determine metadata columns.
+    excluded = {key_column}
+    if vector_column is not None:
+        excluded.add(vector_column)
+    if text_column is not None:
+        excluded.add(text_column)
+    meta_cols: list[str]
+    if metadata_columns is None:
+        meta_cols = [c for c in df.columns if c not in excluded]
+    else:
+        meta_cols = list(metadata_columns)
+
+    # Compute embeddings if needed.
+    vectors_iter: list[Any]
+    if vector_column is not None:
+        vectors_iter = df[vector_column].tolist()
+    else:
+        texts: list[str] = [str(t) for t in df[text_column].tolist()]
+        vectors_iter = embed_texts(
+            texts=texts,
+            model_id=bedrock_model_id,  # type: ignore[arg-type]
+            model_kwargs=bedrock_model_kwargs,
+            use_threads=use_threads,
+            boto3_session=boto3_session,
+        )
+
+    # Build raw vector items. `to_dict(orient="records")` is faster than .iterrows() and
+    # avoids constructing per-row Series.
+    keys = df[key_column].astype(str).tolist()
+    metas = df[meta_cols].to_dict(orient="records") if meta_cols else [{}] * len(df)
+    items: list[dict[str, Any]] = []
+    for key, vec, meta in zip(keys, vectors_iter, metas):
+        item: dict[str, Any] = {"key": key, "data": vec}
+        cleaned = _drop_nan(meta)
+        if cleaned:
+            item["metadata"] = cleaned
+        items.append(item)
+
+    put_vectors(
+        vectors=items,
+        vector_bucket=vector_bucket,
+        vector_bucket_arn=vector_bucket_arn,
+        index=index,
+        index_arn=index_arn,
+        use_threads=use_threads,
+        boto3_session=boto3_session,
+    )
+
+
+def _delete_chunk(client: "BaseClient", chunk: list[str], target: dict[str, str]) -> None:
+    client.delete_vectors(**target, keys=chunk)  # type: ignore[attr-defined]
+
+
+@apply_configs
+def delete_vectors(
+    *,
+    keys: list[str],
+    vector_bucket: str | None = None,
+    vector_bucket_arn: str | None = None,
+    index: str | None = None,
+    index_arn: str | None = None,
+    use_threads: bool | int = True,
+    boto3_session: boto3.Session | None = None,
+) -> None:
+    """Delete vectors by key (chunks at 500 per underlying call)."""
+    if not keys:
+        return
+    target = _resolve_target(
+        vector_bucket=vector_bucket, vector_bucket_arn=vector_bucket_arn, index=index, index_arn=index_arn
+    )
+    client = _utils.client(service_name="s3vectors", session=boto3_session)
+    chunks = _utils.chunkify(list(keys), max_length=_KEYS_PER_DELETE)
+    executor = _get_executor(use_threads=use_threads)
+    executor.map(_delete_chunk, client, chunks, [target] * len(chunks))

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -3,6 +3,7 @@ API Reference
 
 * `Amazon S3`_
 * `Amazon S3 Tables`_
+* `Amazon S3 Vectors`_
 * `AWS Glue Catalog`_
 * `Amazon Athena`_
 * `Amazon Redshift`_
@@ -332,6 +333,29 @@ Amazon S3 Tables
     delete_table
     from_iceberg
     to_iceberg
+
+Amazon S3 Vectors
+-----------------
+
+.. currentmodule:: awswrangler.s3
+
+.. autosummary::
+    :toctree: stubs
+
+    create_vector_bucket
+    delete_vector_bucket
+    list_vector_buckets
+    get_vector_bucket
+    create_vector_index
+    delete_vector_index
+    list_vector_indexes
+    get_vector_index
+    put_vectors
+    put_vectors_from_df
+    get_vectors
+    delete_vectors
+    list_vectors
+    query_vectors
 
 Amazon Timestream
 -----------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ dev = [
     "setuptools",
     "wheel>=0.45.1,<=0.47.0",
     "msgpack",
-    "boto3-stubs[athena, cleanrooms, chime, cloudwatch, dynamodb, ec2, emr, emr-serverless, glue, kms, logs, neptune, opensearch, opensearchserverless, quicksight, rds, rds-data, redshift, redshift-data, s3, secretsmanager, ssm, sts, timestream-query, timestream-write]>=1.36.2,<2",
+    "boto3-stubs[athena, bedrock-runtime, cleanrooms, chime, cloudwatch, dynamodb, ec2, emr, emr-serverless, glue, kms, logs, neptune, opensearch, opensearchserverless, quicksight, rds, rds-data, redshift, redshift-data, s3, s3vectors, secretsmanager, ssm, sts, timestream-query, timestream-write]>=1.36.2,<2",
     "doc8>=1.1,<3.0",
     "mypy~=1.14",
     "ruff>=0.9.2,<0.16.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -459,7 +459,7 @@ def vector_bucket():
 
 @pytest.fixture(scope="function")
 def vector_index(vector_bucket):
-    index_name = f"idx_{uuid.uuid4().hex[:8]}"
+    index_name = f"idx-{uuid.uuid4().hex[:8]}"
     print(f"S3 Vector index: {index_name}")
     wr.s3.create_vector_index(
         vector_bucket=vector_bucket,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -444,6 +444,36 @@ def s3_table_namespace(s3_table_bucket):
         pass
 
 
+@pytest.fixture(scope="session")
+def vector_bucket():
+    suffix = uuid.uuid4().hex[:8]
+    bucket_name = f"test-s3vectors-{suffix}"
+    print(f"S3 Vector bucket: {bucket_name}")
+    wr.s3.create_vector_bucket(name=bucket_name)
+    yield bucket_name
+    try:
+        wr.s3.delete_vector_bucket(name=bucket_name)
+    except botocore.exceptions.ClientError:
+        pass
+
+
+@pytest.fixture(scope="function")
+def vector_index(vector_bucket):
+    index_name = f"idx_{uuid.uuid4().hex[:8]}"
+    print(f"S3 Vector index: {index_name}")
+    wr.s3.create_vector_index(
+        vector_bucket=vector_bucket,
+        name=index_name,
+        dimension=4,
+        distance_metric="cosine",
+    )
+    yield vector_bucket, index_name
+    try:
+        wr.s3.delete_vector_index(name=index_name, vector_bucket=vector_bucket)
+    except botocore.exceptions.ClientError:
+        pass
+
+
 @pytest.fixture(scope="function")
 def timestream_database():
     name = f"tbl_{get_time_str_with_random_suffix()}"

--- a/tests/unit/test_s3_vectors.py
+++ b/tests/unit/test_s3_vectors.py
@@ -1,0 +1,185 @@
+"""Live integration tests for awswrangler S3 Vectors entry points.
+
+These tests hit real AWS — they require credentials and a region where Amazon S3 Vectors is
+available. They use the ``vector_bucket`` (session) and ``vector_index`` (function) fixtures
+from ``tests/conftest.py``, which create and tear down throwaway resources via the awswrangler
+control-plane functions themselves (no CDK stack needed).
+
+Pure-mock unit tests live in ``tests/unit/test_s3_vectors_mocked.py``.
+"""
+
+from __future__ import annotations
+
+import time
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import awswrangler as wr
+
+
+def _wait_for_indexed(
+    vector_bucket: str,
+    index_name: str,
+    expected_keys: set[str],
+    timeout: float = 30.0,
+) -> None:
+    """Poll list_vectors until all expected keys are visible (writes are strongly consistent
+    once the call returns, but listings may briefly trail; tolerate up to `timeout` seconds)."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        df = wr.s3.list_vectors(vector_bucket=vector_bucket, index=index_name, use_threads=False)
+        if expected_keys.issubset(set(df["key"].tolist())):
+            return
+        time.sleep(1)
+    raise AssertionError(f"Vectors not indexed within {timeout}s; expected {expected_keys}")
+
+
+def test_get_vector_bucket(vector_bucket: str) -> None:
+    info = wr.s3.get_vector_bucket(name=vector_bucket)
+    assert info["vectorBucketName"] == vector_bucket
+    assert "vectorBucketArn" in info
+
+
+def test_list_vector_buckets_includes_test_bucket(vector_bucket: str) -> None:
+    buckets = wr.s3.list_vector_buckets()
+    names = {b["vectorBucketName"] for b in buckets}
+    assert vector_bucket in names
+
+
+def test_get_vector_index(vector_index: tuple[str, str]) -> None:
+    bucket, index = vector_index
+    info = wr.s3.get_vector_index(name=index, vector_bucket=bucket)
+    assert info["indexName"] == index
+    assert info["dimension"] == 4
+    assert info["distanceMetric"] == "cosine"
+    assert info["dataType"] == "float32"
+
+
+def test_list_vector_indexes(vector_index: tuple[str, str]) -> None:
+    bucket, index = vector_index
+    indexes = wr.s3.list_vector_indexes(vector_bucket=bucket)
+    names = {i["indexName"] for i in indexes}
+    assert index in names
+
+
+def test_put_query_round_trip(vector_index: tuple[str, str]) -> None:
+    bucket, index = vector_index
+    df = pd.DataFrame(
+        {
+            "id": ["doc-1", "doc-2", "doc-3", "doc-4"],
+            "embedding": [
+                np.array([0.10, 0.20, 0.30, 0.40], dtype=np.float32),
+                np.array([0.15, 0.25, 0.35, 0.45], dtype=np.float32),
+                np.array([0.90, 0.80, 0.70, 0.60], dtype=np.float32),
+                np.array([0.05, 0.05, 0.05, 0.05], dtype=np.float32),
+            ],
+            "genre": ["documentary", "documentary", "drama", "comedy"],
+            "year": [2021, 2023, 2019, 2024],
+        }
+    )
+
+    wr.s3.put_vectors_from_df(
+        df=df,
+        key_column="id",
+        vector_column="embedding",
+        vector_bucket=bucket,
+        index=index,
+        use_threads=False,
+    )
+
+    # Closest match to doc-1's vector should be doc-1 itself.
+    results = wr.s3.query_vectors(
+        query_vector=[0.10, 0.20, 0.30, 0.40],
+        top_k=1,
+        return_distance=True,
+        return_metadata=True,
+        vector_bucket=bucket,
+        index=index,
+    )
+    assert results.iloc[0]["key"] == "doc-1"
+    assert results.attrs.get("distance_metric") == "cosine"
+
+
+def test_query_with_metadata_filter(vector_index: tuple[str, str]) -> None:
+    bucket, index = vector_index
+    df = pd.DataFrame(
+        {
+            "id": ["a", "b", "c"],
+            "embedding": [
+                [0.1, 0.2, 0.3, 0.4],
+                [0.11, 0.21, 0.31, 0.41],
+                [0.9, 0.9, 0.9, 0.9],
+            ],
+            "year": [2018, 2024, 2025],
+        }
+    )
+    wr.s3.put_vectors_from_df(
+        df=df,
+        key_column="id",
+        vector_column="embedding",
+        vector_bucket=bucket,
+        index=index,
+        use_threads=False,
+    )
+
+    # Even though "a" is closest, the filter excludes it.
+    results = wr.s3.query_vectors(
+        query_vector=[0.1, 0.2, 0.3, 0.4],
+        top_k=2,
+        filter={"year": {"$gte": 2024}},
+        return_metadata=True,
+        vector_bucket=bucket,
+        index=index,
+    )
+    assert "a" not in set(results["key"].tolist())
+    assert {"b", "c"}.issuperset(set(results["key"].tolist()))
+
+
+def test_get_and_delete_vectors(vector_index: tuple[str, str]) -> None:
+    bucket, index = vector_index
+    keys = [f"k{i}" for i in range(5)]
+    vectors = [{"key": k, "data": [float(i) / 10, 0.0, 0.0, 0.0], "metadata": {"i": i}} for i, k in enumerate(keys)]
+    wr.s3.put_vectors(vectors=vectors, vector_bucket=bucket, index=index, use_threads=False)
+
+    fetched = wr.s3.get_vectors(
+        keys=keys,
+        return_data=True,
+        return_metadata=True,
+        vector_bucket=bucket,
+        index=index,
+        use_threads=False,
+    )
+    assert set(fetched["key"].tolist()) == set(keys)
+    assert all(isinstance(v, list) and len(v) == 4 for v in fetched["vector"])
+
+    wr.s3.delete_vectors(keys=keys[:3], vector_bucket=bucket, index=index, use_threads=False)
+    remaining = wr.s3.get_vectors(keys=keys, vector_bucket=bucket, index=index, use_threads=False)
+    assert set(remaining["key"].tolist()) == set(keys[3:])
+
+
+def test_list_vectors_returns_all_with_parallel_segments(vector_index: tuple[str, str]) -> None:
+    bucket, index = vector_index
+    keys = [f"row-{i}" for i in range(20)]
+    vectors = [{"key": k, "data": [float(i), 0.0, 0.0, 0.0]} for i, k in enumerate(keys)]
+    wr.s3.put_vectors(vectors=vectors, vector_bucket=bucket, index=index, use_threads=False)
+    _wait_for_indexed(bucket, index, set(keys))
+
+    df = wr.s3.list_vectors(vector_bucket=bucket, index=index, use_threads=4)
+    assert set(df["key"].tolist()) >= set(keys)
+
+
+@pytest.mark.parametrize("use_threads", [False, True])
+def test_put_vectors_chunks_above_api_limit(vector_index: tuple[str, str], use_threads: bool) -> None:
+    bucket, index = vector_index
+    n = 1100  # > 500 (API limit) so awswrangler must chunk.
+    vectors = [{"key": f"bulk-{i}", "data": [float(i), 0.0, 0.0, 0.0]} for i in range(n)]
+    wr.s3.put_vectors(vectors=vectors, vector_bucket=bucket, index=index, use_threads=use_threads)
+    fetched = wr.s3.get_vectors(
+        keys=[f"bulk-{i}" for i in range(n)],
+        vector_bucket=bucket,
+        index=index,
+        use_threads=use_threads,
+    )
+    assert len(fetched) == n

--- a/tests/unit/test_s3_vectors.py
+++ b/tests/unit/test_s3_vectors.py
@@ -140,7 +140,7 @@ def test_query_with_metadata_filter(vector_index: tuple[str, str]) -> None:
 def test_get_and_delete_vectors(vector_index: tuple[str, str]) -> None:
     bucket, index = vector_index
     keys = [f"k{i}" for i in range(5)]
-    vectors = [{"key": k, "data": [float(i) / 10, 0.0, 0.0, 0.0], "metadata": {"i": i}} for i, k in enumerate(keys)]
+    vectors = [{"key": k, "data": [float(i + 1) / 10, 0.0, 0.0, 0.0], "metadata": {"i": i}} for i, k in enumerate(keys)]
     wr.s3.put_vectors(vectors=vectors, vector_bucket=bucket, index=index, use_threads=False)
 
     fetched = wr.s3.get_vectors(
@@ -162,7 +162,7 @@ def test_get_and_delete_vectors(vector_index: tuple[str, str]) -> None:
 def test_list_vectors_returns_all_with_parallel_segments(vector_index: tuple[str, str]) -> None:
     bucket, index = vector_index
     keys = [f"row-{i}" for i in range(20)]
-    vectors = [{"key": k, "data": [float(i), 0.0, 0.0, 0.0]} for i, k in enumerate(keys)]
+    vectors = [{"key": k, "data": [float(i + 1), 0.0, 0.0, 0.0]} for i, k in enumerate(keys)]
     wr.s3.put_vectors(vectors=vectors, vector_bucket=bucket, index=index, use_threads=False)
     _wait_for_indexed(bucket, index, set(keys))
 
@@ -174,7 +174,7 @@ def test_list_vectors_returns_all_with_parallel_segments(vector_index: tuple[str
 def test_put_vectors_chunks_above_api_limit(vector_index: tuple[str, str], use_threads: bool) -> None:
     bucket, index = vector_index
     n = 1100  # > 500 (API limit) so awswrangler must chunk.
-    vectors = [{"key": f"bulk-{i}", "data": [float(i), 0.0, 0.0, 0.0]} for i in range(n)]
+    vectors = [{"key": f"bulk-{i}", "data": [float(i + 1), 0.0, 0.0, 0.0]} for i in range(n)]
     wr.s3.put_vectors(vectors=vectors, vector_bucket=bucket, index=index, use_threads=use_threads)
     fetched = wr.s3.get_vectors(
         keys=[f"bulk-{i}" for i in range(n)],

--- a/tests/unit/test_s3_vectors_mocked.py
+++ b/tests/unit/test_s3_vectors_mocked.py
@@ -409,6 +409,63 @@ def test_list_vectors_max_items_truncates() -> None:
     assert len(df) == 3
 
 
+def test_list_vectors_chunked_true_yields_one_frame_per_page() -> None:
+    client = MagicMock()
+    client.list_vectors.side_effect = [
+        {"vectors": [{"key": "k1"}, {"key": "k2"}], "nextToken": "tok"},
+        {"vectors": [{"key": "k3"}]},
+    ]
+    with _patch_client(client):
+        it = wr.s3.list_vectors(vector_bucket="b", index="i", chunked=True, use_threads=8)
+        frames = list(it)
+    # Chunked forces single-segment sequential streaming regardless of use_threads.
+    for call in client.list_vectors.call_args_list:
+        assert "segmentCount" not in call.kwargs
+        assert "segmentIndex" not in call.kwargs
+    assert [f["key"].tolist() for f in frames] == [["k1", "k2"], ["k3"]]
+
+
+def test_list_vectors_chunked_integer_yields_fixed_size_frames() -> None:
+    client = MagicMock()
+    client.list_vectors.side_effect = [
+        {"vectors": [{"key": f"k{i}"} for i in range(3)], "nextToken": "tok"},
+        {"vectors": [{"key": f"k{i}"} for i in range(3, 7)]},
+    ]
+    with _patch_client(client):
+        it = wr.s3.list_vectors(vector_bucket="b", index="i", chunked=2)
+        frames = list(it)
+    assert [len(f) for f in frames] == [2, 2, 2, 1]
+    assert [k for f in frames for k in f["key"].tolist()] == [f"k{i}" for i in range(7)]
+
+
+def test_list_vectors_chunked_is_lazy() -> None:
+    client = MagicMock()
+    client.list_vectors.side_effect = [
+        {"vectors": [{"key": "k1"}], "nextToken": "tok"},
+        {"vectors": [{"key": "k2"}]},
+    ]
+    with _patch_client(client):
+        it = wr.s3.list_vectors(vector_bucket="b", index="i", chunked=True)
+        # No API call should have happened yet.
+        assert client.list_vectors.call_count == 0
+        next(it)
+        assert client.list_vectors.call_count == 1
+        next(it)
+        assert client.list_vectors.call_count == 2
+
+
+def test_list_vectors_chunked_respects_max_items() -> None:
+    client = MagicMock()
+    client.list_vectors.side_effect = [
+        {"vectors": [{"key": f"k{i}"} for i in range(4)], "nextToken": "tok"},
+        {"vectors": [{"key": f"k{i}"} for i in range(4, 8)]},
+    ]
+    with _patch_client(client):
+        frames = list(wr.s3.list_vectors(vector_bucket="b", index="i", chunked=True, max_items=5))
+    keys = [k for f in frames for k in f["key"].tolist()]
+    assert keys == ["k0", "k1", "k2", "k3", "k4"]
+
+
 # ---------------------------------------------------------------------------
 # query_vectors
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_s3_vectors_mocked.py
+++ b/tests/unit/test_s3_vectors_mocked.py
@@ -1,0 +1,604 @@
+"""Unit tests for awswrangler.s3 S3 Vectors entry points.
+
+Moto does not yet support s3vectors, so these tests mock the boto3 client returned by
+`awswrangler._utils.client` and assert on call arguments and result shaping.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import awswrangler as wr
+from awswrangler import exceptions
+from awswrangler.s3._vectors import _bedrock, _write
+from awswrangler.s3._vectors import _utils as _vutils
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _patch_client(mock_client: MagicMock) -> Any:
+    """Patch awswrangler._utils.client so any service request returns mock_client."""
+    return patch("awswrangler._utils.client", return_value=mock_client)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_target
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_target_by_index_arn() -> None:
+    out = _vutils._resolve_target(
+        vector_bucket=None, vector_bucket_arn=None, index=None, index_arn="arn:aws:s3vectors:::bucket/b/index/i"
+    )
+    assert out == {"indexArn": "arn:aws:s3vectors:::bucket/b/index/i"}
+
+
+def test_resolve_target_by_index_and_bucket_name() -> None:
+    out = _vutils._resolve_target(vector_bucket="my-b", vector_bucket_arn=None, index="my-i", index_arn=None)
+    assert out == {"indexName": "my-i", "vectorBucketName": "my-b"}
+
+
+def test_resolve_target_by_index_and_bucket_arn() -> None:
+    out = _vutils._resolve_target(
+        vector_bucket=None,
+        vector_bucket_arn="arn:aws:s3vectors:::bucket/b",
+        index="my-i",
+        index_arn=None,
+    )
+    assert out == {"indexName": "my-i", "vectorBucketArn": "arn:aws:s3vectors:::bucket/b"}
+
+
+def test_resolve_target_index_arn_excludes_others() -> None:
+    with pytest.raises(exceptions.InvalidArgumentCombination):
+        _vutils._resolve_target(
+            vector_bucket="b", vector_bucket_arn=None, index=None, index_arn="arn:aws:s3vectors:::bucket/b/index/i"
+        )
+
+
+def test_resolve_target_no_index() -> None:
+    with pytest.raises(exceptions.InvalidArgumentCombination):
+        _vutils._resolve_target(vector_bucket="b", vector_bucket_arn=None, index=None, index_arn=None)
+
+
+def test_resolve_target_both_buckets() -> None:
+    with pytest.raises(exceptions.InvalidArgumentCombination):
+        _vutils._resolve_target(vector_bucket="b", vector_bucket_arn="arn:b", index="i", index_arn=None)
+
+
+def test_resolve_target_neither_bucket() -> None:
+    with pytest.raises(exceptions.InvalidArgumentCombination):
+        _vutils._resolve_target(vector_bucket=None, vector_bucket_arn=None, index="i", index_arn=None)
+
+
+# ---------------------------------------------------------------------------
+# Float32 + metadata cleanup
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        [0.1, 0.2, 0.3],
+        np.array([0.1, 0.2, 0.3], dtype=np.float64),
+        np.array([0.1, 0.2, 0.3], dtype=np.float32),
+        (0.1, 0.2, 0.3),
+    ],
+)
+def test_to_float32_list(value: Any) -> None:
+    result = _vutils._to_float32_list(value)
+    assert isinstance(result, list)
+    assert len(result) == 3
+    assert all(isinstance(x, float) for x in result)
+
+
+def test_to_float32_rejects_2d() -> None:
+    with pytest.raises(exceptions.InvalidArgumentValue):
+        _vutils._to_float32_list(np.array([[0.1], [0.2]]))
+
+
+@pytest.mark.parametrize("bad_value", [float("nan"), float("inf"), float("-inf")])
+def test_to_float32_rejects_non_finite(bad_value: float) -> None:
+    with pytest.raises(exceptions.InvalidArgumentValue, match="non-finite"):
+        _vutils._to_float32_list([0.1, bad_value, 0.3])
+
+
+def test_drop_nan_keeps_falsy_values_and_collections() -> None:
+    cleaned = _write._drop_nan(
+        {
+            "a": 0,
+            "b": False,
+            "c": "",
+            "d": None,
+            "e": float("nan"),
+            "f": "x",
+            "g": pd.NA,
+            "h": [1, 2, 3],
+            "i": {"nested": "dict"},
+        }
+    )
+    assert cleaned == {"a": 0, "b": False, "c": "", "f": "x", "h": [1, 2, 3], "i": {"nested": "dict"}}
+
+
+# ---------------------------------------------------------------------------
+# Aliasing identity (the public surface mirrors the private functions)
+# ---------------------------------------------------------------------------
+
+
+def test_public_aliases_point_to_private_implementations() -> None:
+    from awswrangler.s3 import _vectors
+
+    for name in (
+        "create_vector_bucket",
+        "delete_vector_bucket",
+        "list_vector_buckets",
+        "get_vector_bucket",
+        "create_vector_index",
+        "delete_vector_index",
+        "list_vector_indexes",
+        "get_vector_index",
+        "put_vectors",
+        "put_vectors_from_df",
+        "get_vectors",
+        "delete_vectors",
+        "list_vectors",
+        "query_vectors",
+    ):
+        assert getattr(wr.s3, name) is getattr(_vectors, name), name
+
+
+# ---------------------------------------------------------------------------
+# put_vectors — chunking + payload shape
+# ---------------------------------------------------------------------------
+
+
+def test_put_vectors_chunks_at_500() -> None:
+    client = MagicMock()
+    client.put_vectors.return_value = {}
+    n = 1200
+    vectors = [{"key": f"k{i}", "data": [float(i), float(i)]} for i in range(n)]
+
+    with _patch_client(client):
+        wr.s3.put_vectors(vectors=vectors, vector_bucket="b", index="i", use_threads=False)
+
+    # 1200 items @ max 500/call → ceil(1200/500) = 3 calls. chunkify balances sizes.
+    assert client.put_vectors.call_count == 3
+    sizes = [len(call.kwargs["vectors"]) for call in client.put_vectors.call_args_list]
+    assert sum(sizes) == n
+    assert all(0 < s <= 500 for s in sizes)
+    # Targeting passed through.
+    for call in client.put_vectors.call_args_list:
+        assert call.kwargs["vectorBucketName"] == "b"
+        assert call.kwargs["indexName"] == "i"
+
+
+def test_put_vectors_coerces_to_float32() -> None:
+    client = MagicMock()
+    client.put_vectors.return_value = {}
+    payload = [{"key": "k1", "data": np.array([1.0, 2.0], dtype=np.float64), "metadata": {"x": 1}}]
+
+    with _patch_client(client):
+        wr.s3.put_vectors(vectors=payload, vector_bucket="b", index="i", use_threads=False)
+
+    item = client.put_vectors.call_args.kwargs["vectors"][0]
+    assert item["key"] == "k1"
+    assert item["data"]["float32"] == [1.0, 2.0]
+    assert item["metadata"] == {"x": 1}
+
+
+def test_put_vectors_accepts_explicit_float32_envelope() -> None:
+    client = MagicMock()
+    client.put_vectors.return_value = {}
+    payload = [{"key": "k1", "data": {"float32": [0.5, 0.5]}}]
+
+    with _patch_client(client):
+        wr.s3.put_vectors(vectors=payload, vector_bucket="b", index="i", use_threads=False)
+
+    item = client.put_vectors.call_args.kwargs["vectors"][0]
+    assert item["data"] == {"float32": [0.5, 0.5]}
+
+
+def test_put_vectors_empty_is_noop() -> None:
+    client = MagicMock()
+    with _patch_client(client):
+        wr.s3.put_vectors(vectors=[], vector_bucket="b", index="i")
+    client.put_vectors.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# put_vectors_from_df
+# ---------------------------------------------------------------------------
+
+
+def test_put_vectors_from_df_with_vector_column() -> None:
+    client = MagicMock()
+    client.put_vectors.return_value = {}
+    df = pd.DataFrame(
+        {
+            "id": ["a", "b", "c"],
+            "embedding": [[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]],
+            "genre": ["doc", "drama", None],
+            "year": [2020, 2021, float("nan")],
+        }
+    )
+
+    with _patch_client(client):
+        wr.s3.put_vectors_from_df(
+            df=df,
+            key_column="id",
+            vector_column="embedding",
+            vector_bucket="b",
+            index="i",
+            use_threads=False,
+        )
+
+    sent = client.put_vectors.call_args.kwargs["vectors"]
+    assert [v["key"] for v in sent] == ["a", "b", "c"]
+    assert all(v["data"]["float32"] for v in sent)
+    # Row a: both metadata fields present.
+    assert sent[0]["metadata"] == {"genre": "doc", "year": 2020}
+    # Row c: NaN year and None genre dropped → no metadata at all.
+    assert "metadata" not in sent[2]
+
+
+def test_put_vectors_from_df_requires_one_of_vector_or_text() -> None:
+    df = pd.DataFrame({"id": ["a"], "embedding": [[0.1]]})
+    with pytest.raises(exceptions.InvalidArgumentCombination):
+        wr.s3.put_vectors_from_df(df=df, key_column="id", vector_bucket="b", index="i")
+    with pytest.raises(exceptions.InvalidArgumentCombination):
+        wr.s3.put_vectors_from_df(
+            df=df,
+            key_column="id",
+            vector_column="embedding",
+            text_column="x",
+            vector_bucket="b",
+            index="i",
+        )
+
+
+def test_put_vectors_from_df_text_column_requires_bedrock_model() -> None:
+    df = pd.DataFrame({"id": ["a"], "text": ["hello"]})
+    with pytest.raises(exceptions.InvalidArgumentCombination):
+        wr.s3.put_vectors_from_df(df=df, key_column="id", text_column="text", vector_bucket="b", index="i")
+
+
+def test_put_vectors_from_df_with_text_column_calls_bedrock() -> None:
+    s3v_client = MagicMock()
+    s3v_client.put_vectors.return_value = {}
+
+    def fake_client(service_name: str, **_: Any) -> MagicMock:
+        if service_name == "bedrock-runtime":
+            br = MagicMock()
+            br.invoke_model.side_effect = lambda **kw: {
+                "body": io.BytesIO(json.dumps({"embedding": [0.1, 0.2, 0.3]}).encode())
+            }
+            return br
+        return s3v_client
+
+    df = pd.DataFrame({"id": ["a", "b"], "text": ["hello", "world"]})
+
+    def fake_client_v2(service_name: str, **_: Any) -> MagicMock:
+        if service_name == "bedrock-runtime":
+            br = MagicMock()
+            # Return values that round-trip exactly through float32.
+            br.invoke_model.side_effect = lambda **kw: {
+                "body": io.BytesIO(json.dumps({"embedding": [0.5, 0.25, 0.125]}).encode())
+            }
+            return br
+        return s3v_client
+
+    with patch("awswrangler._utils.client", side_effect=fake_client_v2):
+        wr.s3.put_vectors_from_df(
+            df=df,
+            key_column="id",
+            text_column="text",
+            bedrock_model_id="amazon.titan-embed-text-v2:0",
+            vector_bucket="b",
+            index="i",
+            use_threads=False,
+        )
+    sent = s3v_client.put_vectors.call_args.kwargs["vectors"]
+    assert [v["key"] for v in sent] == ["a", "b"]
+    assert all(v["data"]["float32"] == [0.5, 0.25, 0.125] for v in sent)
+
+
+# ---------------------------------------------------------------------------
+# get_vectors / delete_vectors — chunking
+# ---------------------------------------------------------------------------
+
+
+def test_get_vectors_chunks_at_100_and_returns_dataframe() -> None:
+    client = MagicMock()
+    # Each call returns a couple of records keyed by the requested keys.
+    client.get_vectors.side_effect = lambda **kw: {
+        "vectors": [{"key": k, "data": {"float32": [1.0, 2.0]}, "metadata": {"x": 1}} for k in kw["keys"]]
+    }
+    keys = [f"k{i}" for i in range(250)]
+
+    with _patch_client(client):
+        df = wr.s3.get_vectors(
+            keys=keys,
+            return_data=True,
+            return_metadata=True,
+            vector_bucket="b",
+            index="i",
+            use_threads=False,
+        )
+
+    # 250 keys @ max 100/call → ceil(250/100) = 3 calls. chunkify balances sizes.
+    assert client.get_vectors.call_count == 3
+    sizes = [len(call.kwargs["keys"]) for call in client.get_vectors.call_args_list]
+    assert sum(sizes) == 250
+    assert all(0 < s <= 100 for s in sizes)
+    assert list(df.columns) == ["key", "vector", "metadata"]
+    assert len(df) == 250
+
+
+def test_get_vectors_empty_keys_returns_empty_df() -> None:
+    client = MagicMock()
+    with _patch_client(client):
+        df = wr.s3.get_vectors(keys=[], vector_bucket="b", index="i")
+    assert df.empty
+    assert list(df.columns) == ["key"]
+    client.get_vectors.assert_not_called()
+
+
+def test_delete_vectors_chunks_at_500() -> None:
+    client = MagicMock()
+    client.delete_vectors.return_value = {}
+    keys = [f"k{i}" for i in range(600)]
+
+    with _patch_client(client):
+        wr.s3.delete_vectors(keys=keys, vector_bucket="b", index="i", use_threads=False)
+
+    # 600 keys @ max 500/call → ceil(600/500) = 2 calls.
+    assert client.delete_vectors.call_count == 2
+    sizes = [len(call.kwargs["keys"]) for call in client.delete_vectors.call_args_list]
+    assert sum(sizes) == 600
+    assert all(0 < s <= 500 for s in sizes)
+
+
+# ---------------------------------------------------------------------------
+# list_vectors — segments + pagination
+# ---------------------------------------------------------------------------
+
+
+def test_list_vectors_paginates_single_segment() -> None:
+    client = MagicMock()
+    client.list_vectors.side_effect = [
+        {"vectors": [{"key": "k1"}, {"key": "k2"}], "nextToken": "tok"},
+        {"vectors": [{"key": "k3"}]},
+    ]
+    with _patch_client(client):
+        df = wr.s3.list_vectors(vector_bucket="b", index="i", use_threads=False)
+    assert client.list_vectors.call_count == 2
+    # No segment params on a single-threaded list.
+    for call in client.list_vectors.call_args_list:
+        assert "segmentCount" not in call.kwargs
+    assert df["key"].tolist() == ["k1", "k2", "k3"]
+
+
+def test_list_vectors_uses_parallel_segments() -> None:
+    client = MagicMock()
+    # Each segment returns one record so we can count calls per segment.
+    client.list_vectors.side_effect = lambda **kw: {"vectors": [{"key": f"seg{kw['segmentIndex']}"}]}
+    with _patch_client(client):
+        df = wr.s3.list_vectors(vector_bucket="b", index="i", use_threads=4)
+    assert client.list_vectors.call_count == 4
+    seg_indexes = sorted(call.kwargs["segmentIndex"] for call in client.list_vectors.call_args_list)
+    assert seg_indexes == [0, 1, 2, 3]
+    assert all(call.kwargs["segmentCount"] == 4 for call in client.list_vectors.call_args_list)
+    assert sorted(df["key"].tolist()) == ["seg0", "seg1", "seg2", "seg3"]
+
+
+def test_list_vectors_max_items_truncates() -> None:
+    client = MagicMock()
+    client.list_vectors.return_value = {
+        "vectors": [{"key": f"k{i}"} for i in range(10)],
+    }
+    with _patch_client(client):
+        df = wr.s3.list_vectors(vector_bucket="b", index="i", max_items=3, use_threads=False)
+    assert len(df) == 3
+
+
+# ---------------------------------------------------------------------------
+# query_vectors
+# ---------------------------------------------------------------------------
+
+
+def test_query_vectors_happy_path() -> None:
+    client = MagicMock()
+    client.query_vectors.return_value = {
+        "distanceMetric": "cosine",
+        "vectors": [
+            {"key": "a", "distance": 0.01, "metadata": {"genre": "doc"}},
+            {"key": "b", "distance": 0.05, "metadata": {"genre": "drama"}},
+        ],
+    }
+    # Use values that round-trip exactly through float32 to avoid precision noise in assertions.
+    qv = [0.5, 0.25, 0.125]
+    with _patch_client(client):
+        df = wr.s3.query_vectors(
+            query_vector=qv,
+            top_k=5,
+            filter={"year": {"$gte": 2020}},
+            vector_bucket="b",
+            index="i",
+        )
+    sent = client.query_vectors.call_args.kwargs
+    assert sent["topK"] == 5
+    assert sent["queryVector"] == {"float32": qv}
+    assert sent["filter"] == {"year": {"$gte": 2020}}
+    assert list(df.columns) == ["key", "distance", "metadata"]
+    assert df.attrs["distance_metric"] == "cosine"
+
+
+def test_query_vectors_top_k_bounds() -> None:
+    with pytest.raises(exceptions.InvalidArgumentValue):
+        wr.s3.query_vectors(query_vector=[0.1], top_k=0, vector_bucket="b", index="i")
+    with pytest.raises(exceptions.InvalidArgumentValue):
+        wr.s3.query_vectors(query_vector=[0.1], top_k=101, vector_bucket="b", index="i")
+
+
+def test_query_vectors_either_vector_or_text_required() -> None:
+    with pytest.raises(exceptions.InvalidArgumentCombination):
+        wr.s3.query_vectors(vector_bucket="b", index="i")
+    with pytest.raises(exceptions.InvalidArgumentCombination):
+        wr.s3.query_vectors(query_vector=[0.1], query_text="hi", vector_bucket="b", index="i")
+
+
+def test_query_vectors_text_requires_bedrock_model() -> None:
+    with pytest.raises(exceptions.InvalidArgumentCombination):
+        wr.s3.query_vectors(query_text="hi", vector_bucket="b", index="i")
+
+
+def test_query_vectors_with_text_calls_bedrock_then_query() -> None:
+    s3v_client = MagicMock()
+    s3v_client.query_vectors.return_value = {"vectors": [{"key": "a"}]}
+
+    def fake_client(service_name: str, **_: Any) -> MagicMock:
+        if service_name == "bedrock-runtime":
+            br = MagicMock()
+            br.invoke_model.return_value = {"body": io.BytesIO(json.dumps({"embedding": [0.5, 0.25, 0.125]}).encode())}
+            return br
+        return s3v_client
+
+    with patch("awswrangler._utils.client", side_effect=fake_client):
+        df = wr.s3.query_vectors(
+            query_text="hello",
+            bedrock_model_id="amazon.titan-embed-text-v2:0",
+            top_k=1,
+            vector_bucket="b",
+            index="i",
+        )
+    sent = s3v_client.query_vectors.call_args.kwargs
+    assert sent["queryVector"] == {"float32": [0.5, 0.25, 0.125]}
+    assert df["key"].tolist() == ["a"]
+
+
+# ---------------------------------------------------------------------------
+# Bedrock helper
+# ---------------------------------------------------------------------------
+
+
+def _mock_bedrock_response(payload: dict[str, Any]) -> Any:
+    return {"body": io.BytesIO(json.dumps(payload).encode())}
+
+
+def test_bedrock_titan_request_and_response_shape() -> None:
+    client = MagicMock()
+    client.invoke_model.return_value = _mock_bedrock_response({"embedding": [0.1, 0.2]})
+    with _patch_client(client):
+        out = _bedrock.embed_texts(
+            ["hello"], "amazon.titan-embed-text-v2:0", model_kwargs={"dimensions": 256}, use_threads=False
+        )
+    body = json.loads(client.invoke_model.call_args.kwargs["body"])
+    assert body == {"inputText": "hello", "dimensions": 256}
+    assert client.invoke_model.call_args.kwargs["modelId"] == "amazon.titan-embed-text-v2:0"
+    assert out == [[0.1, 0.2]]
+
+
+def test_bedrock_cohere_request_and_response_shape() -> None:
+    client = MagicMock()
+    client.invoke_model.return_value = _mock_bedrock_response({"embeddings": [[0.7, 0.8]]})
+    with _patch_client(client):
+        out = _bedrock.embed_texts(
+            ["hello"], "cohere.embed-english-v3", model_kwargs={"input_type": "search_query"}, use_threads=False
+        )
+    body = json.loads(client.invoke_model.call_args.kwargs["body"])
+    assert body == {"texts": ["hello"], "input_type": "search_query"}
+    assert out == [[0.7, 0.8]]
+
+
+def test_bedrock_unknown_model_raises() -> None:
+    with pytest.raises(exceptions.InvalidArgument):
+        _bedrock.embed_texts(["hello"], "unknown.model", use_threads=False)
+
+
+def test_bedrock_empty_texts_skips_invoke() -> None:
+    client = MagicMock()
+    with _patch_client(client):
+        out = _bedrock.embed_texts([], "amazon.titan-embed-text-v2:0", use_threads=False)
+    assert out == []
+    client.invoke_model.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Management — buckets and indexes
+# ---------------------------------------------------------------------------
+
+
+def test_create_vector_bucket_returns_arn() -> None:
+    client = MagicMock()
+    client.create_vector_bucket.return_value = {"vectorBucketArn": "arn:aws:s3vectors:::bucket/b"}
+    with _patch_client(client):
+        out = wr.s3.create_vector_bucket(
+            "b", tags={"env": "test"}, sse_type="aws:kms", encryption_kms_key_arn="arn:aws:kms:::key/abc"
+        )
+    sent = client.create_vector_bucket.call_args.kwargs
+    assert sent["vectorBucketName"] == "b"
+    assert sent["encryptionConfiguration"] == {"sseType": "aws:kms", "kmsKeyArn": "arn:aws:kms:::key/abc"}
+    assert sent["tags"] == {"env": "test"}
+    assert out == "arn:aws:s3vectors:::bucket/b"
+
+
+def test_list_vector_buckets_paginates() -> None:
+    client = MagicMock()
+    client.list_vector_buckets.side_effect = [
+        {"vectorBuckets": [{"vectorBucketName": "b1"}], "nextToken": "tok"},
+        {"vectorBuckets": [{"vectorBucketName": "b2"}]},
+    ]
+    with _patch_client(client):
+        out = wr.s3.list_vector_buckets()
+    assert [b["vectorBucketName"] for b in out] == ["b1", "b2"]
+
+
+def test_create_vector_index_payload() -> None:
+    client = MagicMock()
+    client.create_index.return_value = {"indexArn": "arn:idx"}
+    with _patch_client(client):
+        out = wr.s3.create_vector_index(
+            vector_bucket="b",
+            name="i",
+            dimension=384,
+            distance_metric="cosine",
+            non_filterable_metadata_keys=["raw_text"],
+        )
+    sent = client.create_index.call_args.kwargs
+    assert sent["indexName"] == "i"
+    assert sent["dimension"] == 384
+    assert sent["dataType"] == "float32"
+    assert sent["distanceMetric"] == "cosine"
+    assert sent["vectorBucketName"] == "b"
+    assert sent["metadataConfiguration"] == {"nonFilterableMetadataKeys": ["raw_text"]}
+    assert out == "arn:idx"
+
+
+def test_delete_vector_index_accepts_arn() -> None:
+    client = MagicMock()
+    client.delete_index.return_value = {}
+    with _patch_client(client):
+        wr.s3.delete_vector_index(arn="arn:aws:s3vectors:::bucket/b/index/i")
+    assert client.delete_index.call_args.kwargs == {"indexArn": "arn:aws:s3vectors:::bucket/b/index/i"}
+
+
+def test_delete_vector_index_accepts_name_plus_bucket() -> None:
+    client = MagicMock()
+    client.delete_index.return_value = {}
+    with _patch_client(client):
+        wr.s3.delete_vector_index(name="i", vector_bucket="b")
+    sent = client.delete_index.call_args.kwargs
+    assert sent == {"indexName": "i", "vectorBucketName": "b"}
+
+
+def test_delete_vector_index_arn_with_name_raises() -> None:
+    with pytest.raises(exceptions.InvalidArgumentCombination):
+        wr.s3.delete_vector_index(arn="arn:idx", name="i", vector_bucket="b")

--- a/tutorials/043 - Amazon S3 Vectors.ipynb
+++ b/tutorials/043 - Amazon S3 Vectors.ipynb
@@ -1,0 +1,759 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![AWS SDK for pandas](_static/logo.png \"AWS SDK for pandas\")](https://github.com/aws/aws-sdk-pandas)\n",
+    "\n",
+    "# 43 - Amazon S3 Vectors\n",
+    "\n",
+    "[Amazon S3 Vectors](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-vectors.html) provides cost-optimized native vector storage on S3 for similarity search and RAG. The hierarchy is **vector bucket** → **vector index** → **vectors**, where each vector is a tuple of `(key, float32[], metadata)`.\n",
+    "\n",
+    "AWS SDK for pandas wraps the `s3vectors` boto3 service and exposes 14 functions on `wr.s3` covering the full bucket / index / data lifecycle, with DataFrame-friendly I/O and optional on-the-fly embedding via Amazon Bedrock."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import getpass\n",
+    "\n",
+    "import pandas as pd\n",
+    "\n",
+    "import awswrangler as wr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bucket_name = getpass.getpass(\"Enter a vector bucket name:\")\n",
+    "index_name = \"tutorial\"\n",
+    "# Match the embedding model's output dimension. Titan v2 supports 256, 512, or 1024.\n",
+    "dimension = 256"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating resources\n",
+    "\n",
+    "A vector bucket holds many indexes; an index has a fixed dimension and distance metric and holds the actual vectors. All vectors written to an index must match its dimension."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Vector bucket ARN: arn:aws:s3vectors:eu-west-1:123456789012:bucket/test-aws-sdk-pandas-s3-vectors-1\n"
+     ]
+    }
+   ],
+   "source": [
+    "bucket_arn = wr.s3.create_vector_bucket(name=bucket_name)\n",
+    "print(f\"Vector bucket ARN: {bucket_arn}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Vector index ARN: arn:aws:s3vectors:eu-west-1:123456789012:bucket/test-aws-sdk-pandas-s3-vectors-1/index/tutorial\n"
+     ]
+    }
+   ],
+   "source": [
+    "index_arn = wr.s3.create_vector_index(\n",
+    "    vector_bucket=bucket_name,\n",
+    "    name=index_name,\n",
+    "    dimension=dimension,\n",
+    "    distance_metric=\"cosine\",\n",
+    ")\n",
+    "print(f\"Vector index ARN: {index_arn}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Discovery\n",
+    "\n",
+    "`list_vector_buckets`, `get_vector_bucket`, `list_vector_indexes`, and `get_vector_index` describe what's in an account / bucket. List operations paginate internally."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Buckets: ['test-aws-sdk-pandas-s3-vectors-1']\n",
+      "This bucket: {'vectorBucketName': 'test-aws-sdk-pandas-s3-vectors-1', 'vectorBucketArn': 'arn:aws:s3vectors:eu-west-1:123456789012:bucket/test-aws-sdk-pandas-s3-vectors-1', 'creationTime': datetime.datetime(2026, 5, 10, 0, 47, 57, tzinfo=tzlocal()), 'encryptionConfiguration': {'sseType': 'AES256'}}\n",
+      "Indexes: ['tutorial']\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'vectorBucketName': 'test-aws-sdk-pandas-s3-vectors-1',\n",
+       " 'indexName': 'tutorial',\n",
+       " 'indexArn': 'arn:aws:s3vectors:eu-west-1:123456789012:bucket/test-aws-sdk-pandas-s3-vectors-1/index/tutorial',\n",
+       " 'creationTime': datetime.datetime(2026, 5, 10, 0, 48, tzinfo=tzlocal()),\n",
+       " 'dataType': 'float32',\n",
+       " 'dimension': 256,\n",
+       " 'distanceMetric': 'cosine',\n",
+       " 'encryptionConfiguration': {'sseType': 'AES256'}}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "print(\"Buckets:\", [b[\"vectorBucketName\"] for b in wr.s3.list_vector_buckets()])\n",
+    "print(\"This bucket:\", wr.s3.get_vector_bucket(name=bucket_name))\n",
+    "print(\"Indexes:\", [i[\"indexName\"] for i in wr.s3.list_vector_indexes(vector_bucket=bucket_name)])\n",
+    "wr.s3.get_vector_index(name=index_name, vector_bucket=bucket_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Writing vectors\n",
+    "\n",
+    "`put_vectors_from_df` is the DataFrame entry point. The most natural workflow is to pass `text_column` together with a Bedrock embedding model — awswrangler then calls Bedrock for each row and writes the resulting vectors plus any other columns as metadata.\n",
+    "\n",
+    "> **Prerequisite:** the calling identity needs `bedrock:InvokeModel` permission and **Bedrock model access** for the chosen embedding model in the current region (request access in the Bedrock console). Supported model id prefixes: `amazon.titan-embed-text-*`, `cohere.embed-*`.\n",
+    "\n",
+    "If you already have embeddings (computed by your own model or a different SDK), pass them as a column instead via `vector_column`:\n",
+    "\n",
+    "```python\n",
+    "wr.s3.put_vectors_from_df(\n",
+    "    df=my_df,\n",
+    "    key_column=\"id\",\n",
+    "    vector_column=\"embedding\",  # precomputed list[float] / np.ndarray per row\n",
+    "    vector_bucket=bucket_name,\n",
+    "    index=index_name,\n",
+    ")\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>title</th>\n",
+       "      <th>genre</th>\n",
+       "      <th>year</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>m-1</td>\n",
+       "      <td>A wildlife photographer documents the rebirth ...</td>\n",
+       "      <td>documentary</td>\n",
+       "      <td>2022</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>m-2</td>\n",
+       "      <td>An investigative reporter uncovers fraud at a ...</td>\n",
+       "      <td>drama</td>\n",
+       "      <td>2019</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>m-3</td>\n",
+       "      <td>A coming-of-age comedy about siblings inheriti...</td>\n",
+       "      <td>comedy</td>\n",
+       "      <td>2024</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>m-4</td>\n",
+       "      <td>A heart-warming tale of an elderly widower and...</td>\n",
+       "      <td>drama</td>\n",
+       "      <td>2023</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>m-5</td>\n",
+       "      <td>A documentary tracing the history of jazz from...</td>\n",
+       "      <td>documentary</td>\n",
+       "      <td>2018</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    id                                              title        genre  year\n",
+       "0  m-1  A wildlife photographer documents the rebirth ...  documentary  2022\n",
+       "1  m-2  An investigative reporter uncovers fraud at a ...        drama  2019\n",
+       "2  m-3  A coming-of-age comedy about siblings inheriti...       comedy  2024\n",
+       "3  m-4  A heart-warming tale of an elderly widower and...        drama  2023\n",
+       "4  m-5  A documentary tracing the history of jazz from...  documentary  2018"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"id\": [\"m-1\", \"m-2\", \"m-3\", \"m-4\", \"m-5\"],\n",
+    "        \"title\": [\n",
+    "            \"A wildlife photographer documents the rebirth of a forest after a wildfire.\",\n",
+    "            \"An investigative reporter uncovers fraud at a multinational bank.\",\n",
+    "            \"A coming-of-age comedy about siblings inheriting a struggling family bakery.\",\n",
+    "            \"A heart-warming tale of an elderly widower and a stray dog.\",\n",
+    "            \"A documentary tracing the history of jazz from New Orleans to Tokyo.\",\n",
+    "        ],\n",
+    "        \"genre\": [\"documentary\", \"drama\", \"comedy\", \"drama\", \"documentary\"],\n",
+    "        \"year\": [2022, 2019, 2024, 2023, 2018],\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wr.s3.put_vectors_from_df(\n",
+    "    df=df,\n",
+    "    key_column=\"id\",\n",
+    "    text_column=\"title\",\n",
+    "    bedrock_model_id=\"amazon.titan-embed-text-v2:0\",\n",
+    "    bedrock_model_kwargs={\"dimensions\": dimension},\n",
+    "    vector_bucket=bucket_name,\n",
+    "    index=index_name,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Querying by text\n",
+    "\n",
+    "`query_vectors` runs an approximate-nearest-neighbour search. Pass `query_text` + `bedrock_model_id` to embed the query on the fly, or `query_vector` to query with a precomputed embedding (shown later)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>key</th>\n",
+       "      <th>distance</th>\n",
+       "      <th>metadata</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>m-4</td>\n",
+       "      <td>0.560630</td>\n",
+       "      <td>{'year': 2023, 'genre': 'drama'}</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>m-2</td>\n",
+       "      <td>0.701137</td>\n",
+       "      <td>{'genre': 'drama', 'year': 2019}</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>m-5</td>\n",
+       "      <td>0.751206</td>\n",
+       "      <td>{'year': 2018, 'genre': 'documentary'}</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   key  distance                                metadata\n",
+       "0  m-4  0.560630        {'year': 2023, 'genre': 'drama'}\n",
+       "1  m-2  0.701137        {'genre': 'drama', 'year': 2019}\n",
+       "2  m-5  0.751206  {'year': 2018, 'genre': 'documentary'}"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "wr.s3.query_vectors(\n",
+    "    query_text=\"a touching story about loneliness and companionship\",\n",
+    "    bedrock_model_id=\"amazon.titan-embed-text-v2:0\",\n",
+    "    bedrock_model_kwargs={\"dimensions\": dimension},\n",
+    "    top_k=3,\n",
+    "    return_distance=True,\n",
+    "    return_metadata=True,\n",
+    "    vector_bucket=bucket_name,\n",
+    "    index=index_name,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Filtering on metadata\n",
+    "\n",
+    "Filters use MongoDB-style operators (`$eq`, `$ne`, `$gt`, `$gte`, `$lt`, `$lte`, `$in`, `$nin`, `$exists`, `$and`, `$or`). They are evaluated *during* the search, not as a post-filter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>key</th>\n",
+       "      <th>distance</th>\n",
+       "      <th>metadata</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>m-1</td>\n",
+       "      <td>0.776892</td>\n",
+       "      <td>{'year': 2022, 'genre': 'documentary'}</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   key  distance                                metadata\n",
+       "0  m-1  0.776892  {'year': 2022, 'genre': 'documentary'}"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "wr.s3.query_vectors(\n",
+    "    query_text=\"music history\",\n",
+    "    bedrock_model_id=\"amazon.titan-embed-text-v2:0\",\n",
+    "    bedrock_model_kwargs={\"dimensions\": dimension},\n",
+    "    top_k=5,\n",
+    "    filter={\"$and\": [{\"genre\": {\"$eq\": \"documentary\"}}, {\"year\": {\"$gte\": 2020}}]},\n",
+    "    return_metadata=True,\n",
+    "    vector_bucket=bucket_name,\n",
+    "    index=index_name,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Working with vectors directly\n",
+    "\n",
+    "`get_vectors` retrieves vectors by key, optionally returning the embedding data and/or metadata. Useful for inspection, re-querying, or exporting subsets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>key</th>\n",
+       "      <th>vector</th>\n",
+       "      <th>metadata</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>m-3</td>\n",
+       "      <td>[-0.03277716785669327, 0.10634636878967285, 0....</td>\n",
+       "      <td>{'year': 2024, 'genre': 'comedy'}</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>m-1</td>\n",
+       "      <td>[-0.12095249444246292, 0.10887987911701202, 0....</td>\n",
+       "      <td>{'year': 2022, 'genre': 'documentary'}</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   key                                             vector  \\\n",
+       "0  m-3  [-0.03277716785669327, 0.10634636878967285, 0....   \n",
+       "1  m-1  [-0.12095249444246292, 0.10887987911701202, 0....   \n",
+       "\n",
+       "                                 metadata  \n",
+       "0       {'year': 2024, 'genre': 'comedy'}  \n",
+       "1  {'year': 2022, 'genre': 'documentary'}  "
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fetched = wr.s3.get_vectors(\n",
+    "    keys=[\"m-1\", \"m-3\"],\n",
+    "    return_data=True,\n",
+    "    return_metadata=True,\n",
+    "    vector_bucket=bucket_name,\n",
+    "    index=index_name,\n",
+    ")\n",
+    "fetched"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Querying with a precomputed vector\n",
+    "\n",
+    "Any `list[float]` / `np.ndarray` of the right dimension works. Here we re-use a vector we just fetched — in practice, this is where you'd plug in embeddings from your own model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>key</th>\n",
+       "      <th>distance</th>\n",
+       "      <th>metadata</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>m-3</td>\n",
+       "      <td>0.000384</td>\n",
+       "      <td>{'genre': 'comedy', 'year': 2024}</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>m-2</td>\n",
+       "      <td>0.733959</td>\n",
+       "      <td>{'genre': 'drama', 'year': 2019}</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>m-4</td>\n",
+       "      <td>0.755624</td>\n",
+       "      <td>{'year': 2023, 'genre': 'drama'}</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   key  distance                           metadata\n",
+       "0  m-3  0.000384  {'genre': 'comedy', 'year': 2024}\n",
+       "1  m-2  0.733959   {'genre': 'drama', 'year': 2019}\n",
+       "2  m-4  0.755624   {'year': 2023, 'genre': 'drama'}"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "wr.s3.query_vectors(\n",
+    "    query_vector=fetched.iloc[0][\"vector\"],\n",
+    "    top_k=3,\n",
+    "    return_distance=True,\n",
+    "    return_metadata=True,\n",
+    "    vector_bucket=bucket_name,\n",
+    "    index=index_name,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Deleting vectors by key"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wr.s3.delete_vectors(\n",
+    "    keys=[\"m-3\"],\n",
+    "    vector_bucket=bucket_name,\n",
+    "    index=index_name,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Bulk export\n",
+    "\n",
+    "`list_vectors` walks the entire index. With `use_threads=True` it parallelises across up to 16 segments under the hood; pass `return_data=True` / `return_metadata=True` to include the full payload."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>key</th>\n",
+       "      <th>metadata</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>m-1</td>\n",
+       "      <td>{'year': 2022, 'genre': 'documentary'}</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>m-5</td>\n",
+       "      <td>{'genre': 'documentary', 'year': 2018}</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>m-4</td>\n",
+       "      <td>{'year': 2023, 'genre': 'drama'}</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>m-2</td>\n",
+       "      <td>{'genre': 'drama', 'year': 2019}</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   key                                metadata\n",
+       "0  m-1  {'year': 2022, 'genre': 'documentary'}\n",
+       "1  m-5  {'genre': 'documentary', 'year': 2018}\n",
+       "2  m-4        {'year': 2023, 'genre': 'drama'}\n",
+       "3  m-2        {'genre': 'drama', 'year': 2019}"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "wr.s3.list_vectors(\n",
+    "    return_metadata=True,\n",
+    "    vector_bucket=bucket_name,\n",
+    "    index=index_name,\n",
+    "    use_threads=4,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cleanup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wr.s3.delete_vector_index(name=index_name, vector_bucket=bucket_name)\n",
+    "wr.s3.delete_vector_bucket(name=bucket_name)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "awsdkpandas (.venv)",
+   "language": "python",
+   "name": "awsdkpandas"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <4.0"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -520,7 +520,7 @@ sqlserver = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "boto3-stubs", extra = ["athena", "chime", "cleanrooms", "cloudwatch", "dynamodb", "ec2", "emr", "emr-serverless", "glue", "kms", "logs", "neptune", "opensearch", "opensearchserverless", "quicksight", "rds", "rds-data", "redshift", "redshift-data", "s3", "secretsmanager", "ssm", "sts", "timestream-query", "timestream-write"] },
+    { name = "boto3-stubs", extra = ["athena", "bedrock-runtime", "chime", "cleanrooms", "cloudwatch", "dynamodb", "ec2", "emr", "emr-serverless", "glue", "kms", "logs", "neptune", "opensearch", "opensearchserverless", "quicksight", "rds", "rds-data", "redshift", "redshift-data", "s3", "s3vectors", "secretsmanager", "ssm", "sts", "timestream-query", "timestream-write"] },
     { name = "bump-my-version" },
     { name = "doc8" },
     { name = "ipython" },
@@ -590,7 +590,7 @@ provides-extras = ["redshift", "mysql", "postgres", "sqlserver", "oracle", "grem
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "boto3-stubs", extras = ["athena", "cleanrooms", "chime", "cloudwatch", "dynamodb", "ec2", "emr", "emr-serverless", "glue", "kms", "logs", "neptune", "opensearch", "opensearchserverless", "quicksight", "rds", "rds-data", "redshift", "redshift-data", "s3", "secretsmanager", "ssm", "sts", "timestream-query", "timestream-write"], specifier = ">=1.36.2,<2" },
+    { name = "boto3-stubs", extras = ["athena", "bedrock-runtime", "cleanrooms", "chime", "cloudwatch", "dynamodb", "ec2", "emr", "emr-serverless", "glue", "kms", "logs", "neptune", "opensearch", "opensearchserverless", "quicksight", "rds", "rds-data", "redshift", "redshift-data", "s3", "s3vectors", "secretsmanager", "ssm", "sts", "timestream-query", "timestream-write"], specifier = ">=1.36.2,<2" },
     { name = "bump-my-version", specifier = ">=0.29,<1.4" },
     { name = "doc8", specifier = ">=1.1,<3.0" },
     { name = "ipython", specifier = ">=8.18.1,<9" },
@@ -693,6 +693,9 @@ wheels = [
 athena = [
     { name = "mypy-boto3-athena" },
 ]
+bedrock-runtime = [
+    { name = "mypy-boto3-bedrock-runtime" },
+]
 chime = [
     { name = "mypy-boto3-chime" },
 ]
@@ -749,6 +752,9 @@ redshift-data = [
 ]
 s3 = [
     { name = "mypy-boto3-s3" },
+]
+s3vectors = [
+    { name = "mypy-boto3-s3vectors" },
 ]
 secretsmanager = [
     { name = "mypy-boto3-secretsmanager" },
@@ -2882,6 +2888,18 @@ wheels = [
 ]
 
 [[package]]
+name = "mypy-boto3-bedrock-runtime"
+version = "1.42.82"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/e0/4f43d520e47ae75d7d1650792e2f8930a710c01c22647d9c8ed439d2193c/mypy_boto3_bedrock_runtime-1.42.82.tar.gz", hash = "sha256:889fa422df0b64b24c134df52e873554cb54582f7a9664bb81a5507b4b908081", size = 29909, upload-time = "2026-04-02T19:59:11.835Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/61/7d76a3713232ed5f7f319fa2345da07d45a31e39f44d113e525d96a0ba44/mypy_boto3_bedrock_runtime-1.42.82-py3-none-any.whl", hash = "sha256:a8beda7040f38fb41b738b2ae66c71bf38c638eaecadd20599caf114a84bf639", size = 36162, upload-time = "2026-04-02T19:59:10.627Z" },
+]
+
+[[package]]
 name = "mypy-boto3-chime"
 version = "1.42.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3107,6 +3125,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/b3/d2cdd49f272add9a178a1a238f6bdd80f0e6b503506b002e727ba699f23a/mypy_boto3_s3-1.42.67.tar.gz", hash = "sha256:3a3a918a9949f2d6f8071d490b8968ddce634aa19590697537e5189cbdca403e", size = 76415, upload-time = "2026-03-12T20:02:08.476Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/a5/7d4a7bb51c7bb9b188f306555bfcf5537c7f0524964350ff9d04d86e0786/mypy_boto3_s3-1.42.67-py3-none-any.whl", hash = "sha256:93208799734611da4caa5fa8f5ce677b62758ddcd34b737b9f7ae471d179b95e", size = 83570, upload-time = "2026-03-12T20:02:04.391Z" },
+]
+
+[[package]]
+name = "mypy-boto3-s3vectors"
+version = "1.42.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/5b/5dd79687c3ef0ad3f7fc09cde91437e4d5fe914864e34937a4765e97e0e5/mypy_boto3_s3vectors-1.42.3.tar.gz", hash = "sha256:6a89e611607f0205ae31a8470134bb0926cc126c7104579f9dbb7c5ee236750d", size = 18487, upload-time = "2025-12-04T21:11:57.659Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/00/0d2191efa38f64867b5b9ebd025c3fde0eec9b96b947aa5acd05cfe3c856/mypy_boto3_s3vectors-1.42.3-py3-none-any.whl", hash = "sha256:e55f78fec625181c788a306782e28a415a23dee4a063970d6beab0b9d4fa3ba3", size = 24478, upload-time = "2025-12-04T21:11:55.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
  ### Feature or Bugfix
  - Feature

  ### Detail

  Add first-class Amazon S3 Vectors support to AWS SDK for pandas, turning a DataFrame into a queryable semantic index and closing the loop for cost-optimised RAG workflows on AWS.

  End-to-end walkthrough: [tutorials/043 - Amazon S3 Vectors.ipynb](https://github.com/aws/aws-sdk-pandas/blob/95356c166334e25c37882ddb5b8c7056bd8d6b79/tutorials/043%20-%20Amazon%20S3%20Vectors.ipynb).

  Example:

  ```python
  import awswrangler as wr
  import pandas as pd

  df = pd.DataFrame(
      {
          "id": ["m-1", "m-2", "m-3", "m-4", "m-5"],
          "title": [
              "A wildlife photographer documents the rebirth of a forest after a wildfire.",
              "An investigative reporter uncovers fraud at a multinational bank.",
              "A coming-of-age comedy about siblings inheriting a struggling family bakery.",
              "A heart-warming tale of an elderly widower and a stray dog.",
              "A documentary tracing the history of jazz from New Orleans to Tokyo.",
          ],
          "genre": ["documentary", "drama", "comedy", "drama", "documentary"],
          "year": [2022, 2019, 2024, 2023, 2018],
      }
  )

  # Index a DataFrame — Bedrock embeds each row's `title` on the fly,
  # every other column flows through as filterable metadata.
  wr.s3.put_vectors_from_df(
      df=movies,
      key_column="id",
      text_column="title",
      bedrock_model_id="amazon.titan-embed-text-v2:0",
      bedrock_model_kwargs={"dimensions": 256},
      vector_bucket="movies-bucket",
      index="catalog",
  )

  # Query — natural language in, ranked DataFrame out, with metadata filtering.
  results = wr.s3.query_vectors(
      query_text="a heart-warming story about loneliness and friendship",
      bedrock_model_id="amazon.titan-embed-text-v2:0",
      bedrock_model_kwargs={"dimensions": 256},
      top_k=5,
      filter={"$and": [{"genre": {"$eq": "drama"}}, {"year": {"$gte": 2020}}]},
      vector_bucket="movies-bucket",
      index="catalog",
  )
  ```

  #### What's shipping

  14 new functions on `wr.s3`, covering the full lifecycle of [Amazon S3 Vectors](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-vectors.html) (boto3 service `s3vectors`, API version 2025-07-15):

  | Group   | Functions |
  |---------|-----------|
  | Buckets | `create_vector_bucket`, `delete_vector_bucket`, `list_vector_buckets`, `get_vector_bucket` |
  | Indexes | `create_vector_index`, `delete_vector_index`, `list_vector_indexes`, `get_vector_index` |
  | Data    | `put_vectors`, `put_vectors_from_df`, `get_vectors`, `delete_vectors`, `list_vectors`, `query_vectors` |

  #### Design highlights

  - **DataFrame-first, embedding included.** `put_vectors_from_df` accepts either a precomputed `vector_column` or a `text_column` + `bedrock_model_id` and embeds via Amazon Bedrock
  (Titan, Cohere) on the fly. `query_vectors` mirrors this with `query_vector` / `query_text`. Users go from "I have a CSV of documents" to "queryable index" without leaving awswrangler.
  - **MongoDB-style metadata filters** (`$eq`, `$ne`, `$gt`, `$gte`, `$lt`, `$lte`, `$in`, `$nin`, `$exists`, `$and`, `$or`) pass straight through to `QueryVectors` and are evaluated
  server-side *during* search — so filtered queries actually find matches instead of post-filtering the top-k away.
  - **Production-grade chunking and parallelism.** Calls split to AWS API limits automatically (500/put, 100/get, 500/delete, 1000/list-page); `list_vectors` uses up to 16 parallel
  `segmentCount` workers per the service's parallel-list contract. Float32 coercion + non-finite rejection happens client-side; `NaN` / `pd.NA` / `None` metadata cells are dropped per
  row.
  - **Private subpackage, flat public surface.** Implementation lives in `awswrangler/s3/_vectors/` (split into `_mgmt.py`, `_read.py`, `_write.py`, `_utils.py`, `_bedrock.py`) and is
  re-exported flat as `wr.s3.create_vector_bucket(...)`, `wr.s3.query_vectors(...)`, etc., matching the existing s3_tables convention. The internal layout mirrors `awswrangler/dynamodb/`
  and `awswrangler/opensearch/`.

  #### Tests

  - 46 mocked unit tests in `tests/unit/test_s3_vectors_mocked.py`. No AWS required — exercise chunking, parameter resolution, float32 behaviour, NaN/`pd.NA` handling, parallel-segment list, query top-k bounds, Bedrock Titan/Cohere request/response shapes, and aliasing identity. Full run in ~100ms.
  - 10 live integration tests in `tests/unit/test_s3_vectors.py` using new `vector_bucket` (session-scope) and `vector_index` (function-scope) fixtures in `tests/conftest.py`. Fixtures self-bootstrap via the new `wr.s3.create_vector_bucket` / `create_vector_index` — no CDK stack needed.

  #### Out of scope (explicit follow-ups)

  - Tag operations (`TagResource`, `UntagResource`, `ListTagsForResource`) — tags still settable on `Create*` calls.
  - Bucket policy operations.
  - Public namespace exposure (`wr.s3.vectors.*`) and `DeprecationWarning` on the flat aliases — to be coordinated with an analogous `s3_tables` refactor.

  ### Relates

  - Amazon S3 Vectors announcement: https://aws.amazon.com/blogs/aws/introducing-amazon-s3-vectors-first-cloud-storage-with-native-vector-support-at-scale/
  - S3 Vectors user guide: https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-vectors.html
  - S3 Vectors API reference: https://docs.aws.amazon.com/AmazonS3/latest/API/API_Operations_Amazon_S3_Vectors.html

  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.