### PR TITLE
fix: handle zero max_items_evaluated in DynamoDB read_items

### DIFF
--- a/awswrangler/dynamodb/_read.py
+++ b/awswrangler/dynamodb/_read.py
@@ -392,7 +392,18 @@ def _read_items(
         items = _read_batch_items(table_name, dynamodb_client, chunked, **kwargs)
 
     else:
-        if limit:
+        if limit is not None:
+            if limit < 0:
+                raise exceptions.InvalidArgumentValue("`max_items_evaluated` must be greater than or equal to 0.")
+            if limit == 0:
+                empty_items: _ItemsListType = []
+                if chunked:
+                    return _convert_items_chunked(
+                        items_iterator=iter([empty_items]),
+                        as_dataframe=as_dataframe,
+                        arrow_kwargs=arrow_kwargs,
+                    )
+                return _convert_items(items=empty_items, as_dataframe=as_dataframe, arrow_kwargs=arrow_kwargs)
             kwargs["Limit"] = limit
             _logger.debug("`max_items_evaluated` argument detected, setting use_threads to False")
             use_threads = False
@@ -744,12 +755,20 @@ def read_items(  # noqa: PLR0912, PLR0915
             **kwargs.get("ExpressionAttributeValues", {}),
             **_serialize_item(expression_attribute_values, serializer),
         }
-    if max_items_evaluated:
+    if max_items_evaluated is not None:
         kwargs["Limit"] = max_items_evaluated
 
     _logger.debug("DynamoDB scan/query kwargs: %s", kwargs)
     # If kwargs are sufficiently informative, proceed with actual read op
-    if any((partition_values, key_condition_expression, filter_expression, allow_full_scan, max_items_evaluated)):
+    if any(
+        (
+            partition_values,
+            key_condition_expression,
+            filter_expression,
+            allow_full_scan,
+            max_items_evaluated is not None,
+        )
+    ):
         return _read_items(
             table_name=table_name,
             as_dataframe=as_dataframe,

--- a/tests/unit/test_moto.py
+++ b/tests/unit/test_moto.py
@@ -844,3 +844,31 @@ def test_create_iceberg_table_escapes_single_quotes_in_columns_comments() -> Non
     # The intended LOCATION (un-doubled quotes) is the only top-level clause.
     assert "LOCATION 's3://intended/output/'" in sql
     assert "LOCATION 's3://other/'" not in sql
+
+
+def test_dynamodb_read_items_max_items_evaluated_zero(moto_dynamodb_client, moto_dynamodb_table) -> None:
+    items = [{"key": 1, "value": "A"}, {"key": 2, "value": "B"}]
+    wr.dynamodb.put_items(items=items, table_name=moto_dynamodb_table)
+
+    # 1. max_items_evaluated=0 without allow_full_scan
+    df0 = wr.dynamodb.read_items(table_name=moto_dynamodb_table, max_items_evaluated=0)
+    assert isinstance(df0, pd.DataFrame)
+    assert len(df0) == 0
+
+    # 2. max_items_evaluated=0 with allow_full_scan=True
+    df0_scan = wr.dynamodb.read_items(table_name=moto_dynamodb_table, max_items_evaluated=0, allow_full_scan=True)
+    assert isinstance(df0_scan, pd.DataFrame)
+    assert len(df0_scan) == 0
+
+    # 3. max_items_evaluated=0 as_dataframe=False
+    items0 = wr.dynamodb.read_items(table_name=moto_dynamodb_table, max_items_evaluated=0, as_dataframe=False)
+    assert items0 == []
+
+    # 4. max_items_evaluated=0 chunked=True
+    chunks = list(wr.dynamodb.read_items(table_name=moto_dynamodb_table, max_items_evaluated=0, chunked=True))
+    assert len(chunks) == 1
+    assert len(chunks[0]) == 0
+
+    # 5. max_items_evaluated=-1 raises InvalidArgumentValue
+    with pytest.raises(wr.exceptions.InvalidArgumentValue):
+        wr.dynamodb.read_items(table_name=moto_dynamodb_table, max_items_evaluated=-1)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
Fixes an issue in `awswrangler.dynamodb.read_items` where setting `max_items_evaluated=0` was evaluated as a falsey truthiness check (`if max_items_evaluated:` and `if limit:`) rather than an explicit `is not None` check.

This resulted in two bugs when `max_items_evaluated=0` was provided:
1. `read_items` raised `exceptions.InvalidArgumentCombination` stating that at least one read argument (like `max_items_evaluated`) must be provided, even though `max_items_evaluated` was explicitly passed.
2. If `allow_full_scan=True` was also provided alongside `max_items_evaluated=0`, `max_items_evaluated=0` was ignored and all items in the DynamoDB table were scanned/queried without any limit.

**Changes:**
- Update `max_items_evaluated` argument validation in `read_items()` and `_read_items()` to check `is not None`.
- For `max_items_evaluated=0`, return an empty DataFrame (or empty list/iterator based on `as_dataframe` and `chunked` arguments) directly without executing unnecessary network/scan requests or violating botocore parameter validation limits.
- Raise `InvalidArgumentValue` if `max_items_evaluated < 0`.
- Add regression tests in `tests/unit/test_moto.py`.

### Relates
- N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
