### PR TITLE
fix: omit Comment key when column_comment is None in add_column

### DIFF
--- a/awswrangler/catalog/_add.py
+++ b/awswrangler/catalog/_add.py
@@ -399,9 +399,10 @@ def add_column(
         client_glue = _utils.client(service_name="glue", session=boto3_session)
         table_res = client_glue.get_table(**_catalog_id(catalog_id=catalog_id, DatabaseName=database, Name=table))
         table_input: dict[str, Any] = _update_table_definition(table_res)
-        table_input["StorageDescriptor"]["Columns"].append(
-            {"Name": column_name, "Type": column_type, "Comment": column_comment}
-        )
+        col_dict: dict[str, Any] = {"Name": column_name, "Type": column_type}
+        if column_comment is not None:
+            col_dict["Comment"] = column_comment
+        table_input["StorageDescriptor"]["Columns"].append(col_dict)
         res: dict[str, Any] = client_glue.update_table(
             **_catalog_id(catalog_id=catalog_id, DatabaseName=database, TableInput=table_input)
         )

--- a/tests/unit/test_moto.py
+++ b/tests/unit/test_moto.py
@@ -631,6 +631,37 @@ def test_glue_get_partition(moto_glue):
     assert parquet_partition_value == values
 
 
+def test_glue_add_column_without_comment(moto_glue):
+    database_name = "mydb_add_col"
+    table_name = "mytable_add_col"
+
+    wr.catalog.create_database(name=database_name)
+    wr.catalog.create_parquet_table(
+        database=database_name,
+        table=table_name,
+        path="s3://bucket/prefix/",
+        columns_types={"col0": "bigint"},
+    )
+    wr.catalog.add_column(
+        database=database_name,
+        table=table_name,
+        column_name="col1",
+        column_type="string",
+    )
+    wr.catalog.add_column(
+        database=database_name,
+        table=table_name,
+        column_name="col2",
+        column_type="double",
+        column_comment="column comment",
+    )
+    dtypes = wr.catalog.get_table_types(database=database_name, table=table_name)
+    assert dtypes == {"col0": "bigint", "col1": "string", "col2": "double"}
+    comments = wr.catalog.get_columns_comments(database=database_name, table=table_name)
+    assert comments.get("col2") == "column comment"
+    assert "col1" not in comments or comments.get("col1") is None
+
+
 def test_dynamodb_basic_usage(moto_dynamodb_client, moto_dynamodb_table):
     items = [{"key": 1}, {"key": 2, "my_value": "Hello"}]
 


### PR DESCRIPTION
## Description
This PR fixes a `ParamValidationError` in `awswrangler.catalog.add_column()` when calling the function without providing a `column_comment` (leaving it as default `column_comment=None`).

### Root Cause
When `column_comment` is `None`, `add_column()` appends `{"Name": column_name, "Type": column_type, "Comment": column_comment}` into `table_input["StorageDescriptor"]["Columns"]`.
During the subsequent `client_glue.update_table` call, `botocore` validates `TableInput` against the AWS Glue service model. Because `"Comment": None` is explicitly set, `botocore` parameter validation fails:
`botocore.exceptions.ParamValidationError: Parameter validation failed: Invalid type for parameter TableInput.StorageDescriptor.Columns[X].Comment, value: None, type: <class 'NoneType'>, valid types: <class 'str'>`

### Fix
Construct the column dictionary dynamically so that the `"Comment"` key is only included when `column_comment` is not `None`.

### Regression Tests & Validation
- Added `test_glue_add_column_without_comment` in `tests/unit/test_moto.py` testing `add_column` both with default `column_comment=None` and with an explicit comment string.
- Ran `AWS_DEFAULT_REGION=us-east-1 uv run pytest tests/unit/test_moto.py` (47 passed).
- Ran `uv run ruff check awswrangler/catalog/_add.py tests/unit/test_moto.py`.
- Ran `uv run mypy awswrangler/catalog/_add.py`.
- Verified `git diff --check`.
- Live AWS integration tests were omitted as local `moto` unit tests provide full, deterministic verification without requiring live AWS credentials.
