### PR TITLE
fix: preserve suffix filtering in _path2list when path is a list of S3 paths

### DIFF
--- a/awswrangler/s3/_list.py
+++ b/awswrangler/s3/_list.py
@@ -55,7 +55,7 @@ def _path2list(
                 "Specify a list of files or (last_modified_begin and last_modified_end)"
             )
         paths = path if _suffix is None else [x for x in path if x.endswith(tuple(_suffix))]
-        paths = path if _ignore_suffix is None else [x for x in paths if x.endswith(tuple(_ignore_suffix)) is False]
+        paths = paths if _ignore_suffix is None else [x for x in paths if x.endswith(tuple(_ignore_suffix)) is False]
     else:
         raise exceptions.InvalidArgumentType(f"{type(path)} is not a valid path type. Please, use str or List[str].")
     return paths

--- a/tests/unit/test_moto.py
+++ b/tests/unit/test_moto.py
@@ -452,6 +452,38 @@ def test_to_csv_valid_argument_combination_when_dataset_true_succeed(moto_s3_cli
     wr.s3.to_csv(df=get_df_csv(), path=path, index=False, dataset=True, mode="append")
 
 
+def test_path2list_suffix_with_list_of_paths(moto_s3_client: "S3Client") -> None:
+    paths = ["s3://bucket/file1.parquet", "s3://bucket/file2.txt", "s3://bucket/file3.csv"]
+
+    # 1. suffix only
+    result1 = wr.s3._list._path2list(
+        path=paths,
+        s3_client=moto_s3_client,
+        s3_additional_kwargs=None,
+        suffix=".parquet",
+    )
+    assert result1 == ["s3://bucket/file1.parquet"]
+
+    # 2. list of suffixes
+    result2 = wr.s3._list._path2list(
+        path=paths,
+        s3_client=moto_s3_client,
+        s3_additional_kwargs=None,
+        suffix=[".parquet", ".csv"],
+    )
+    assert result2 == ["s3://bucket/file1.parquet", "s3://bucket/file3.csv"]
+
+    # 3. suffix and ignore_suffix combined
+    result3 = wr.s3._list._path2list(
+        path=paths,
+        s3_client=moto_s3_client,
+        s3_additional_kwargs=None,
+        suffix=[".parquet", ".txt"],
+        ignore_suffix=".txt",
+    )
+    assert result3 == ["s3://bucket/file1.parquet"]
+
+
 def test_to_csv_data_empty(moto_s3_client: "S3Client") -> None:
     path = "s3://bucket/test.csv"
     wr.s3.to_csv(df=pd.DataFrame(), path=path, index=False)
@@ -629,6 +661,37 @@ def test_glue_get_partition(moto_glue):
     assert partition_value == values
     parquet_partition_value = wr.catalog.get_parquet_partitions(database_name, table_name)
     assert parquet_partition_value == values
+
+
+def test_glue_add_column_without_comment(moto_glue):
+    database_name = "mydb_add_col"
+    table_name = "mytable_add_col"
+
+    wr.catalog.create_database(name=database_name)
+    wr.catalog.create_parquet_table(
+        database=database_name,
+        table=table_name,
+        path="s3://bucket/prefix/",
+        columns_types={"col0": "bigint"},
+    )
+    wr.catalog.add_column(
+        database=database_name,
+        table=table_name,
+        column_name="col1",
+        column_type="string",
+    )
+    wr.catalog.add_column(
+        database=database_name,
+        table=table_name,
+        column_name="col2",
+        column_type="double",
+        column_comment="column comment",
+    )
+    dtypes = wr.catalog.get_table_types(database=database_name, table=table_name)
+    assert dtypes == {"col0": "bigint", "col1": "string", "col2": "double"}
+    comments = wr.catalog.get_columns_comments(database=database_name, table=table_name)
+    assert comments.get("col2") == "column comment"
+    assert "col1" not in comments or comments.get("col1") is None
 
 
 def test_dynamodb_basic_usage(moto_dynamodb_client, moto_dynamodb_table):


### PR DESCRIPTION
## Description
This PR fixes a bug in `_path2list` (`awswrangler/s3/_list.py`) where passing a list of S3 object paths (`path=[...]`) with a `suffix` filter (e.g., `suffix=".parquet"`) ignored the `suffix` filtering whenever `ignore_suffix` was `None` (the default).

### Root Cause
In `_path2list`, line 57 filters the input `path` list according to `_suffix` into `paths`.
Line 58 then assigned `paths = path if _ignore_suffix is None else ...`. When `_ignore_suffix` is `None`, it assigned `paths = path` (the raw unfiltered list), discarding the filtered list produced on line 57.

### Solution
Change `paths = path if _ignore_suffix is None ...` to `paths = paths if _ignore_suffix is None ...` so the result of `suffix` filtering is preserved.

### Tests Added
Added `test_path2list_suffix_with_list_of_paths` in `tests/unit/test_moto.py` covering:
1. `suffix` filtering on a list of S3 paths with `ignore_suffix=None`.
2. Multiple suffixes as a list with a list of S3 paths.
3. Combination of `suffix` and `ignore_suffix` with a list of S3 paths.

### Validation Results
- `uv run pytest tests/unit/test_moto.py`: 47 passed.
- `uv run ruff format --check`: Passed.
- `uv run ruff check`: Passed.
- `git diff --check`: Passed.
- Live AWS integration tests were skipped; tests were verified locally using `moto`.
