### PR TITLE
fix(redshift): preserve column names with spaces in wr.redshift.copy(…

### DIFF
--- a/awswrangler/redshift/_write.py
+++ b/awswrangler/redshift/_write.py
@@ -724,9 +724,7 @@ def copy(  # noqa: PLR0913
             s3_additional_kwargs=s3_additional_kwargs,
             max_rows_by_file=max_rows_by_file,
             pyarrow_additional_kwargs={"flavor": None},
-
-
-)
+        )
         copy_from_files(
             path=path,
             con=con,

--- a/awswrangler/redshift/_write.py
+++ b/awswrangler/redshift/_write.py
@@ -723,7 +723,10 @@ def copy(  # noqa: PLR0913
             boto3_session=boto3_session,
             s3_additional_kwargs=s3_additional_kwargs,
             max_rows_by_file=max_rows_by_file,
-        )
+            pyarrow_additional_kwargs={"flavor": None},
+
+
+)
         copy_from_files(
             path=path,
             con=con,

--- a/tests/unit/test_redshift.py
+++ b/tests/unit/test_redshift.py
@@ -1657,3 +1657,34 @@ def test_copy_serialize_to_json_super(
     df_res["text"] = df_res["text"].apply(json.loads)
 
     assert_pandas_equals(df, df_res)
+
+def test_copy_preserves_column_names_with_spaces() -> None:
+    """wr.redshift.copy() must pass flavor=None so column names with spaces
+    are not sanitized by pyarrow before writing to the Redshift staging path.
+    See: https://github.com/aws/aws-sdk-pandas/issues/3293
+    """
+    from unittest.mock import MagicMock, call, patch
+
+    df = pd.DataFrame({"my col": [1, 2, 3], "other col": ["a", "b", "c"]})
+
+    with patch("awswrangler.redshift._write.s3.to_parquet") as mock_to_parquet, \
+         patch("awswrangler.redshift._write.copy_from_files"), \
+         patch("awswrangler.redshift._write.s3.delete_objects"), \
+         patch("awswrangler.redshift._write.s3.list_objects", return_value=[]):
+
+        try:
+            wr.redshift.copy(
+                df=df,
+                path="s3://fake-bucket/fake-path/",
+                con=MagicMock(),
+                table="test_table",
+                schema="public",
+                iam_role="arn:aws:iam::123456789012:role/fake-role",
+            )
+        except Exception:
+            pass
+
+        assert mock_to_parquet.called
+        kwargs = mock_to_parquet.call_args.kwargs
+        assert "pyarrow_additional_kwargs" in kwargs
+        assert kwargs["pyarrow_additional_kwargs"].get("flavor") is None


### PR DESCRIPTION
Fixes #3293

## Problem
`wr.redshift.copy()` silently renames DataFrame columns containing spaces
before writing them to S3 (e.g. `"my col"` → `"my_col"`). The Redshift COPY
then fails with `column "my col" of relation "..." does not exist` because the
DDL was generated from the original column names.

## Root Cause
`s3.to_parquet()` defaults to `flavor="spark"` which calls pyarrow's
`sanitize_pandas_metadata`, replacing spaces with underscores in column names.
The internal call in `copy()` did not override this default.

## Fix
Pass `pyarrow_additional_kwargs={"flavor": None}` to the internal `s3.to_parquet()`
call in `wr.redshift.copy()`. The default is only applied when `"flavor"` is
absent, so passing `None` explicitly suppresses the sanitization.

## Changes
- `awswrangler/redshift/_write.py`: add `pyarrow_additional_kwargs={"flavor": None}`
  to the `s3.to_parquet()` call inside `copy()`
