### PR TITLE
fix: correct target deletion path in merge_datasets for root dataset files

### DIFF
--- a/awswrangler/s3/_copy.py
+++ b/awswrangler/s3/_copy.py
@@ -162,11 +162,16 @@ def merge_datasets(
         _logger.debug("Deleting to overwrite: %s/", target_path)
         delete_objects(path=f"{target_path}/", use_threads=use_threads, boto3_session=boto3_session)
     elif mode == "overwrite_partitions":
-        paths_wo_prefix: list[str] = [x.replace(f"{source_path}/", "") for x in paths]
-        paths_wo_filename: list[str] = [f"{x.rpartition('/')[0]}/" for x in paths_wo_prefix]
-        partitions_paths: list[str] = list(set(paths_wo_filename))
-        target_partitions_paths = [f"{target_path}/{x}" for x in partitions_paths]
-        for path in target_partitions_paths:
+        prefix = f"{source_path}/"
+        paths_wo_prefix: list[str] = [x[len(prefix) :] if x.startswith(prefix) else x for x in paths]
+        partitions_paths: set[str] = set()
+        for x in paths_wo_prefix:
+            folder = x.rpartition("/")[0]
+            if folder:
+                partitions_paths.add(f"{target_path}/{folder}/")
+            else:
+                partitions_paths.add(f"{target_path}/")
+        for path in partitions_paths:
             _logger.debug("Deleting to overwrite_partitions: %s", path)
             delete_objects(path=path, use_threads=use_threads, boto3_session=boto3_session)
     elif mode != "append":

--- a/tests/unit/test_moto.py
+++ b/tests/unit/test_moto.py
@@ -872,3 +872,29 @@ def test_dynamodb_read_items_max_items_evaluated_zero(moto_dynamodb_client, moto
     # 5. max_items_evaluated=-1 raises InvalidArgumentValue
     with pytest.raises(wr.exceptions.InvalidArgumentValue):
         wr.dynamodb.read_items(table_name=moto_dynamodb_table, max_items_evaluated=-1)
+
+
+def test_merge_datasets_overwrite_partitions_root_files(moto_s3_client) -> None:
+    bucket = "bucket"
+    # Target has an existing file directly in target_path and in a partition
+    moto_s3_client.put_object(Bucket=bucket, Key="target/file_old.csv", Body=b"old")
+    moto_s3_client.put_object(Bucket=bucket, Key="target/part=1/file_old_p.csv", Body=b"old_p")
+
+    # Source has a new file directly in source_path and in partition part=1
+    moto_s3_client.put_object(Bucket=bucket, Key="source/file_new.csv", Body=b"new")
+    moto_s3_client.put_object(Bucket=bucket, Key="source/part=1/file_new_p.csv", Body=b"new_p")
+
+    # Merge with mode="overwrite_partitions"
+    copied = wr.s3.merge_datasets(
+        source_path=f"s3://{bucket}/source/",
+        target_path=f"s3://{bucket}/target/",
+        mode="overwrite_partitions",
+    )
+
+    assert set(copied) == {f"s3://{bucket}/target/file_new.csv", f"s3://{bucket}/target/part=1/file_new_p.csv"}
+
+    target_objects = wr.s3.list_objects(f"s3://{bucket}/target/")
+    assert set(target_objects) == {
+        f"s3://{bucket}/target/file_new.csv",
+        f"s3://{bucket}/target/part=1/file_new_p.csv",
+    }


### PR DESCRIPTION
## Description
In `awswrangler.s3.merge_datasets` with `mode="overwrite_partitions"`, dataset files directly under `source_path` (without sub-partition folders) produced `x.rpartition("/")[0] == ""`. This resulted in target delete paths formatted as `s3://bucket/target//` with a double slash. Because `delete_objects` searches for S3 keys matching prefix `target//`, zero objects were matched and existing target files directly at the root of `target_path` remained undeleted.

In addition, `x.replace(f"{source_path}/", "")` performed global substring replacement on `x` instead of safely stripping only the leading prefix path.

This PR:
1. Safely strips leading `source_path` prefix using `x[len(prefix):]` when `x.startswith(prefix)`.
2. Correctly formats the root target directory path as `s3://bucket/target/` when root dataset files are present, ensuring pre-existing target root files are properly deleted in `overwrite_partitions` mode.

## Checklist
- [x] Description of the change above
- [x] Run unit tests (`pytest tests/unit/test_moto.py`)
- [x] Added regression tests in `tests/unit/test_moto.py`

## Validation Results
- `pytest tests/unit/test_moto.py`: PASSED (47 passed in 3.30s)
- `git diff --check`: PASSED (0 errors/warnings)
