### PR TITLE
fix(secretsmanager): return SecretBinary without double base64 decode

### DIFF
--- a/awswrangler/secretsmanager.py
+++ b/awswrangler/secretsmanager.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import base64
 import json
 import logging
 from typing import Any, Dict, cast
@@ -39,7 +38,9 @@ def get_secret(name: str, boto3_session: boto3.Session | None = None) -> str | b
     response = client.get_secret_value(SecretId=name)
     if "SecretString" in response:
         return response["SecretString"]
-    return base64.b64decode(response["SecretBinary"])
+    # botocore already base64-decodes blob-typed response members, so ``SecretBinary`` holds
+    # the raw secret bytes. Decoding again corrupts the value (and raises for non-base64 bytes).
+    return response["SecretBinary"]
 
 
 def get_secret_json(name: str, boto3_session: boto3.Session | None = None) -> dict[str, Any]:

--- a/tests/unit/test_moto.py
+++ b/tests/unit/test_moto.py
@@ -936,3 +936,19 @@ def test_dynamodb_read_items_max_items_evaluated_zero(moto_dynamodb_client, moto
     # 5. max_items_evaluated=-1 raises InvalidArgumentValue
     with pytest.raises(wr.exceptions.InvalidArgumentValue):
         wr.dynamodb.read_items(table_name=moto_dynamodb_table, max_items_evaluated=-1)
+
+
+def test_secretsmanager_get_secret_binary(moto_aws) -> None:
+    session = boto3.Session(region_name="us-east-1")
+    # Bytes that are not valid base64 input; the previous double-decode silently returned b"".
+    raw = bytes(range(8))
+    session.client("secretsmanager").create_secret(Name="aws-sdk-pandas/binary-secret", SecretBinary=raw)
+
+    assert wr.secretsmanager.get_secret("aws-sdk-pandas/binary-secret", boto3_session=session) == raw
+
+
+def test_secretsmanager_get_secret_string(moto_aws) -> None:
+    session = boto3.Session(region_name="us-east-1")
+    session.client("secretsmanager").create_secret(Name="aws-sdk-pandas/string-secret", SecretString="p@ssw0rd")
+
+    assert wr.secretsmanager.get_secret("aws-sdk-pandas/string-secret", boto3_session=session) == "p@ssw0rd"


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- `get_secret` called `base64.b64decode` on `SecretBinary`, but botocore already decodes blob-typed response members. The second decode silently corrupted the bytes (and raised for non-base64 secrets). Return the value as-is.
- Removed the now-unused `base64` import; added moto tests for the binary and string branches.
- The bug never surfaced internally because every database module resolves credentials via `get_secret_json`, which goes through the (correct) `SecretString` branch — only direct `get_secret()` calls on binary secrets were affected, and those either raised `binascii.Error` or, when the raw bytes happened to be valid base64, silently returned corrupted bytes.

### Relates
- N/A