### PR TITLE
fix: coerce nanoseconds (#3357)

### DIFF
--- a/awswrangler/_data_types.py
+++ b/awswrangler/_data_types.py
@@ -606,6 +606,7 @@ def pyarrow2pandas_defaults(
         "split_blocks": True,
         "self_destruct": True,
         "ignore_metadata": False,
+        "coerce_temporal_nanoseconds": False,
         "types_mapper": get_pyarrow2pandas_type_mapper(dtype_backend),
     }
     if kwargs:


### PR DESCRIPTION
Fixes #3357

## Problem

DataFrame columns with nanosecond-resolution datetime values are not handled correctly during type coercion.

## Fix

Add nanosecond coercion logic in `awswrangler/_data_types.py`.

## Scope

Single-file change in `awswrangler/_data_types.py`.

## Verification

Datetime columns with nanosecond precision are correctly coerced without precision loss or overflow errors.