### PR TITLE
fix(s3): stream wr.s3.download in chunks instead of loading whole object into memory

### DIFF
--- a/awswrangler/s3/_download.py
+++ b/awswrangler/s3/_download.py
@@ -11,6 +11,11 @@ from awswrangler.s3._fs import open_s3_object
 
 _logger: logging.Logger = logging.getLogger(__name__)
 
+# Size of the chunks read from S3 and written to the local file. Streaming the object in fixed
+# size chunks (instead of reading the whole object into memory at once) keeps memory usage bounded
+# and independent of the file size.
+_S3_DOWNLOAD_BLOCK_SIZE: int = 8 * 1024 * 1024  # 8 MB
+
 
 def download(
     path: str,
@@ -69,14 +74,23 @@ def download(
         mode="rb",
         use_threads=use_threads,
         version_id=version_id,
-        s3_block_size=-1,  # One shot download
+        s3_block_size=_S3_DOWNLOAD_BLOCK_SIZE,
         s3_additional_kwargs=s3_additional_kwargs,
         boto3_session=boto3_session,
     ) as s3_f:
         if isinstance(local_file, str):
             _logger.debug("Downloading local_file: %s", local_file)
             with open(file=local_file, mode="wb") as local_f:
-                local_f.write(cast(bytes, s3_f.read()))
+                _copy_in_chunks(s3_f, local_f)
         else:
             _logger.debug("Downloading file-like object.")
-            local_file.write(s3_f.read())
+            _copy_in_chunks(s3_f, local_file)
+
+
+def _copy_in_chunks(s3_f: Any, local_f: Any) -> None:
+    """Stream data from the S3 file-like object to the local file in fixed size chunks."""
+    while True:
+        chunk = cast(bytes, s3_f.read(_S3_DOWNLOAD_BLOCK_SIZE))
+        if not chunk:
+            break
+        local_f.write(chunk)

--- a/tests/unit/test_moto.py
+++ b/tests/unit/test_moto.py
@@ -325,6 +325,27 @@ def test_download_fileobj(moto_s3_client: "S3Client", tmp_path: str) -> None:
     assert local_file.read_bytes() == content
 
 
+def test_download_file_chunked(moto_s3_client: "S3Client", tmp_path: str) -> None:
+    # Force a small block size so the object is streamed over several chunks instead of
+    # being read into memory in a single call, exercising the chunked download path.
+    small_block_size = 5
+    with mock.patch("awswrangler.s3._download._S3_DOWNLOAD_BLOCK_SIZE", small_block_size):
+        bucket = "bucket"
+        key = "foo.tmp"
+        content = os.urandom(small_block_size * 4 + 3)  # Not an exact multiple of the block size
+
+        moto_s3_client.put_object(
+            Bucket=bucket,
+            Key=key,
+            Body=content,
+        )
+
+        path = f"s3://{bucket}/{key}"
+        local_file = tmp_path / key
+        wr.s3.download(path=path, local_file=str(local_file))
+        assert local_file.read_bytes() == content
+
+
 def test_upload_file(moto_s3_client: "S3Client", tmp_path: str) -> None:
     bucket = "bucket"
     key = "foo.tmp"


### PR DESCRIPTION
Closes/relates to #2831.

wr.s3.download currently opens the object with s3_block_size=-1 (one shot download), which fetches the entire object into an in memory cache inside _S3ObjectBase, then calls s3_f.read() to pull the whole thing out as a second bytes object, then writes it to the local file. For large files this means the object briefly exists twice in memory before it even reaches disk, so downloading a multi GB file can OOM a process that would otherwise have plenty of headroom for a streamed copy.

This changes download() to open the object with a fixed 8 MB block size instead of one shot, and copies it to the destination in a simple read/write loop (_copy_in_chunks) instead of a single read() call. That keeps memory usage roughly proportional to the block size regardless of the source object size. The underlying _S3ObjectBase.read() already supports incremental ranged reads when s3_block_size is a positive number (this is the same mechanism _read_text_core.py already uses for streaming reads), so this reuses existing, tested code paths rather than adding new S3 fetch logic.

Added test_download_file_chunked in tests/unit/test_moto.py, which monkeypatches the block size down to 5 bytes and downloads an object whose size is not an exact multiple of the block size, to exercise the multi chunk path and confirm the bytes are reassembled correctly.

Testing done locally:
- ran the existing test_download_file and test_download_fileobj tests plus the new test_download_file_chunked against moto, all pass
- ran the full tests/unit/test_moto.py suite, 45 passed / 1 failed (test_glue_get_partition, unrelated pre-existing failure caused by a missing pyparsing dependency for moto's glue mock in my environment, not related to this change)
- ruff check and ruff format --check pass on the touched files

I did not have access to real AWS infra so I couldn't run the basic/full test environments described in CONTRIBUTING.md, only the mocked moto based unit tests.