### PR TITLE
fix: use fixed microsecond value in test_time_unit_precision to preve…

### DIFF
--- a/tests/unit/test_timestream.py
+++ b/tests/unit/test_timestream.py
@@ -676,7 +676,7 @@ def test_batch_load(timestream_database_and_table, path, path2, time_unit, keep_
 def test_time_unit_precision(timestream_database_and_table, time_unit, precision):
     df_write = pd.DataFrame(
         {
-            "time": [datetime.now()] * 3,
+            "time": [datetime.now().replace(microsecond=123456)] * 3,
             "dim0": ["foo", "boo", "bar"],
             "dim1": [1, 2, 3],
             "measure0": ["a", "b", "c"],


### PR DESCRIPTION
Fixes #3166

### Problem
`test_time_unit_precision` was transiently failing ~10% of the time with:
```
AssertionError: assert 5 == 6
```

### Root Cause
`datetime.now()` can produce microseconds ending in `0` (e.g. `123450`). Python's `float.__repr__` silently strips trailing zeros, so `str(timestamp)` returns only 5 decimal places instead of 6. The assertion `len(...split(".")[1]) == precision` then fails.

### Fix
Replace `datetime.now()` with `datetime.now().replace(microsecond=123456)` in the test input. The value `123456` has no trailing zeros, guaranteeing the assertion passes deterministically for all four parametrized cases (`SECONDS`, `MILLISECONDS`, `MICROSECONDS`, `None`).

No changes to source code — `_write.py` is correct and unaffected.

### Files Changed
`tests/unit/test_timestream.py`