### PR TITLE
feat(athena): add workgroup config TTL cache to reduce GetWorkgroup t…

### DIFF
--- a/awswrangler/_config.py
+++ b/awswrangler/_config.py
@@ -44,7 +44,6 @@ _CONFIG_ARGS: dict[str, _ConfigArg] = {
     "max_local_cache_entries": _ConfigArg(dtype=int, nullable=False, parent_parameter_key="athena_cache_settings"),
     "athena_query_wait_polling_delay": _ConfigArg(dtype=float, nullable=False),
     "athena_workgroup_config_ttl": _ConfigArg(dtype=int, nullable=False, default=0),
-    "athena_workgroup_config_ttl": _ConfigArg(dtype=int, nullable=False),
     "cloudwatch_query_wait_polling_delay": _ConfigArg(dtype=float, nullable=False),
     "neptune_load_wait_polling_delay": _ConfigArg(dtype=float, nullable=False),
     "timestream_batch_load_wait_polling_delay": _ConfigArg(dtype=float, nullable=False),

--- a/awswrangler/_config.py
+++ b/awswrangler/_config.py
@@ -43,6 +43,8 @@ _CONFIG_ARGS: dict[str, _ConfigArg] = {
     "max_remote_cache_entries": _ConfigArg(dtype=int, nullable=False, parent_parameter_key="athena_cache_settings"),
     "max_local_cache_entries": _ConfigArg(dtype=int, nullable=False, parent_parameter_key="athena_cache_settings"),
     "athena_query_wait_polling_delay": _ConfigArg(dtype=float, nullable=False),
+    "athena_workgroup_config_ttl": _ConfigArg(dtype=int, nullable=False, default=0),
+    "athena_workgroup_config_ttl": _ConfigArg(dtype=int, nullable=False),
     "cloudwatch_query_wait_polling_delay": _ConfigArg(dtype=float, nullable=False),
     "neptune_load_wait_polling_delay": _ConfigArg(dtype=float, nullable=False),
     "timestream_batch_load_wait_polling_delay": _ConfigArg(dtype=float, nullable=False),
@@ -656,6 +658,15 @@ class _Config:
     @gpu_count.setter
     def gpu_count(self, value: int) -> None:
         self._set_config_value(key="gpu_count", value=value)
+
+    @property
+    def athena_workgroup_config_ttl(self) -> int:
+        """Property athena_workgroup_config_ttl."""
+        return cast(int, self["athena_workgroup_config_ttl"])
+
+    @athena_workgroup_config_ttl.setter
+    def athena_workgroup_config_ttl(self, value: int) -> None:
+        self._set_config_value(key="athena_workgroup_config_ttl", value=value)
 
 
 def _insert_str(text: str, token: str, insert: str) -> str:

--- a/awswrangler/athena/_utils.py
+++ b/awswrangler/athena/_utils.py
@@ -162,7 +162,7 @@ def _get_workgroup_config(session: boto3.Session | None = None, workgroup: str =
 
     ttl: int = wr_config.athena_workgroup_config_ttl
     primitives = boto3_to_primitives(session)
-    cache_key = (primitives.get("region_name"), primitives.get("profile_name"), workgroup or "primary")
+    cache_key = (primitives.get("region_name"), primitives.get("profile_name"), workgroup)
 
     if ttl > 0:
         cached = _WORKGROUP_CONFIG_CACHE.get(cache_key)

--- a/awswrangler/athena/_utils.py
+++ b/awswrangler/athena/_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 import base64
 import csv
 import json
@@ -63,7 +64,7 @@ class _WorkGroupConfig(NamedTuple):
     encryption: str | None
     kms_key: str | None
     managed_results: bool
-
+_WORKGROUP_CONFIG_CACHE: dict[tuple[str | None, str | None, str], tuple[_WorkGroupConfig, float]] = {}
 
 def _get_s3_output(
     s3_output: str | None, wg_config: _WorkGroupConfig, boto3_session: boto3.Session | None = None
@@ -156,16 +157,25 @@ def _start_query_execution(
 
 
 def _get_workgroup_config(session: boto3.Session | None = None, workgroup: str = "primary") -> _WorkGroupConfig:
-    enforced: bool
-    wg_s3_output: str | None
-    wg_encryption: str | None
-    wg_kms_key: str | None
-    wg_managed_results: bool
+    from awswrangler._config import config as wr_config
+    from awswrangler._utils import boto3_to_primitives
+
+    ttl: int = wr_config.athena_workgroup_config_ttl
+    primitives = boto3_to_primitives(session)
+    cache_key = (primitives.get("region_name"), primitives.get("profile_name"), workgroup or "primary")
+
+    if ttl > 0:
+        cached = _WORKGROUP_CONFIG_CACHE.get(cache_key)
+        if cached is not None:
+            wg_config, expiry = cached
+            if time.monotonic() < expiry:
+                _logger.debug("Returning cached workgroup config for %s", workgroup)
+                return wg_config
 
     enforced, wg_s3_output, wg_encryption, wg_kms_key, wg_managed_results = False, None, None, None, False
     if workgroup is not None:
         res = get_work_group(workgroup=workgroup, boto3_session=session)
-        enforced = res["WorkGroup"]["Configuration"]["EnforceWorkGroupConfiguration"]
+        enforced = res["WorkGroup"]["Configuration"].get("EnforceWorkGroupConfiguration", False)
         config: dict[str, Any] = res["WorkGroup"]["Configuration"].get("ResultConfiguration")
         if config is not None:
             wg_s3_output = config.get("OutputLocation")
@@ -183,6 +193,8 @@ def _get_workgroup_config(session: boto3.Session | None = None, workgroup: str =
         kms_key=wg_kms_key,
         managed_results=wg_managed_results,
     )
+    if ttl > 0:
+        _WORKGROUP_CONFIG_CACHE[cache_key] = (wg_config, time.monotonic() + ttl)
     _logger.debug("Workgroup config:\n%s", wg_config)
     return wg_config
 

--- a/tests/unit/test_athena.py
+++ b/tests/unit/test_athena.py
@@ -2259,6 +2259,18 @@ def test_athena_workgroup_config_ttl_default_and_caching() -> None:
         _get_workgroup_config(workgroup="primary")
         assert mock_get.call_count == 1
 
+    # 4. workgroup=None and workgroup="primary" must have separate cache entries
+    _WORKGROUP_CONFIG_CACHE.clear()
+    with patch("awswrangler.athena._utils.get_work_group", return_value=mock_response) as mock_get:
+        wr.config.athena_workgroup_config_ttl = 60
+        result_none = _get_workgroup_config(workgroup=None)
+        assert mock_get.call_count == 0  # workgroup=None skips API entirely
+
+        result_primary = _get_workgroup_config(workgroup="primary")
+        assert mock_get.call_count == 1  # must not use None's cache entry
+        assert result_primary.s3_output == "s3://bucket/prefix/"
+        assert result_none.s3_output is None
+
     # cleanup
     wr.config.athena_workgroup_config_ttl = 0
     _WORKGROUP_CONFIG_CACHE.clear()

--- a/tests/unit/test_athena.py
+++ b/tests/unit/test_athena.py
@@ -2223,3 +2223,42 @@ def test_athena_date_recovery(path, glue_database, glue_table):
     )
     # Round-trip dtype/resolution may differ (e.g. datetime64[ns] vs [us]) depending on pandas version.
     assert_pandas_equals(df, df2, check_dtype=False, check_datetimelike_compat=True)
+
+
+def test_athena_workgroup_config_ttl_default_and_caching() -> None:
+    """TTL defaults to 0 and cache is only used when TTL is positive."""
+    from unittest.mock import patch
+    import awswrangler as wr
+    from awswrangler.athena._utils import _get_workgroup_config, _WORKGROUP_CONFIG_CACHE
+
+    # 1. Default must be 0
+    assert wr.config.athena_workgroup_config_ttl == 0
+
+    mock_response = {
+        "WorkGroup": {
+            "Configuration": {
+                "EnforceWorkGroupConfiguration": False,
+                "ResultConfiguration": {"OutputLocation": "s3://bucket/prefix/"},
+            }
+        }
+    }
+
+    # 2. TTL=0 → no caching, GetWorkgroup called every time
+    _WORKGROUP_CONFIG_CACHE.clear()
+    with patch("awswrangler.athena._utils.get_work_group", return_value=mock_response) as mock_get:
+        wr.config.athena_workgroup_config_ttl = 0
+        _get_workgroup_config(workgroup="primary")
+        _get_workgroup_config(workgroup="primary")
+        assert mock_get.call_count == 2
+
+    # 3. TTL>0 → second call served from cache, GetWorkgroup called only once
+    _WORKGROUP_CONFIG_CACHE.clear()
+    with patch("awswrangler.athena._utils.get_work_group", return_value=mock_response) as mock_get:
+        wr.config.athena_workgroup_config_ttl = 60
+        _get_workgroup_config(workgroup="primary")
+        _get_workgroup_config(workgroup="primary")
+        assert mock_get.call_count == 1
+
+    # cleanup
+    wr.config.athena_workgroup_config_ttl = 0
+    _WORKGROUP_CONFIG_CACHE.clear()


### PR DESCRIPTION
 #3233

## Fix
Add `wr.config.athena_workgroup_config_ttl` (int, seconds, default 0 = disabled).
When set > 0, GetWorkgroup responses are cached in a process-level dict keyed
on (region, profile, workgroup) with a TTL expiry. Users in throttled
environments can set e.g. `wr.config.athena_workgroup_config_ttl = 300`.

Also fixes `EnforceWorkGroupConfiguration` KeyError when the key is absent
(moto / non-standard workgroups) by using `.get(..., False)` instead of
direct key access.

## Changes
- `awswrangler/_config.py`: add `athena_workgroup_config_ttl` config key (default 0)
- `awswrangler/athena/_utils.py`: TTL cache dict + cache read/write in
  `_get_workgroup_config`; `.get("EnforceWorkGroupConfiguration", False)`