### PR TITLE
fix: ignore double colon cast operators in SQL parameter substitution

### DIFF
--- a/awswrangler/_sql_formatter.py
+++ b/awswrangler/_sql_formatter.py
@@ -155,7 +155,7 @@ def _format_parameters(params: dict[str, Any], engine: _Engine) -> dict[str, Any
     return processed_params
 
 
-_PATTERN = re.compile(r":([A-Za-z0-9_]+)(?![A-Za-z0-9_])")
+_PATTERN = re.compile(r"(?<!:):([A-Za-z0-9_]+)(?![A-Za-z0-9_])")
 
 
 def _create_engine(engine_type: _EngineTypeLiteral) -> _Engine:

--- a/tests/unit/test_sql_params_formatter.py
+++ b/tests/unit/test_sql_params_formatter.py
@@ -4,7 +4,13 @@ from dataclasses import dataclass
 
 import pytest
 
-from awswrangler._sql_formatter import _Engine, _format_parameters, _HiveEngine, _PrestoEngine
+from awswrangler._sql_formatter import (
+    _Engine,
+    _format_parameters,
+    _HiveEngine,
+    _PrestoEngine,
+    _process_sql_params,
+)
 
 _hive_engine_param = pytest.param(_HiveEngine(), id="hive")
 _presto_engine_param = pytest.param(_PrestoEngine(), id="presto")
@@ -118,3 +124,11 @@ def test_invalid_parameter_type(engine: _Engine) -> None:
             {"point": Point(7, 1)},
             engine=engine,
         )
+
+
+def test_process_sql_params_double_colon_cast() -> None:
+    sql = "SELECT col::text, col::timestamp FROM table WHERE id = :id AND status = :text"
+    params = {"id": 1, "text": "active"}
+    processed_sql = _process_sql_params(sql, params)
+    expected_sql = "SELECT col::text, col::timestamp FROM table WHERE id = 1 AND status = 'active'"
+    assert processed_sql == expected_sql


### PR DESCRIPTION
## Description
Fixes an issue in `awswrangler._sql_formatter._process_sql_params` where double-colon type cast operators (e.g. `col::text`, `col::timestamp`, `col::varchar`, `col::integer`) are mistakenly parsed as parameter placeholders when a parameter name matches the cast target type name.

## Root Cause
The parameter substitution regex `_PATTERN` was defined as `re.compile(r":([A-Za-z0-9_]+)(?![A-Za-z0-9_])")`. When a SQL query contains double colons `::` (standard ANSI / PostgreSQL / Athena / Presto / Trino / CleanRooms cast syntax), the second colon was matched as a parameter placeholder. If `params` contained a key matching the type name (such as `text` in `col::text`), `_process_sql_params` substituted the cast operator, corrupting the SQL query to `col:'value'` and causing runtime SQL syntax errors.

## Solution
Updated `_PATTERN` in `awswrangler/_sql_formatter.py` with a negative lookbehind `(?<!:)` to ensure single-colon parameters (e.g., `:id`) are matched without matching double-colon cast operators (`::type`):
```python
_PATTERN = re.compile(r"(?<!:):([A-Za-z0-9_]+)(?![A-Za-z0-9_])")
```

## Validation & Testing
- Added unit test `test_process_sql_params_double_colon_cast` in `tests/unit/test_sql_params_formatter.py` asserting that double-colon type casts are preserved while parameter placeholders are correctly substituted.
- Confirmed test failure on `upstream/main` baseline before applying fix.
- Ran quality checks:
  - `pytest tests/unit/test_sql_params_formatter.py` (Passed 13/13)
  - `ruff format --check .` (Passed)
  - `ruff check .` (Passed)
  - `mypy awswrangler/_sql_formatter.py tests/unit/test_sql_params_formatter.py` (Success)
  - `git diff --check` (Clean)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
