### PR TITLE
fix(lambda-layer): disable utf8proc to drop ~35MB libicu dependency (…

### DIFF
--- a/building/lambda/build-lambda-layer.sh
+++ b/building/lambda/build-lambda-layer.sh
@@ -46,6 +46,7 @@ cmake \
     -DARROW_WITH_ZSTD=OFF \
     -DARROW_WITH_LZ4=OFF \
     -DARROW_WITH_BROTLI=OFF \
+    -DARROW_WITH_UTF8PROC=OFF \
     -DARROW_BUILD_TESTS=OFF \
     -GNinja \
     ..

--- a/building/lambda/build-lambda-layer.sh
+++ b/building/lambda/build-lambda-layer.sh
@@ -112,7 +112,7 @@ find python -regex '^.*\(__pycache__\|\.py[co]\)$' -delete
 # is on LD_LIBRARY_PATH. Search ldconfig cache first, then fall back to a
 # filesystem search (libatomic under gcc10 lives in /usr/lib/gcc/*).
 mkdir -p lib
-for libfile in libxslt.so.1 libexslt.so.0 libatomic.so.1 libicudata.so.67 libicui18n.so.67 libicuuc.so.67; do
+for libfile in libxslt.so.1 libexslt.so.0 libatomic.so.1; do
   src=$(ldconfig -p 2>/dev/null | awk -v lib="${libfile}" '$1 == lib { print $NF; exit }')
   if [ -z "${src}" ] || [ ! -e "${src}" ]; then
     src=$(find /usr/lib /usr/lib64 -name "${libfile}" -print -quit 2>/dev/null)


### PR DESCRIPTION
Fixes #3331

## Problem
Layer size jumped from 167MB to 204MB in 3.16.1 (+37MB, +22%), breaking Lambda
deployments that hit the 250MB unzipped limit. The culprit: building pyarrow 22
with `ARROW_COMPUTE=ON` auto-enables `utf8proc`, which on AL2023 dynamically
links against three libicu shared libraries (~35MB combined).
Commit 56f12d8 bundled them for runtime compatibility, causing the size spike.

## Fix
Two changes to `building/lambda/build-lambda-layer.sh`:

1. Add `-DARROW_WITH_UTF8PROC=OFF` to the cmake invocation — breaks the
   utf8proc → libicu chain at build time.
2. Remove `libicudata.so.67 libicui18n.so.67 libicuuc.so.67` from the
   library bundle loop — they are no longer needed at runtime.

Expected layer size reduction: ~35MB, bringing the layer back to ~169MB.

## Tradeoff
Unicode normalization in Arrow compute kernels is disabled. This has no effect
on awswrangler's usage of Arrow (Parquet/CSV/JSON I/O and type casting only).

## Changes
- `building/lambda/build-lambda-layer.sh`: add cmake flag, trim bundle loop