### PR TITLE
fix(redshift): reject half-specified S3 credential pair

### DIFF
--- a/awswrangler/redshift/_utils.py
+++ b/awswrangler/redshift/_utils.py
@@ -45,6 +45,10 @@ def _make_s3_auth_string(
         auth_str: str = f"ACCESS_KEY_ID '{aws_access_key_id}'\nSECRET_ACCESS_KEY '{aws_secret_access_key}'\n"
         if aws_session_token is not None:
             auth_str += f"SESSION_TOKEN '{aws_session_token}'\n"
+    elif aws_access_key_id is not None or aws_secret_access_key is not None:
+        raise exceptions.InvalidArgument(
+            "aws_access_key_id and aws_secret_access_key must be provided together."
+        )
     elif iam_role is not None:
         auth_str = f"IAM_ROLE '{iam_role}'\n"
     else:

--- a/awswrangler/redshift/_utils.py
+++ b/awswrangler/redshift/_utils.py
@@ -46,9 +46,7 @@ def _make_s3_auth_string(
         if aws_session_token is not None:
             auth_str += f"SESSION_TOKEN '{aws_session_token}'\n"
     elif aws_access_key_id is not None or aws_secret_access_key is not None:
-        raise exceptions.InvalidArgument(
-            "aws_access_key_id and aws_secret_access_key must be provided together."
-        )
+        raise exceptions.InvalidArgument("aws_access_key_id and aws_secret_access_key must be provided together.")
     elif iam_role is not None:
         auth_str = f"IAM_ROLE '{iam_role}'\n"
     else:

--- a/tests/unit/test_moto.py
+++ b/tests/unit/test_moto.py
@@ -936,3 +936,27 @@ def test_dynamodb_read_items_max_items_evaluated_zero(moto_dynamodb_client, moto
     # 5. max_items_evaluated=-1 raises InvalidArgumentValue
     with pytest.raises(wr.exceptions.InvalidArgumentValue):
         wr.dynamodb.read_items(table_name=moto_dynamodb_table, max_items_evaluated=-1)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"aws_access_key_id": "AKIA_EXAMPLE"},
+        {"aws_secret_access_key": "secret_example"},
+    ],
+)
+def test_redshift_auth_string_partial_credentials(kwargs) -> None:
+    from awswrangler.redshift._utils import _make_s3_auth_string
+
+    # Supplying only one of the access-key pair previously fell through to ambient
+    # session credentials silently; it must now fail loudly.
+    with pytest.raises(wr.exceptions.InvalidArgument):
+        _make_s3_auth_string(**kwargs)
+
+
+def test_redshift_auth_string_full_credentials() -> None:
+    from awswrangler.redshift._utils import _make_s3_auth_string
+
+    auth_str = _make_s3_auth_string(aws_access_key_id="AKIA_EXAMPLE", aws_secret_access_key="secret_example")
+    assert "ACCESS_KEY_ID 'AKIA_EXAMPLE'" in auth_str
+    assert "SECRET_ACCESS_KEY 'secret_example'" in auth_str


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Passing only one of `aws_access_key_id` / `aws_secret_access_key` to COPY/UNLOAD silently fell back to `iam_role` or ambient session credentials, ignoring the caller's input. `_make_s3_auth_string` now raises `InvalidArgument` when exactly one of the pair is provided.
- Minor behavior change: previously-tolerated partial input now errors.

### Relates
- N/A