### PR TITLE
fix(lambda): use PyPI wheels for numpy/pandas on AL2023 layer builds …

### DIFF
--- a/building/lambda/Dockerfile.al2023
+++ b/building/lambda/Dockerfile.al2023
@@ -33,11 +33,14 @@ RUN pip3 install --upgrade cmake==3.31.6
 # libcst (used for build-time stub docstring extraction) are required.
 RUN pip3 install --upgrade six "cython>=3.1" hypothesis uv build scikit-build-core "libcst>=1.8.6"
 
-ENV PIP_NO_BINARY="numpy,pandas"
+# AL2023 has glibc 2.34, which satisfies the manylinux_2_28 tag that PyPI
+# ships numpy/pandas wheels under. Building numpy/pandas from source here
+# without locking the build-time numpy to the runtime numpy produces an
+# ABI-mismatched pandas binary that SIGSEGVs on datetime64 construction
+# (issue #3393). The AL2-based Dockerfile still forces source builds because
+# AL2's glibc 2.26 can't load manylinux_2_28 wheels.
 ENV UV_PROJECT_ENVIRONMENT="/var/lang"
-RUN uv sync --frozen --inexact --no-dev --no-install-project \
-    --no-binary-package numpy \
-    --no-binary-package pandas
+RUN uv sync --frozen --inexact --no-dev --no-install-project
 
 RUN rm -f pyproject.toml uv.lock
 

--- a/building/lambda/build-lambda-layer.sh
+++ b/building/lambda/build-lambda-layer.sh
@@ -89,7 +89,18 @@ popd
 
 pushd /aws-sdk-pandas
 
-pip3 install . --no-binary numpy,pandas --find-links="${PYARROW_WHEEL_DIR}" -t ./python ".[redshift,mysql,postgres,gremlin,opensearch,openpyxl]" "pyarrow==${ARROW_VERSION}"
+# Building numpy/pandas from source on AL2023 without pinning the build-time
+# numpy to the runtime numpy produces an ABI-mismatched pandas binary that
+# SIGSEGVs on datetime64 construction (issue #3393). AL2023's glibc 2.34
+# satisfies the manylinux_2_28 tag that PyPI ships numpy/pandas wheels under,
+# so use those wheels. AL2 (glibc 2.26) is too old to load manylinux_2_28,
+# so keep forcing source builds there.
+NO_BINARY_FLAG=""
+if [ -r /etc/os-release ] && grep -q '^VERSION_ID="2"' /etc/os-release; then
+  NO_BINARY_FLAG="--no-binary numpy,pandas"
+fi
+
+pip3 install . ${NO_BINARY_FLAG} --find-links="${PYARROW_WHEEL_DIR}" -t ./python ".[redshift,mysql,postgres,gremlin,opensearch,openpyxl]" "pyarrow==${ARROW_VERSION}"
 
 # CVE-2026-41066: upgrade lxml past redshift-connector's <=6.0.2 cap.
 # pyproject.toml's [tool.uv] override-dependencies only applies to uv, not pip,


### PR DESCRIPTION
### Feature or Bugfix
  - Bugfix

  ### Detail
  - The managed Lambda layer `AWSSDKPandas-Python312:29` (and Python 3.13/3.14 equivalents) SIGSEGVs on any pandas `datetime64` construction — `df["t"] = datetime.datetime.now()`, `pd.to_datetime(...)`, or any awswrangler internal timestamp casting. Crash originates in `pandas/core/construction.py:503 ensure_wrapped_if_datetimelike`, on Lambda it surfaces as `Runtime.ExitError: signal: segmentation fault` on every invocation that touches a datetime value.
  - Root cause: `pip install --no-binary numpy,pandas` under default build isolation on AL2023 produces a pandas binary linked against a numpy ABI that doesn't match the numpy 2.5.x wheel resolved separately in the same layer. Confirmed by reproducing the exact stack trace in `public.ecr.aws/lambda/python:3.12` with `--no-binary numpy,pandas`, and confirming the same versions from PyPI wheels work cleanly.
  - The `--no-binary` flag was originally required on AL2 (glibc 2.26) because PyPI's `manylinux_2_28` wheels wouldn't load. AL2023 (glibc 2.34) satisfies `manylinux_2_28`, so the flag is no longer needed for Python 3.12/3.13/3.14 builds and is actively causing the ABI mismatch.
  - Fix: drop `PIP_NO_BINARY` env and `--no-binary-package numpy/pandas` from `uv sync` in `Dockerfile.al2023`; gate the `--no-binary numpy,pandas` flag on `build-lambda-layer.sh` via `/etc/os-release` so only AL2 (`VERSION_ID="2"`) keeps source builds. AL2 py3.10/3.11 verified unaffected — its older numpy 2.4.x source build works correctly.

  ### Relates
  - Fixes #3393

  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
