### PR TITLE
fix(s3): strip pandas metadata from schema in _read_parquet_chunked t…

### DIFF
--- a/awswrangler/s3/_read_parquet.py
+++ b/awswrangler/s3/_read_parquet.py
@@ -212,7 +212,32 @@ def _read_parquet_file(
             path=path,
             path_root=path_root,
         )
+ def _strip_pandas_metadata(schema: "pa.Schema") -> "pa.Schema":
 
+    """Return schema with the b'pandas' metadata key removed.
+
+
+    Parquet files written by pandas embed a full-file RangeIndex in
+
+    schema metadata. When reading in chunks each batch is only a slice
+
+    of the file, so applying the full-file index to a smaller table
+
+    raises ValueError. Removing the key lets PyArrow use a default
+
+    per-chunk RangeIndex instead.
+
+    """
+
+    existing = schema.metadata or {}
+
+    if b"pandas" not in existing:
+
+        return schema
+
+    filtered = {k: v for k, v in existing.items() if k != b"pandas"}
+
+    return schema.with_metadata(filtered)
 
 def _read_parquet_chunked(
     s3_client: "S3Client" | None,
@@ -252,6 +277,7 @@ def _read_parquet_chunked(
             schema = metadata.schema.to_arrow_schema()
             if columns:
                 schema = pa.schema([schema.field(column) for column in columns], schema.metadata)
+                schema = _strip_pandas_metadata(schema)
 
             use_threads_flag: bool = use_threads if isinstance(use_threads, bool) else bool(use_threads > 1)
             table_kwargs = {"path": path, "path_root": path_root}


### PR DESCRIPTION
## Problem
`wr.s3.read_parquet` with `chunked=True` or `chunked=<integer>` throws a `ValueError: Length mismatch` on parquet files written by pandas when using PyArrow >= 3.0.

## Root Cause
Pandas writes a full-file `RangeIndex` (e.g. `start=0, stop=6741043`) into the parquet schema metadata under the `b'pandas'` key. When reading in chunks, `iter_batches()` returns small slices (e.g. 65536 rows), but PyArrow >= 3.0 reads the full-file metadata and tries to apply the full-file index to the smaller chunk, causing the mismatch.

## Fix
Added a helper `_strip_pandas_metadata(schema)` in `awswrangler/s3/_read_parquet.py` that removes the `b'pandas'` key from the Arrow schema metadata before constructing each chunk's table inside `_read_parquet_chunked()`. PyArrow then falls back to a correct per-chunk `RangeIndex`.

## Changes
- `awswrangler/s3/_read_parquet.py` — added `_strip_pandas_metadata()` helper and one call inside `_read_parquet_chunked()`

## Testing
Reproducible with any pandas-written parquet file larger than the chunk size, using `chunked=True` or `chunked=<integer>` on PyArrow >= 3.0.

Fixes #769