### PR TITLE
fix: pass delete_objects to get_botocore_valid_kwargs in _delete_objects

### DIFF
--- a/awswrangler/s3/_delete.py
+++ b/awswrangler/s3/_delete.py
@@ -43,7 +43,7 @@ def _delete_objects(
 
     if s3_additional_kwargs:
         extra_kwargs: dict[str, Any] = get_botocore_valid_kwargs(
-            function_name="list_objects_v2", s3_additional_kwargs=s3_additional_kwargs
+            function_name="delete_objects", s3_additional_kwargs=s3_additional_kwargs
         )
     else:
         extra_kwargs = {}

--- a/tests/unit/test_moto.py
+++ b/tests/unit/test_moto.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 from typing import TYPE_CHECKING
@@ -483,6 +485,37 @@ def test_s3_delete_object_success(moto_s3_client: "S3Client") -> None:
     wr.s3.delete_objects(path=path)
     with pytest.raises(wr.exceptions.NoFilesFound):
         wr.s3.read_parquet(path=path, dataset=True)
+
+
+def test_s3_delete_objects_additional_kwargs(moto_s3_client: "S3Client") -> None:
+    path = "s3://bucket/test_kwargs.txt"
+    moto_s3_client.put_object(Bucket="bucket", Key="test_kwargs.txt", Body=b"test")
+
+    orig_client = wr._utils.client
+    captured_kwargs = {}
+
+    def custom_client(service_name: str, session: boto3.Session | None = None) -> "S3Client":
+        client = orig_client(service_name, session)
+        if service_name == "s3":
+            orig_delete = client.delete_objects
+
+            def mock_delete(**kwargs):
+                nonlocal captured_kwargs
+                captured_kwargs = kwargs
+                return orig_delete(**kwargs)
+
+            client.delete_objects = mock_delete
+        return client  # type: ignore[return-value]
+
+    with patch("awswrangler.s3._delete._utils.client", side_effect=custom_client):
+        wr.s3.delete_objects(
+            path=path,
+            s3_additional_kwargs={"BypassGovernanceRetention": True, "RequestPayer": "requester", "Delimiter": "/"},
+        )
+
+    assert captured_kwargs.get("BypassGovernanceRetention") is True
+    assert captured_kwargs.get("RequestPayer") == "requester"
+    assert "Delimiter" not in captured_kwargs
 
 
 @pytest.mark.parametrize("chunked", [True, False])


### PR DESCRIPTION
## Description

Fixes an issue where `awswrangler.s3.delete_objects` passed `function_name="list_objects_v2"` instead of `function_name="delete_objects"` to `get_botocore_valid_kwargs()`.

### Root Cause
In `awswrangler/s3/_delete.py`, `_delete_objects` called:
```python
extra_kwargs: dict[str, Any] = get_botocore_valid_kwargs(
    function_name="list_objects_v2", s3_additional_kwargs=s3_additional_kwargs
)
```
Because of this:
1. Valid S3 `delete_objects` parameters passed in `s3_additional_kwargs` (e.g., `BypassGovernanceRetention`, `MFA`, `ChecksumAlgorithm`) were filtered out and silently ignored because they are not valid parameters for `list_objects_v2`.
2. Conversely, parameters valid for `list_objects_v2` but invalid for `delete_objects` (such as `Delimiter` or `ContinuationToken`) were incorrectly preserved and passed to `s3_client.delete_objects()`.

### Fix
Changed `function_name="list_objects_v2"` to `function_name="delete_objects"` in `awswrangler/s3/_delete.py`.

### Testing
- Added regression test `test_s3_delete_objects_additional_kwargs` in `tests/unit/test_moto.py` verifying that `delete_objects`-specific parameters (`BypassGovernanceRetention`, `RequestPayer`) are retained and passed to `s3_client.delete_objects()`, while non-`delete_objects` parameters (`Delimiter`) are filtered out.
- Verified with `pytest tests/unit/test_moto.py`, `ruff check`, `ruff format --check`, and `mypy`.
- No AWS credentials or live AWS infrastructure required for testing.
