### PR TITLE
feat: support bootstrap action arguments in emr.create_cluster

### DIFF
--- a/awswrangler/emr.py
+++ b/awswrangler/emr.py
@@ -17,6 +17,43 @@ _logger: logging.Logger = logging.getLogger(__name__)
 _ActionOnFailureLiteral = Literal["TERMINATE_JOB_FLOW", "TERMINATE_CLUSTER", "CANCEL_AND_WAIT", "CONTINUE"]
 
 
+def _normalize_bootstrap_actions(
+    bootstraps_paths: list[str | dict[str, Any]] | None = None,
+) -> list[dict[str, Any]] | None:
+    """Normalize bootstrap actions to the EMR API format.
+
+    Accepts plain script paths (``str``) for backwards compatibility and
+    dictionaries with script metadata. Dictionaries use the flat format
+    ``{"Path": ..., "Args": [...], "Name": ...}``, where ``Args`` and
+    ``Name`` are optional (``Name`` defaults to the script path).
+    """
+    if not bootstraps_paths:
+        return None
+
+    actions: list[dict[str, Any]] = []
+    for bootstrap in bootstraps_paths:
+        if isinstance(bootstrap, str):
+            actions.append({"Name": bootstrap, "ScriptBootstrapAction": {"Path": bootstrap}})
+            continue
+
+        if not isinstance(bootstrap, dict):
+            raise exceptions.InvalidArgumentValue(
+                "Each bootstrap action must be either a string path or a dictionary with 'Path'."
+            )
+
+        path: str | None = cast(str | None, bootstrap.get("Path"))
+        if path is None:
+            raise exceptions.InvalidArgumentValue("Bootstrap action dictionaries must include 'Path'.")
+        action_name: str = cast(str, bootstrap.get("Name", path))
+        script_bootstrap_action: dict[str, Any] = {"Path": path}
+        args: list[str] | None = cast(list[str] | None, bootstrap.get("Args"))
+        if args is not None:
+            script_bootstrap_action["Args"] = args
+        actions.append({"Name": action_name, "ScriptBootstrapAction": script_bootstrap_action})
+
+    return actions
+
+
 def _get_ecr_credentials_refresh_content(region: str) -> str:
     if re.fullmatch(r"[a-z0-9-]+", region) is None:
         raise exceptions.InvalidArgumentValue(f"Invalid AWS region: {region}")
@@ -296,8 +333,9 @@ def _build_cluster_args(**pars: Any) -> dict[str, Any]:  # noqa: PLR0912,PLR0915
         args["Applications"] = [{"Name": x} for x in pars["applications"]]
 
     # Bootstraps
-    if pars["bootstraps_paths"]:
-        args["BootstrapActions"] = [{"Name": x, "ScriptBootstrapAction": {"Path": x}} for x in pars["bootstraps_paths"]]
+    bootstrap_actions: list[dict[str, Any]] | None = _normalize_bootstrap_actions(pars["bootstraps_paths"])
+    if bootstrap_actions is not None:
+        args["BootstrapActions"] = bootstrap_actions
 
     # Debugging and Steps
     if (pars["debugging"] is True) or (pars["steps"] is not None):
@@ -471,7 +509,7 @@ def create_cluster(  # noqa: PLR0913, PLR0917
     consistent_view_retry_seconds: int = 10,
     consistent_view_retry_count: int = 5,
     consistent_view_table_name: str = "EmrFSMetadata",
-    bootstraps_paths: list[str] | None = None,
+    bootstraps_paths: list[str | dict[str, Any]] | None = None,
     debugging: bool = True,
     applications: list[str] | None = None,
     visible_to_all_users: bool = True,
@@ -596,7 +634,11 @@ def create_cluster(  # noqa: PLR0913, PLR0917
     consistent_view_table_name
         Name of the DynamoDB table to store the consistent view data.
     bootstraps_paths
-        Bootstraps paths (e.g ["s3://BUCKET_NAME/script.sh"]).
+        Bootstrap actions.
+        You can pass script paths (e.g. ["s3://BUCKET_NAME/script.sh"]) or dictionaries
+        with script arguments (e.g. [{"Name": "install-deps", "Path": "s3://BUCKET_NAME/script.sh",
+        "Args": ["--foo", "bar"]}]). ``Args`` and ``Name`` are optional; ``Name``
+        defaults to the script path.
     debugging
         Debugging enabled?
     applications

--- a/tests/unit/test_emr_bootstraps.py
+++ b/tests/unit/test_emr_bootstraps.py
@@ -1,0 +1,121 @@
+# tests/unit/test_emr_bootstraps.py
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+import awswrangler as wr
+
+
+class _FakeEmrClient:
+    def __init__(self):
+        self.run_job_flow_args = None
+
+    def run_job_flow(self, **kwargs):
+        self.run_job_flow_args = kwargs
+        return {"JobFlowId": "j-TEST"}
+
+
+def _create_cluster_with_bootstraps(bootstraps_paths):
+    fake_emr_client = _FakeEmrClient()
+    with mock.patch("awswrangler.emr._utils.client", return_value=fake_emr_client):
+        with mock.patch("awswrangler.emr.sts.get_account_id", return_value="123456789012"):
+            with mock.patch("awswrangler.emr._utils.get_region_from_session", return_value="us-east-1"):
+                wr.emr.create_cluster(
+                    subnet_id="subnet-12345678",
+                    bootstraps_paths=bootstraps_paths,
+                )
+    return fake_emr_client.run_job_flow_args
+
+
+def test_create_cluster_bootstraps_legacy_paths() -> None:
+    args = _create_cluster_with_bootstraps(["s3://bucket/bootstrap.sh"])
+
+    assert args is not None
+    assert args["BootstrapActions"] == [
+        {"Name": "s3://bucket/bootstrap.sh", "ScriptBootstrapAction": {"Path": "s3://bucket/bootstrap.sh"}}
+    ]
+
+
+def test_create_cluster_bootstraps_path_args_dict() -> None:
+    args = _create_cluster_with_bootstraps(
+        [
+            {
+                "Path": "s3://bucket/bootstrap.sh",
+                "Args": ["--arg", "value"],
+            }
+        ]
+    )
+
+    assert args is not None
+    assert args["BootstrapActions"] == [
+        {
+            "Name": "s3://bucket/bootstrap.sh",
+            "ScriptBootstrapAction": {
+                "Path": "s3://bucket/bootstrap.sh",
+                "Args": ["--arg", "value"],
+            },
+        }
+    ]
+
+
+def test_create_cluster_bootstraps_path_args_dict_with_name() -> None:
+    args = _create_cluster_with_bootstraps(
+        [
+            {
+                "Name": "install-dependencies",
+                "Path": "s3://bucket/bootstrap.sh",
+                "Args": ["--package", "numpy"],
+            }
+        ]
+    )
+
+    assert args is not None
+    assert args["BootstrapActions"] == [
+        {
+            "Name": "install-dependencies",
+            "ScriptBootstrapAction": {
+                "Path": "s3://bucket/bootstrap.sh",
+                "Args": ["--package", "numpy"],
+            },
+        }
+    ]
+
+
+def test_create_cluster_bootstraps_mixed_paths_and_dicts() -> None:
+    args = _create_cluster_with_bootstraps(
+        [
+            "s3://bucket/first.sh",
+            {"Path": "s3://bucket/second.sh", "Args": ["--flag"]},
+        ]
+    )
+
+    assert args is not None
+    assert args["BootstrapActions"] == [
+        {"Name": "s3://bucket/first.sh", "ScriptBootstrapAction": {"Path": "s3://bucket/first.sh"}},
+        {
+            "Name": "s3://bucket/second.sh",
+            "ScriptBootstrapAction": {"Path": "s3://bucket/second.sh", "Args": ["--flag"]},
+        },
+    ]
+
+
+def test_create_cluster_bootstraps_no_args_key_when_args_missing() -> None:
+    args = _create_cluster_with_bootstraps([{"Path": "s3://bucket/bootstrap.sh"}])
+
+    assert args is not None
+    assert args["BootstrapActions"] == [
+        {"Name": "s3://bucket/bootstrap.sh", "ScriptBootstrapAction": {"Path": "s3://bucket/bootstrap.sh"}}
+    ]
+
+
+def test_create_cluster_bootstraps_invalid_dict_raises() -> None:
+    with pytest.raises(wr.exceptions.InvalidArgumentValue):
+        _create_cluster_with_bootstraps([{"Name": "broken"}])
+
+
+def test_create_cluster_bootstraps_invalid_type_raises() -> None:
+    with pytest.raises(wr.exceptions.InvalidArgumentValue):
+        _create_cluster_with_bootstraps([123])


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
- `wr.emr.create_cluster(bootstraps_paths=...)` now accepts dictionaries in addition to plain script paths, so bootstrap scripts can receive arguments.
- Supported format (flat, per maintainer feedback on #3347): `{"Path": "s3://bucket/script.sh", "Args": ["--foo", "bar"], "Name": "optional-name"}`. `Args` and `Name` are optional; `Name` defaults to the script path.
- Invalid entries (missing `Path`, wrong type) raise `wr.exceptions.InvalidArgumentValue`.
- Fully backwards compatible: existing `list[str]` usage produces identical `BootstrapActions`.
- New unit tests: `tests/unit/test_emr_bootstraps.py` (7 tests, all passing locally; mocked EMR client, no AWS needed).

### Testing
- `python -m pytest tests/unit/test_emr_bootstraps.py` — 7 passed
- `python -m pytest tests/unit/test_emr.py -k "not test_cluster"` — 13 passed (2 pre-existing errors from blocked network access in this sandbox, unrelated to this change)
- `ruff check` / `ruff format --check` — clean

### Relates
- https://github.com/aws/aws-sdk-pandas/issues/3191

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
