### PR TITLE
fix(s3): stream wr.s3.download in bounded chunks to cap memory (#2831)

### DIFF
--- a/awswrangler/s3/_download.py
+++ b/awswrangler/s3/_download.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import shutil
 from typing import Any, cast
 
 import boto3
@@ -10,6 +11,10 @@ import boto3
 from awswrangler.s3._fs import open_s3_object
 
 _logger: logging.Logger = logging.getLogger(__name__)
+
+# Block size used to stream an object to disk. Reading in fixed-size blocks
+# keeps peak memory bounded to roughly this value instead of the whole file.
+_DOWNLOAD_CHUNK_SIZE: int = 8 * 1024 * 1024  # 8 MiB
 
 
 def download(
@@ -69,14 +74,19 @@ def download(
         mode="rb",
         use_threads=use_threads,
         version_id=version_id,
-        s3_block_size=-1,  # One shot download
+        # Stream the object in fixed-size blocks (via HTTP Range requests)
+        # rather than loading it whole into memory. A one-shot read of a
+        # large object holds the entire body in the reader's cache *and*
+        # again in the write call, i.e. ~2x the file size in RAM, which
+        # OOMs on small hosts (see GitHub issue #2831).
+        s3_block_size=_DOWNLOAD_CHUNK_SIZE,
         s3_additional_kwargs=s3_additional_kwargs,
         boto3_session=boto3_session,
     ) as s3_f:
         if isinstance(local_file, str):
             _logger.debug("Downloading local_file: %s", local_file)
             with open(file=local_file, mode="wb") as local_f:
-                local_f.write(cast(bytes, s3_f.read()))
+                shutil.copyfileobj(cast(Any, s3_f), local_f, length=_DOWNLOAD_CHUNK_SIZE)
         else:
             _logger.debug("Downloading file-like object.")
-            local_file.write(s3_f.read())
+            shutil.copyfileobj(cast(Any, s3_f), local_file, length=_DOWNLOAD_CHUNK_SIZE)

--- a/tests/unit/test_s3_download_streaming.py
+++ b/tests/unit/test_s3_download_streaming.py
@@ -7,6 +7,8 @@ assert the content round-trips AND that the object is fetched in bounded
 byte-range chunks rather than one shot.
 """
 
+from __future__ import annotations
+
 import io
 
 import boto3
@@ -63,7 +65,7 @@ def test_download_to_path_streams_in_bounded_chunks(moto_s3_client, tmp_path, mo
 
 def test_download_to_fileobj_preserves_content(moto_s3_client):
     size = _DOWNLOAD_CHUNK_SIZE + 777
-    payload = bytes(bytearray((i % 256 for i in range(size))))
+    payload = bytes(bytearray(i % 256 for i in range(size)))
     moto_s3_client.put_object(Bucket="bucket", Key="obj.bin", Body=payload)
 
     buf = io.BytesIO()

--- a/tests/unit/test_s3_download_streaming.py
+++ b/tests/unit/test_s3_download_streaming.py
@@ -1,0 +1,72 @@
+# mypy: disable-error-code=no-untyped-def
+"""Tests for the streaming behavior of ``wr.s3.download`` (issue #2831).
+
+``download`` must not load the whole object into memory in a single
+``get_object`` call: on a small host that OOMs for large files. These tests
+assert the content round-trips AND that the object is fetched in bounded
+byte-range chunks rather than one shot.
+"""
+
+import io
+
+import boto3
+import moto
+import pytest
+
+import awswrangler as wr
+from awswrangler.s3._download import _DOWNLOAD_CHUNK_SIZE
+
+
+@pytest.fixture(scope="function")
+def moto_s3_client():
+    with moto.mock_aws():
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        s3_client.create_bucket(Bucket="bucket")
+        yield s3_client
+
+
+def _largest_range_bytes(monkeypatch) -> list[int]:
+    """Patch _fetch_range to record the size of every byte-range fetched."""
+    from awswrangler.s3 import _fs
+
+    sizes: list[int] = []
+    original = _fs._fetch_range
+
+    def spy(range_values, *args, **kwargs):
+        start, end = range_values
+        sizes.append(end - start)
+        return original(range_values, *args, **kwargs)
+
+    monkeypatch.setattr(_fs, "_fetch_range", spy)
+    return sizes
+
+
+def test_download_to_path_streams_in_bounded_chunks(moto_s3_client, tmp_path, monkeypatch):
+    # An object several blocks large.
+    size = _DOWNLOAD_CHUNK_SIZE * 3 + 12345
+    payload = b"x" * size
+    moto_s3_client.put_object(Bucket="bucket", Key="big.bin", Body=payload)
+
+    sizes = _largest_range_bytes(monkeypatch)
+
+    local = tmp_path / "big.bin"
+    wr.s3.download(path="s3://bucket/big.bin", local_file=str(local), use_threads=False)
+
+    # Content is preserved.
+    assert local.read_bytes() == payload
+    # No single range request pulled the whole object; peak fetch is bounded.
+    assert sizes, "expected at least one range fetch"
+    assert max(sizes) <= _DOWNLOAD_CHUNK_SIZE, (
+        f"a single range fetched {max(sizes)} bytes, expected <= {_DOWNLOAD_CHUNK_SIZE}"
+    )
+
+
+def test_download_to_fileobj_preserves_content(moto_s3_client):
+    size = _DOWNLOAD_CHUNK_SIZE + 777
+    payload = bytes(bytearray((i % 256 for i in range(size))))
+    moto_s3_client.put_object(Bucket="bucket", Key="obj.bin", Body=payload)
+
+    buf = io.BytesIO()
+    wr.s3.download(path="s3://bucket/obj.bin", local_file=buf, use_threads=False)
+
+    assert buf.getvalue() == payload


### PR DESCRIPTION
## Issue

Fixes #2831.

## Problem

`wr.s3.download` opens the object with `open_s3_object(..., s3_block_size=-1)` (one-shot) and then does `local_f.write(s3_f.read())`. `read()` on a one-shot reader fetches the **entire** object body into the reader's `_cache` in a single `get_object`, and `write()` copies it again — so peak memory is roughly **2x the file size**. Downloading a ~1 GiB file on a 2 GiB host OOMs (the reporter attached a fil-profiler trace and a `dmesg` OOM kill).

## Fix

Stream the object in fixed 8 MiB blocks instead of loading it whole:

- open with a positive `s3_block_size` (`_DOWNLOAD_CHUNK_SIZE = 8 MiB`) so each `read(n)` is served by a bounded HTTP `Range` request rather than one full-body fetch;
- copy with `shutil.copyfileobj(..., length=_DOWNLOAD_CHUNK_SIZE)` for both the local-path and file-like targets.

Peak memory is now bounded to ~the block size regardless of object size. The public API is unchanged.

## Tests

Added `tests/unit/test_s3_download_streaming.py` (moto):

- **bounded chunks** — patches `_fetch_range` to record every byte-range size while downloading a >3-block object; asserts no single range exceeds `_DOWNLOAD_CHUNK_SIZE` and the file content round-trips;
- **file-like target** — content is preserved when downloading into a `BytesIO`.

Strict red→green verified: reverting to the one-shot `read()` makes the bounded-chunks test fail (a single range fetches the whole 25 MiB object); the fix caps it at 8 MiB. `ruff check` / `ruff format --check` clean.