### PR TITLE
fix: handle zero values for max_retries, initial_backoff, and max_backoff in OpenSearch index_documents

### DIFF
--- a/awswrangler/opensearch/_write.py
+++ b/awswrangler/opensearch/_write.py
@@ -585,7 +585,7 @@ https://opendistro.github.io/for-elasticsearch-docs/docs/elasticsearch/rest-api-
     if "refresh" in kwargs and _is_serverless(client):
         raise exceptions.NotSupported("Refresh policy not supported in OpenSearch Serverless.")
 
-    if use_threads and any([max_retries, initial_backoff, max_backoff]):
+    if use_threads and any(x is not None for x in (max_retries, initial_backoff, max_backoff)):
         raise exceptions.InvalidArgumentCombination(
             "`max_retries`, `initial_backoff`, and `max_backoff` are not supported when `use_threads` is set to True"
         )
@@ -635,9 +635,9 @@ https://opendistro.github.io/for-elasticsearch-docs/docs/elasticsearch/rest-api-
                     errors += _errors
             else:
                 # Defaults
-                bulk_kwargs["max_retries"] = 5 if not max_retries else max_retries
-                bulk_kwargs["initial_backoff"] = 2 if not initial_backoff else initial_backoff
-                bulk_kwargs["max_backoff"] = 600 if not max_backoff else max_backoff
+                bulk_kwargs["max_retries"] = 5 if max_retries is None else max_retries
+                bulk_kwargs["initial_backoff"] = 2 if initial_backoff is None else initial_backoff
+                bulk_kwargs["max_backoff"] = 600 if max_backoff is None else max_backoff
 
                 _success, _errors = opensearchpy.helpers.bulk(client, bulk_chunk_documents, **bulk_kwargs)
                 success += _success

--- a/tests/unit/test_opensearch.py
+++ b/tests/unit/test_opensearch.py
@@ -5,6 +5,7 @@ import logging
 import tempfile
 import time
 from typing import Any
+from unittest.mock import MagicMock, patch
 
 import boto3
 import botocore
@@ -13,6 +14,7 @@ import pytest  # type: ignore
 
 import awswrangler as wr
 import awswrangler.pandas as pd
+from awswrangler import exceptions
 from awswrangler.opensearch._utils import _is_serverless
 
 from .._utils import _get_unique_suffix, extract_cloudformation_outputs
@@ -585,3 +587,32 @@ def test_opensearch_serverless_create_collection(opensearch_serverless_client) -
         client.delete_security_policy(name=f"{collection_name}-encryption-policy", type="encryption")
         client.delete_security_policy(name=f"{collection_name}-network-policy", type="network")
         client.delete_access_policy(name=f"{collection_name}-data-policy", type="data")
+
+
+def test_index_documents_zero_retries_and_backoff_use_threads_false():
+    client_mock = MagicMock()
+    with patch("opensearchpy.helpers.bulk", return_value=(1, [])) as mock_bulk:
+        wr.opensearch.index_documents(
+            client=client_mock,
+            documents=[{"_id": "1", "name": "foo"}],
+            index="test-index",
+            use_threads=False,
+            max_retries=0,
+            initial_backoff=0,
+            max_backoff=0,
+        )
+        assert mock_bulk.call_args.kwargs["max_retries"] == 0
+        assert mock_bulk.call_args.kwargs["initial_backoff"] == 0
+        assert mock_bulk.call_args.kwargs["max_backoff"] == 0
+
+
+def test_index_documents_zero_retries_raises_when_use_threads_true():
+    client_mock = MagicMock()
+    with pytest.raises(exceptions.InvalidArgumentCombination):
+        wr.opensearch.index_documents(
+            client=client_mock,
+            documents=[{"_id": "1", "name": "foo"}],
+            index="test-index",
+            use_threads=True,
+            max_retries=0,
+        )


### PR DESCRIPTION
## Description

Fixes an issue in `awswrangler.opensearch.index_documents` where passing `0` for retry and backoff configuration arguments (`max_retries=0`, `initial_backoff=0`, `max_backoff=0`) resulted in incorrect default fallback assignment and validation bypass.

### Root Cause
1. `if use_threads and any([max_retries, initial_backoff, max_backoff]):` evaluated `any([0, None, None])` as `False` because `0` is falsey in Python. As a result, passing `max_retries=0` when `use_threads=True` failed to trigger `exceptions.InvalidArgumentCombination`.
2. When `use_threads=False`, `bulk_kwargs["max_retries"] = 5 if not max_retries else max_retries` evaluated `not 0` as `True`, overriding `max_retries=0` to `5`. Similarly, `initial_backoff=0` was overridden to `2` and `max_backoff=0` was overridden to `600`.

### Solution
- Updated the `use_threads` validation check to `any(x is not None for x in (max_retries, initial_backoff, max_backoff))` to properly check for explicit argument presence.
- Updated default `bulk_kwargs` assignments to check `x is None` instead of `not x`, ensuring explicit zero values (`0`) are preserved.
- Added unit tests with mocked OpenSearch clients to verify both unthreaded zero-value propagation and threaded exception raising.

### Validation Results
- `poetry run pytest tests/unit/test_opensearch.py -k "test_index_documents_zero_retries"` passed cleanly.
- `poetry run pytest tests/unit/test_moto.py` passed cleanly (46 passed).
- `poetry run ruff check` and `poetry run ruff format --check` passed cleanly.

### AWS Integration Tests Not Run
- Tests in `tests/unit/test_opensearch.py` requiring live AWS OpenSearch domain infrastructure were not run as they require live AWS credentials and CloudFormation stack resources.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
