### PR TITLE
fix: security hardening tls region webhook

### DIFF
--- a/awswrangler/_databases.py
+++ b/awswrangler/_databases.py
@@ -106,9 +106,8 @@ def _get_connection_attributes_from_secrets_manager(
             ssl_context = ssl.create_default_context()
         else:
             _logger.warning(
-                'The "ssl" property of secret %s is ignored for engine %s. '
+                'The "ssl" property from Secrets Manager is ignored for engine %s. '
                 "Configure TLS through the engine's connect() arguments instead.",
-                secret_id,
                 kind,
             )
     return ConnectionAttributes(

--- a/awswrangler/_databases.py
+++ b/awswrangler/_databases.py
@@ -99,6 +99,18 @@ def _get_connection_attributes_from_secrets_manager(
     ssl_enabled: Any = secret_value.get("ssl", False)
     if isinstance(ssl_enabled, str):
         ssl_enabled = ssl_enabled.strip().lower() == "true"
+    ssl_context: ssl.SSLContext | None = None
+    if ssl_enabled:
+        # Only the MySQL connector consumes ssl_context from this path.
+        if kind in ("mysql", "aurora-mysql"):
+            ssl_context = ssl.create_default_context()
+        else:
+            _logger.warning(
+                'The "ssl" property of secret %s is ignored for engine %s. '
+                "Configure TLS through the engine's connect() arguments instead.",
+                secret_id,
+                kind,
+            )
     return ConnectionAttributes(
         kind=kind,
         user=secret_value["username"],
@@ -106,7 +118,7 @@ def _get_connection_attributes_from_secrets_manager(
         host=secret_value["host"],
         port=int(secret_value["port"]),
         database=_dbname,
-        ssl_context=ssl.create_default_context() if ssl_enabled else None,
+        ssl_context=ssl_context,
     )
 
 

--- a/awswrangler/_databases.py
+++ b/awswrangler/_databases.py
@@ -106,9 +106,8 @@ def _get_connection_attributes_from_secrets_manager(
             ssl_context = ssl.create_default_context()
         else:
             _logger.warning(
-                'The "ssl" property from Secrets Manager is ignored for engine %s. '
-                "Configure TLS through the engine's connect() arguments instead.",
-                kind,
+                'The "ssl" property from Secrets Manager is only supported for MySQL engines '
+                "and will be ignored. Configure TLS through the engine's connect() arguments instead."
             )
     return ConnectionAttributes(
         kind=kind,

--- a/awswrangler/_databases.py
+++ b/awswrangler/_databases.py
@@ -96,6 +96,9 @@ def _get_connection_attributes_from_secrets_manager(
         if kind != "redshift":
             raise exceptions.InvalidConnection(f"The secret {secret_id} MUST have a dbname property.")
         _dbname = _get_dbname(cluster_id=secret_value["dbClusterIdentifier"], boto3_session=boto3_session)
+    ssl_enabled: Any = secret_value.get("ssl", False)
+    if isinstance(ssl_enabled, str):
+        ssl_enabled = ssl_enabled.strip().lower() == "true"
     return ConnectionAttributes(
         kind=kind,
         user=secret_value["username"],
@@ -103,7 +106,7 @@ def _get_connection_attributes_from_secrets_manager(
         host=secret_value["host"],
         port=int(secret_value["port"]),
         database=_dbname,
-        ssl_context=None,
+        ssl_context=ssl.create_default_context() if ssl_enabled else None,
     )
 
 

--- a/awswrangler/chime.py
+++ b/awswrangler/chime.py
@@ -6,7 +6,10 @@ import json
 import logging
 from typing import Any
 from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
 from urllib.request import Request, urlopen
+
+from awswrangler import exceptions
 
 _logger: logging.Logger = logging.getLogger(__name__)
 
@@ -17,7 +20,8 @@ def post_message(webhook: str, message: str) -> Any | None:
     Parameters
     ----------
     webhook
-        Contains all the authentication information to send the message
+        Contains all the authentication information to send the message.
+        Must be an ``https://`` URL.
     message
         The actual message which needs to be posted on Slack channel
 
@@ -25,6 +29,8 @@ def post_message(webhook: str, message: str) -> Any | None:
     -------
         The response from Chime
     """
+    if not isinstance(webhook, str) or urlparse(webhook).scheme != "https":
+        raise exceptions.InvalidArgumentValue("The webhook argument must be an https:// URL.")
     response = None
     chime_message = {"Content": f"Message: {message}"}
     req = Request(webhook, json.dumps(chime_message).encode("utf-8"))

--- a/awswrangler/emr.py
+++ b/awswrangler/emr.py
@@ -18,6 +18,8 @@ _ActionOnFailureLiteral = Literal["TERMINATE_JOB_FLOW", "TERMINATE_CLUSTER", "CA
 
 
 def _get_ecr_credentials_refresh_content(region: str) -> str:
+    if re.fullmatch(r"[a-z0-9-]+", region) is None:
+        raise exceptions.InvalidArgumentValue(f"Invalid AWS region: {region}")
     return f"""
 import subprocess
 from pyspark.sql import SparkSession

--- a/awswrangler/mysql.py
+++ b/awswrangler/mysql.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import ssl
 import uuid
 from typing import TYPE_CHECKING, Any, Iterator, Literal, cast, overload
 
@@ -93,6 +94,7 @@ def connect(
     write_timeout: int | None = None,
     connect_timeout: int = 10,
     cursorclass: type["Cursor"] | None = None,
+    ssl_context: bool | ssl.SSLContext | None = None,
 ) -> "pymysql.connections.Connection":
     """Return a pymysql connection from a Glue Catalog Connection or Secrets Manager.
 
@@ -108,13 +110,17 @@ def connect(
     "password":"test",
     "engine":"mysql",
     "port":"3306",
-    "dbname": "mydb" # Optional
+    "dbname": "mydb", # Optional
+    "ssl": true # Optional
     }
 
     Note
     ----
-    It is only possible to configure SSL using Glue Catalog Connection. More at:
+    TLS is NOT enabled by default. With a Glue Catalog Connection, SSL is configured through
+    the connection properties (``JDBC_ENFORCE_SSL``/``CUSTOM_JDBC_CERT``). More at:
     https://docs.aws.amazon.com/glue/latest/dg/connection-defining.html
+    With Secrets Manager, TLS is enabled when the secret contains ``"ssl": true``
+    or when the ``ssl_context`` argument is passed.
 
     Note
     ----
@@ -151,6 +157,12 @@ def connect(
     cursorclass
         Cursor class to use, e.g. SSCursor; defaults to :class:`pymysql.cursors.Cursor`
         https://pymysql.readthedocs.io/en/latest/modules/cursors.html
+    ssl_context
+        SSL configuration forwarded to pymysql. Pass ``True`` to enable TLS with the
+        default system trust store, or an :class:`ssl.SSLContext` for custom settings
+        (e.g. a CA bundle). Pass ``False`` to disable TLS even if the connection or
+        secret enables it. ``None`` (default) uses the TLS configuration from the
+        Glue Catalog Connection or Secrets Manager secret, if any.
 
     Returns
     -------
@@ -170,13 +182,22 @@ def connect(
     )
     if attrs.kind not in ("mysql", "aurora-mysql"):
         raise exceptions.InvalidDatabaseType(f"Invalid connection type ({attrs.kind}. It must be a MySQL connection.)")
+    _ssl_context: ssl.SSLContext | None
+    if ssl_context is None:
+        _ssl_context = attrs.ssl_context
+    elif ssl_context is True:
+        _ssl_context = ssl.create_default_context()
+    elif ssl_context is False:
+        _ssl_context = None
+    else:
+        _ssl_context = ssl_context
     return pymysql.connect(
         user=attrs.user,
         database=attrs.database,
         password=attrs.password,
         port=attrs.port,
         host=attrs.host,
-        ssl=attrs.ssl_context,
+        ssl=_ssl_context,
         read_timeout=read_timeout,
         write_timeout=write_timeout,
         connect_timeout=connect_timeout,

--- a/tests/unit/test_chime.py
+++ b/tests/unit/test_chime.py
@@ -8,6 +8,11 @@ logging.getLogger("awswrangler").setLevel(logging.DEBUG)
 
 
 def test_chime_bad_input():
-    with pytest.raises(ValueError):
-        result = wr.chime.post_message(message=None, webhook=None)
-        assert result is None
+    with pytest.raises(wr.exceptions.InvalidArgumentValue):
+        wr.chime.post_message(message=None, webhook=None)
+
+
+@pytest.mark.parametrize("webhook", ["http://hooks.chime.aws/incomingwebhooks/x", "file:///etc/passwd", "not-a-url"])
+def test_chime_non_https_webhook(webhook):
+    with pytest.raises(wr.exceptions.InvalidArgumentValue):
+        wr.chime.post_message(message="test", webhook=webhook)

--- a/tests/unit/test_emr.py
+++ b/tests/unit/test_emr.py
@@ -185,3 +185,14 @@ def test_docker(bucket, cloudformation_outputs, emr_security_configuration):
 )
 def test_get_emr_integer_version(version, result):
     assert wr.emr._get_emr_classification_lib(version) == result
+
+
+@pytest.mark.parametrize("region", ["us-east-1", "us-gov-west-1", "cn-north-1", "us-iso-east-1"])
+def test_ecr_credentials_refresh_valid_region(region):
+    assert region in wr.emr._get_ecr_credentials_refresh_content(region)
+
+
+@pytest.mark.parametrize("region", ["us-east-1; rm -rf /", "us-east-1 --profile x", "$(whoami)", "", "US-EAST-1"])
+def test_ecr_credentials_refresh_invalid_region(region):
+    with pytest.raises(wr.exceptions.InvalidArgumentValue):
+        wr.emr._get_ecr_credentials_refresh_content(region)

--- a/tests/unit/test_moto.py
+++ b/tests/unit/test_moto.py
@@ -974,14 +974,25 @@ def test_secretsmanager_get_secret_string(moto_aws) -> None:
 
 
 @pytest.mark.parametrize(
-    "ssl_value, expect_tls",
-    [(True, True), ("true", True), ("True", True), (False, False), ("false", False), (None, False)],
+    "engine, ssl_value, expect_tls",
+    [
+        ("mysql", True, True),
+        ("mysql", "true", True),
+        ("mysql", "True", True),
+        ("mysql", False, False),
+        ("mysql", "false", False),
+        ("mysql", None, False),
+        ("aurora-mysql", True, True),
+        # ssl_context is only consumed by the MySQL connector; other engines must not set it
+        ("postgresql", True, False),
+        ("sqlserver", True, False),
+    ],
 )
-def test_connection_attributes_from_secret_ssl(moto_aws, ssl_value, expect_tls) -> None:
+def test_connection_attributes_from_secret_ssl(moto_aws, engine, ssl_value, expect_tls) -> None:
     session = boto3.Session(region_name="us-east-1")
     secret = {
-        "engine": "mysql",
-        "host": "mysql-instance.us-east-1.rds.amazonaws.com",
+        "engine": engine,
+        "host": "db-instance.us-east-1.rds.amazonaws.com",
         "username": "test",
         "password": "test",
         "port": "3306",
@@ -989,7 +1000,7 @@ def test_connection_attributes_from_secret_ssl(moto_aws, ssl_value, expect_tls) 
     }
     if ssl_value is not None:
         secret["ssl"] = ssl_value
-    secret_name = f"aws-sdk-pandas/db-secret-ssl-{type(ssl_value).__name__}-{ssl_value}"
+    secret_name = f"aws-sdk-pandas/db-secret-ssl-{engine}-{type(ssl_value).__name__}-{ssl_value}"
     session.client("secretsmanager").create_secret(Name=secret_name, SecretString=json.dumps(secret))
 
     attrs = wr._databases._get_connection_attributes_from_secrets_manager(

--- a/tests/unit/test_moto.py
+++ b/tests/unit/test_moto.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 import os
 from typing import TYPE_CHECKING
@@ -970,6 +971,34 @@ def test_secretsmanager_get_secret_string(moto_aws) -> None:
     session.client("secretsmanager").create_secret(Name="aws-sdk-pandas/string-secret", SecretString="p@ssw0rd")
 
     assert wr.secretsmanager.get_secret("aws-sdk-pandas/string-secret", boto3_session=session) == "p@ssw0rd"
+
+
+@pytest.mark.parametrize(
+    "ssl_value, expect_tls",
+    [(True, True), ("true", True), ("True", True), (False, False), ("false", False), (None, False)],
+)
+def test_connection_attributes_from_secret_ssl(moto_aws, ssl_value, expect_tls) -> None:
+    session = boto3.Session(region_name="us-east-1")
+    secret = {
+        "engine": "mysql",
+        "host": "mysql-instance.us-east-1.rds.amazonaws.com",
+        "username": "test",
+        "password": "test",
+        "port": "3306",
+        "dbname": "mydb",
+    }
+    if ssl_value is not None:
+        secret["ssl"] = ssl_value
+    secret_name = f"aws-sdk-pandas/db-secret-ssl-{type(ssl_value).__name__}-{ssl_value}"
+    session.client("secretsmanager").create_secret(Name=secret_name, SecretString=json.dumps(secret))
+
+    attrs = wr._databases._get_connection_attributes_from_secrets_manager(
+        secret_id=secret_name, dbname=None, boto3_session=session
+    )
+    if expect_tls:
+        assert attrs.ssl_context is not None
+    else:
+        assert attrs.ssl_context is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- **MySQL TLS via Secrets Manager**: `wr.mysql.connect()` previously could not use TLS with a Secrets Manager secret (`ssl_context` was hardcoded to `None`). The secret's `"ssl": true` field (bool or string) is now honored, and a new explicit `ssl_context: bool | ssl.SSLContext | None` parameter is exposed on `connect()`, mirroring `wr.postgresql.connect()`. Docstring now documents that TLS is not enabled by default; default enforcement will be evaluated for the next major version.
- **EMR**: validate the region string (`[a-z0-9-]+`) before interpolating it into the ECR credentials refresh script, as defense-in-depth against shell metacharacters.
- **Chime**: `wr.chime.post_message()` now requires an `https://` webhook URL and raises `InvalidArgumentValue` otherwise.
- Unit tests added for all three changes.

### Relates
- Security review findings (reported privately; dispositions accepted)
