### PR TITLE
fix(neptune): forward boto3_session and s3_additional_kwargs

### DIFF
--- a/awswrangler/neptune/_neptune.py
+++ b/awswrangler/neptune/_neptune.py
@@ -398,7 +398,15 @@ def bulk_load(
         )
 
     try:
-        s3.to_csv(df, path, use_threads=use_threads, dataset=True, index=False)
+        s3.to_csv(
+            df,
+            path,
+            use_threads=use_threads,
+            dataset=True,
+            index=False,
+            boto3_session=boto3_session,
+            s3_additional_kwargs=s3_additional_kwargs,
+        )
 
         bulk_load_from_files(
             client=client,

--- a/tests/unit/test_moto.py
+++ b/tests/unit/test_moto.py
@@ -989,6 +989,9 @@ def test_redshift_auth_string_full_credentials() -> None:
 def test_neptune_bulk_load_forwards_session_and_s3_kwargs(
     engine_get, list_objects, to_csv, delete_objects, bulk_load_from_files
 ) -> None:
+    # bulk_load is gated on the sparql extra, which minimal CI does not install.
+    pytest.importorskip("SPARQLWrapper")
+
     df = pd.DataFrame({"~id": ["0"], "~label": ["v"]})
     session = boto3.Session(region_name="us-east-1")
     s3_kwargs = {"ServerSideEncryption": "aws:kms", "SSEKMSKeyId": "arn:aws:kms:us-east-1:123456789012:key/x"}

--- a/tests/unit/test_moto.py
+++ b/tests/unit/test_moto.py
@@ -14,6 +14,7 @@ import pytest
 from botocore.exceptions import ClientError
 
 import awswrangler as wr
+from awswrangler._distributed import EngineEnum
 from awswrangler.exceptions import InvalidArgumentCombination, InvalidArgumentValue
 
 from .._utils import _get_unique_suffix, ensure_data_types, get_df_csv, get_df_list
@@ -976,3 +977,32 @@ def test_redshift_auth_string_full_credentials() -> None:
     auth_str = _make_s3_auth_string(aws_access_key_id="AKIA_EXAMPLE", aws_secret_access_key="secret_example")
     assert "ACCESS_KEY_ID 'AKIA_EXAMPLE'" in auth_str
     assert "SECRET_ACCESS_KEY 'secret_example'" in auth_str
+
+
+# boto3_session/s3_additional_kwargs are rejected up-front in distributed mode,
+# so the forwarding under test is only reachable on the python engine.
+@mock.patch("awswrangler.neptune._neptune.bulk_load_from_files")
+@mock.patch("awswrangler.neptune._neptune.s3.delete_objects")
+@mock.patch("awswrangler.neptune._neptune.s3.to_csv")
+@mock.patch("awswrangler.neptune._neptune.s3.list_objects", return_value=[])
+@mock.patch("awswrangler._distributed.engine.get", return_value=EngineEnum.PYTHON)
+def test_neptune_bulk_load_forwards_session_and_s3_kwargs(
+    engine_get, list_objects, to_csv, delete_objects, bulk_load_from_files
+) -> None:
+    df = pd.DataFrame({"~id": ["0"], "~label": ["v"]})
+    session = boto3.Session(region_name="us-east-1")
+    s3_kwargs = {"ServerSideEncryption": "aws:kms", "SSEKMSKeyId": "arn:aws:kms:us-east-1:123456789012:key/x"}
+
+    wr.neptune.bulk_load(
+        client=mock.MagicMock(),
+        df=df,
+        path="s3://bucket/stage/",
+        iam_role="arn:aws:iam::123456789012:role/example",
+        boto3_session=session,
+        s3_additional_kwargs=s3_kwargs,
+    )
+
+    # The staged write must run under the caller's session and encryption kwargs,
+    # matching the list_objects/delete_objects calls in the same function.
+    assert to_csv.call_args.kwargs["boto3_session"] is session
+    assert to_csv.call_args.kwargs["s3_additional_kwargs"] == s3_kwargs


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- In `neptune.bulk_load`, the staged `s3.to_csv` omitted `boto3_session` and
  `s3_additional_kwargs` while `s3.list_objects` and `s3.delete_objects` in the same
  function pass both — the staged write ran under the ambient boto3 session and dropped
  the caller's SSE-KMS kwargs. `timestream.batch_load` and `redshift.copy` both forward
  these on their staging writes; this was an isolated omission. Forward both to match.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
