### PR TITLE
fix: support sequence and set types for ignore_suffix in S3 listing and reading

### DIFF
--- a/awswrangler/s3/_list.py
+++ b/awswrangler/s3/_list.py
@@ -26,13 +26,17 @@ def _path2list(
     s3_additional_kwargs: dict[str, Any] | None,
     last_modified_begin: datetime.datetime | None = None,
     last_modified_end: datetime.datetime | None = None,
-    suffix: str | list[str] | None = None,
-    ignore_suffix: str | list[str] | None = None,
+    suffix: str | Sequence[str] | None = None,
+    ignore_suffix: str | Sequence[str] | None = None,
     ignore_empty: bool = False,
 ) -> list[str]:
     """Convert Amazon S3 path to list of objects."""
-    _suffix: list[str] | None = [suffix] if isinstance(suffix, str) else suffix
-    _ignore_suffix: list[str] | None = [ignore_suffix] if isinstance(ignore_suffix, str) else ignore_suffix
+    _suffix: list[str] | None = [suffix] if isinstance(suffix, str) else (list(suffix) if suffix is not None else None)
+    _ignore_suffix: list[str] | None = (
+        [ignore_suffix]
+        if isinstance(ignore_suffix, str)
+        else (list(ignore_suffix) if ignore_suffix is not None else None)
+    )
     if isinstance(path, str):  # prefix
         paths: list[str] = [
             path
@@ -85,14 +89,18 @@ def _list_objects(
     s3_client: "S3Client",
     delimiter: str | None = None,
     s3_additional_kwargs: dict[str, Any] | None = None,
-    suffix: str | list[str] | None = None,
-    ignore_suffix: str | list[str] | None = None,
+    suffix: str | Sequence[str] | None = None,
+    ignore_suffix: str | Sequence[str] | None = None,
     last_modified_begin: datetime.datetime | None = None,
     last_modified_end: datetime.datetime | None = None,
     ignore_empty: bool = False,
 ) -> Iterator[list[str]]:
-    suffix: list[str] | None = [suffix] if isinstance(suffix, str) else suffix
-    ignore_suffix: list[str] | None = [ignore_suffix] if isinstance(ignore_suffix, str) else ignore_suffix
+    _suffix: list[str] | None = [suffix] if isinstance(suffix, str) else (list(suffix) if suffix is not None else None)
+    _ignore_suffix: list[str] | None = (
+        [ignore_suffix]
+        if isinstance(ignore_suffix, str)
+        else (list(ignore_suffix) if ignore_suffix is not None else None)
+    )
     _validate_datetimes(last_modified_begin=last_modified_begin, last_modified_end=last_modified_end)
     bucket, pattern = _utils.parse_path(path=path)
     prefix: str = _prefix_cleanup(prefix=pattern)
@@ -103,8 +111,8 @@ def _list_objects(
         prefix=prefix,
         s3_client=s3_client,
         delimiter=delimiter,
-        suffix=suffix,
-        ignore_suffix=ignore_suffix,
+        suffix=_suffix,
+        ignore_suffix=_ignore_suffix,
         last_modified_begin=last_modified_begin,
         last_modified_end=last_modified_end,
         ignore_empty=ignore_empty,
@@ -382,7 +390,7 @@ def list_objects(
     ignore_suffix_acc = set("/")
     if isinstance(ignore_suffix, str):
         ignore_suffix_acc.add(ignore_suffix)
-    elif isinstance(ignore_suffix, list):
+    elif isinstance(ignore_suffix, (list, tuple, set, Sequence)):
         ignore_suffix_acc.update(ignore_suffix)
 
     result_iterator = _list_objects(

--- a/awswrangler/s3/_read.py
+++ b/awswrangler/s3/_read.py
@@ -12,6 +12,7 @@ from typing import (
     Iterable,
     Iterator,
     NamedTuple,
+    Sequence,
     Tuple,
     cast,
 )
@@ -44,13 +45,13 @@ def _get_path_root(path: str | list[str], dataset: bool) -> str | None:
     return _prefix_cleanup(str(path)) if dataset is True else None
 
 
-def _get_path_ignore_suffix(path_ignore_suffix: str | list[str] | None) -> list[str] | None:
+def _get_path_ignore_suffix(path_ignore_suffix: str | Sequence[str] | None) -> list[str] | None:
     if isinstance(path_ignore_suffix, str):
         path_ignore_suffix = [path_ignore_suffix, "/_SUCCESS"]
     elif path_ignore_suffix is None:
         path_ignore_suffix = ["/_SUCCESS"]
     else:
-        path_ignore_suffix = path_ignore_suffix + ["/_SUCCESS"]
+        path_ignore_suffix = list(path_ignore_suffix) + ["/_SUCCESS"]
     return path_ignore_suffix
 
 

--- a/tests/unit/test_moto.py
+++ b/tests/unit/test_moto.py
@@ -872,3 +872,31 @@ def test_dynamodb_read_items_max_items_evaluated_zero(moto_dynamodb_client, moto
     # 5. max_items_evaluated=-1 raises InvalidArgumentValue
     with pytest.raises(wr.exceptions.InvalidArgumentValue):
         wr.dynamodb.read_items(table_name=moto_dynamodb_table, max_items_evaluated=-1)
+
+
+def test_list_objects_ignore_suffix_sequence_types(moto_s3_client: "S3Client") -> None:
+    bucket = "bucket"
+    moto_s3_client.put_object(Bucket=bucket, Key="dir/file1.csv", Body=b"1")
+    moto_s3_client.put_object(Bucket=bucket, Key="dir/file2.tmp", Body=b"2")
+    moto_s3_client.put_object(Bucket=bucket, Key="dir/file3.bak", Body=b"3")
+
+    # List ignore_suffix
+    files_list = wr.s3.list_objects(f"s3://{bucket}/dir/", ignore_suffix=[".tmp", ".bak"])
+    assert files_list == [f"s3://{bucket}/dir/file1.csv"]
+
+    # Tuple ignore_suffix
+    files_tuple = wr.s3.list_objects(f"s3://{bucket}/dir/", ignore_suffix=(".tmp", ".bak"))
+    assert files_tuple == [f"s3://{bucket}/dir/file1.csv"]
+
+    # Set ignore_suffix
+    files_set = wr.s3.list_objects(f"s3://{bucket}/dir/", ignore_suffix={".tmp", ".bak"})
+    assert files_set == [f"s3://{bucket}/dir/file1.csv"]
+
+
+def test_get_path_ignore_suffix_sequence_types() -> None:
+    from awswrangler.s3._read import _get_path_ignore_suffix
+
+    assert set(_get_path_ignore_suffix((".tmp", ".bak"))) == {".tmp", ".bak", "/_SUCCESS"}
+    assert set(_get_path_ignore_suffix({".tmp", ".bak"})) == {".tmp", ".bak", "/_SUCCESS"}
+    assert _get_path_ignore_suffix(".tmp") == [".tmp", "/_SUCCESS"]
+    assert _get_path_ignore_suffix(None) == ["/_SUCCESS"]


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- `wr.s3.list_objects` silently ignored `ignore_suffix` when passed as a non-`list` sequence or set (such as a `tuple` e.g. `ignore_suffix=(".tmp", ".bak")` or `set` e.g. `ignore_suffix={"_SUCCESS"}`). The internal accumulation logic checked `elif isinstance(ignore_suffix, list):`, skipping any other sequence type and resulting in unignored files being returned.
- `_get_path_ignore_suffix` in `awswrangler/s3/_read.py` raised a `TypeError` when `path_ignore_suffix` was passed a `tuple` or `set` due to direct list concatenation (`path_ignore_suffix + ["/_SUCCESS"]`).
- Updated parameter type annotations and conversion logic across `awswrangler/s3/_list.py` and `awswrangler/s3/_read.py` to convert non-string sequence types (e.g. `tuple`, `set`) to `list[str]`.
- Added unit tests in `tests/unit/test_moto.py` validating `ignore_suffix` behavior across `list`, `tuple`, and `set` inputs.

### Relates
- N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
