### PR TITLE
fix: upload 0-byte object when closing open_s3_object in write mode

### DIFF
--- a/awswrangler/s3/_fs.py
+++ b/awswrangler/s3/_fs.py
@@ -483,7 +483,7 @@ class _S3ObjectBase(io.RawIOBase):
                     ),
                 )
                 _logger.debug("complete_multipart_upload done!")
-            elif self._buffer.tell() > 0:
+            else:
                 _logger.debug("put_object")
                 _utils.try_it(
                     f=self._client.put_object,

--- a/tests/unit/test_moto.py
+++ b/tests/unit/test_moto.py
@@ -844,3 +844,20 @@ def test_create_iceberg_table_escapes_single_quotes_in_columns_comments() -> Non
     # The intended LOCATION (un-doubled quotes) is the only top-level clause.
     assert "LOCATION 's3://intended/output/'" in sql
     assert "LOCATION 's3://other/'" not in sql
+
+
+def test_open_s3_object_empty_file_write(moto_s3_client: "S3Client") -> None:
+    from awswrangler.s3._fs import open_s3_object
+
+    path_new = "s3://bucket/empty_new.txt"
+    with open_s3_object(path_new, mode="wb") as s3obj:
+        pass
+    assert wr.s3.does_object_exist(path_new) is True
+    assert moto_s3_client.get_object(Bucket="bucket", Key="empty_new.txt")["ContentLength"] == 0
+
+    path_existing = "s3://bucket/empty_existing.txt"
+    moto_s3_client.put_object(Bucket="bucket", Key="empty_existing.txt", Body=b"previous data")
+    with open_s3_object(path_existing, mode="w") as s3obj:
+        s3obj.write("")
+    assert moto_s3_client.get_object(Bucket="bucket", Key="empty_existing.txt")["ContentLength"] == 0
+    assert moto_s3_client.get_object(Bucket="bucket", Key="empty_existing.txt")["Body"].read() == b""


### PR DESCRIPTION
## Description

Fixes #3421

### Affected API
`awswrangler.s3._fs.open_s3_object` / `awswrangler.s3`

### Background & Root Cause
When an S3 object stream is opened in write mode (`mode="w"` or `mode="wb"`) using `open_s3_object`, and closed after writing 0 bytes (e.g. creating an empty file, writing `b""`, or exiting the context manager without `write()`), `_S3ObjectBase.close()` previously checked:
```python
if self.writable():
    if self._parts_count > 0:
        ... # complete multipart upload
    elif self._buffer.tell() > 0:
        ... # put_object
```
When `self._parts_count == 0` and `self._buffer.tell() == 0` (0 bytes written), both conditions evaluated to `False`. Consequently, `put_object` was skipped, leaving the S3 object non-existent if new, or retaining pre-existing content if overwriting.

### Corrected Behavior
`_S3ObjectBase.close()` now calls `put_object` whenever `self._parts_count == 0`, uploading `Body=self._buffer.getvalue()` (which is `b""` when 0 bytes are written). This matches standard Python file semantics (`open(path, "wb")`), correctly creating or truncating the S3 object to 0 bytes.

### Local Reproduction & Verification
Added a unit test `test_open_s3_object_empty_file_write` in `tests/unit/test_moto.py` covering:
1. Opening a non-existent S3 path in `"wb"` mode without writing, verifying `does_object_exist` returns `True` and `ContentLength == 0`.
2. Opening an existing S3 path containing prior data in `"w"` mode and writing `""`, verifying the object is truncated to 0 bytes (`ContentLength == 0`).

### Exact Validation Results
- `pytest tests/unit/test_moto.py` -> 46 passed in 3.25s
- `pytest tests/unit/test_utils.py` -> 18 passed in 0.02s
- `ruff format --check .` -> Passed
- `ruff check .` -> Passed
- `git diff --check` -> Clean

### AWS Integration Tests Not Run
Live AWS service tests (requiring AWS infrastructure / credentials) were not executed. Verification was completed using the repository's unit test suite with `moto`.

### Compatibility & Resource Ownership Behavior
- Preserves all public APIs and existing return types.
- Idempotent stream closure logic remains intact.
- No third-party dependencies added or mutated.
